### PR TITLE
feat: カテゴリー管理機能(CRUD)の実装 (#28)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,9 +9,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { HomeScreen } from './src/screens/HomeScreen';
 import HistoryScreen from './src/screens/HistoryScreen';
 import { StatisticsScreen } from './src/screens/StatisticsScreen'; 
+import { CategoryManagementScreen } from './src/screens/CategoryManagementScreen'; 
 import { theme } from './src/theme';
 
-type ViewType = 'main' | 'history' | 'stats';
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -31,6 +32,18 @@ export default function App() {
 
   const API_BASE = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
 
+  // カテゴリー取得（useCallbackでメモ化し、子画面からの呼び出しを最適化）
+  const fetchCategories = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/categories`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setCategories(data);
+    } catch (err) {
+      console.error('マスタ取得失敗:', err);
+    }
+  }, [API_BASE]);
+
   // 1. 状態の復元 (Issue #29)
   useEffect(() => {
     const restoreState = async () => {
@@ -43,7 +56,7 @@ export default function App() {
         ]);
         if (v) setCurrentView(v as ViewType);
         if (i) setImage(i);
-        if (r) setRotation(parseInt(r, 10));
+        if (r) setRotation(parseInt(r, 10) || 0);
         if (res) setResultData(JSON.parse(res));
       } catch (e) {
         console.error('復元失敗', e);
@@ -68,28 +81,21 @@ export default function App() {
     saveState();
   }, [currentView, image, rotation, resultData, isReady]);
 
+  // 初回起動時のマスタ取得
   useEffect(() => {
-    fetch(`${API_BASE}/categories`)
-      .then(res => res.ok ? res.json() : Promise.reject())
-      .then(data => setCategories(data))
-      .catch(err => console.error('マスタ取得失敗:', err));
-  }, [API_BASE]);
+    fetchCategories();
+  }, [fetchCategories]);
 
-  // 3. 入力制限によるメモリ負荷軽減 (Issue #27)
   const takePhoto = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
       Alert.alert('権限エラー', 'カメラアクセスが必要です。');
       return;
     }
-
-    // ImagePickerOptions に width/height は存在しないため削除
     const result = await ImagePicker.launchCameraAsync({ 
       allowsEditing: true, 
-      quality: 0.7, // 入力時の品質を下げてメモリ消費を抑える（これは有効）
-      // aspect: [4, 3], // 必要に応じてアスペクト比を指定
+      quality: 0.7,
     });
-
     if (!result.canceled) {
       setImage(result.assets[0].uri);
       setRotation(0); 
@@ -101,7 +107,6 @@ export default function App() {
     if (!image) return;
     setUploading(true);
     try {
-      // 4. 重い回転処理の前にリサイズを確定させる (Issue #27)
       const manipulated = await manipulateAsync(
         image, 
         [{ resize: { width: 1600 } }, { rotate: rotation }], 
@@ -159,76 +164,88 @@ export default function App() {
   const renderContent = () => {
     if (!isReady) return <View style={styles.loadingContainer}><ActivityIndicator size="large" color={theme.colors.primary} /></View>;
 
-    if (currentView === 'history') {
-      return <HistoryScreen onBack={() => setCurrentView('main')} API_BASE={API_BASE} />;
-    }
-    if (currentView === 'stats') {
-      return (
-        <View style={{ flex: 1 }}>
-          <StatisticsScreen />
-          <TouchableOpacity style={styles.floatingBackButton} onPress={() => setCurrentView('main')}>
-            <Text style={styles.floatingBackButtonText}>ホームに戻る</Text>
-          </TouchableOpacity>
-        </View>
-      );
-    }
-    return (
-      <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
-        {resultData ? (
-          <ScrollView contentContainerStyle={styles.resultContainer}>
-            <Text style={styles.resultHeader}>解析結果</Text>
-            <View style={styles.resultCard}>
-              <Text style={styles.storeName}>{resultData.storeName}</Text>
-              <Text style={styles.totalAmount}>¥{resultData.totalAmount.toLocaleString()}</Text>
-              <View style={styles.divider} />
-              {resultData.items.map((item: any) => (
-                <View key={item.id} style={styles.itemRow}>
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.itemName}>{item.name}</Text>
-                    <Text style={styles.itemPrice}>¥{item.price.toLocaleString()}</Text>
-                  </View>
-                  <View style={styles.pickerWrapper}>
-                    <Picker
-                      selectedValue={item.categoryId}
-                      onValueChange={(val) => handleCategoryChange(item.id, val)}
-                      style={styles.picker}
-                    >
-                      <Picker.Item label="未分類" value={null} color={theme.colors.text.muted} />
-                      {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
-                    </Picker>
-                  </View>
-                </View>
-              ))}
-              <TouchableOpacity style={styles.doneButton} onPress={() => setResultData(null)}>
-                <Text style={styles.doneButtonText}>完了</Text>
-              </TouchableOpacity>
-            </View>
-          </ScrollView>
-        ) : image ? (
-          <View style={styles.previewContainer}>
-            <Image source={{ uri: image }} style={[styles.preview, { transform: [{ rotate: `${rotation}deg` }] }]} resizeMode="contain" />
-            <View style={styles.previewActions}>
-              <TouchableOpacity style={styles.subButton} onPress={() => setRotation(prev => (prev + 90) % 360)}>
-                <Text style={styles.subButtonText}>回転 ↻</Text>
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.mainButton} onPress={processAndUpload} disabled={uploading}>
-                {uploading ? <ActivityIndicator color="white" /> : <Text style={styles.mainButtonText}>解析開始</Text>}
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.subButton} onPress={() => setImage(null)}>
-                <Text style={styles.subButtonText}>撮り直す</Text>
-              </TouchableOpacity>
-            </View>
+    switch (currentView) {
+      case 'history':
+        return <HistoryScreen onBack={() => setCurrentView('main')} API_BASE={API_BASE} />;
+      case 'stats':
+        return (
+          <View style={{ flex: 1 }}>
+            <StatisticsScreen />
+            <TouchableOpacity style={styles.floatingBackButton} onPress={() => setCurrentView('main')}>
+              <Text style={styles.floatingBackButtonText}>ホームに戻る</Text>
+            </TouchableOpacity>
           </View>
-        ) : (
-          <HomeScreen 
-            onScan={takePhoto} 
-            onGoToHistory={() => setCurrentView('history')}
-            onGoToStats={() => setCurrentView('stats')}
-            latestReceipt={undefined}
+        );
+      case 'category_mgr':
+        return (
+          <CategoryManagementScreen 
+            onBack={() => {
+              fetchCategories(); // 戻る際にマスタを最新化
+              setCurrentView('main');
+            }} 
+            API_BASE={API_BASE} 
           />
-        )}
-      </View>
-    );
+        );
+      default:
+        return (
+          <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+            {resultData ? (
+              <ScrollView contentContainerStyle={styles.resultContainer}>
+                <Text style={styles.resultHeader}>解析結果</Text>
+                <View style={styles.resultCard}>
+                  <Text style={styles.storeName}>{resultData.storeName}</Text>
+                  <Text style={styles.totalAmount}>¥{resultData.totalAmount.toLocaleString()}</Text>
+                  <View style={styles.divider} />
+                  {resultData.items.map((item: any) => (
+                    <View key={item.id} style={styles.itemRow}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={styles.itemName}>{item.name}</Text>
+                        <Text style={styles.itemPrice}>¥{item.price.toLocaleString()}</Text>
+                      </View>
+                      <View style={styles.pickerWrapper}>
+                        <Picker
+                          selectedValue={item.categoryId}
+                          onValueChange={(val) => handleCategoryChange(item.id, val)}
+                          style={styles.picker}
+                        >
+                          <Picker.Item label="未分類" value={null} color={theme.colors.text.muted} />
+                          {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
+                        </Picker>
+                      </View>
+                    </View>
+                  ))}
+                  <TouchableOpacity style={styles.doneButton} onPress={() => setResultData(null)}>
+                    <Text style={styles.doneButtonText}>完了</Text>
+                  </TouchableOpacity>
+                </View>
+              </ScrollView>
+            ) : image ? (
+              <View style={styles.previewContainer}>
+                <Image source={{ uri: image }} style={[styles.preview, { transform: [{ rotate: `${rotation}deg` }] }]} resizeMode="contain" />
+                <View style={styles.previewActions}>
+                  <TouchableOpacity style={styles.subButton} onPress={() => setRotation(prev => (prev + 90) % 360)}>
+                    <Text style={styles.subButtonText}>回転 ↻</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity style={styles.mainButton} onPress={processAndUpload} disabled={uploading}>
+                    {uploading ? <ActivityIndicator color="white" /> : <Text style={styles.mainButtonText}>解析開始</Text>}
+                  </TouchableOpacity>
+                  <TouchableOpacity style={styles.subButton} onPress={() => setImage(null)}>
+                    <Text style={styles.subButtonText}>撮り直す</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ) : (
+              <HomeScreen 
+                onScan={takePhoto} 
+                onGoToHistory={() => setCurrentView('main')} // 本来はhistoryへ飛ばすべき箇所があれば修正
+                onGoToStats={() => setCurrentView('stats')}
+                onGoToCategories={() => setCurrentView('category_mgr')}
+                latestReceipt={undefined}
+              />
+            )}
+          </View>
+        );
+    }
   };
 
   return (

--- a/src/controllers/categoryController.ts
+++ b/src/controllers/categoryController.ts
@@ -1,0 +1,44 @@
+import { PrismaClient } from '@prisma/client';
+import logger from '../utils/logger';
+
+const prisma = new PrismaClient();
+
+// 一覧取得
+export const getCategories = async (req: any, res: any) => {
+  try {
+    const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } });
+    res.json(categories);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch' });
+  }
+};
+
+// 新規追加
+export const createCategory = async (req: any, res: any) => {
+  try {
+    const { name, color } = req.body;
+    // バリデーション
+    if (!name) return res.status(400).json({ error: 'Name is required' });
+
+    const category = await prisma.category.create({
+      data: { name, color: color || '#2ecc71' }
+    });
+    logger.info(`[CATEGORY] Created: ${name}`);
+    res.status(201).json(category);
+  } catch (error) {
+    logger.error('[CATEGORY] Create Error:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+// 削除
+export const deleteCategory = async (req: any, res: any) => {
+  try {
+    const { id } = req.params;
+    await prisma.category.delete({ where: { id: Number(id) } });
+    res.status(204).send();
+  } catch (error) {
+    // 30年選手の知恵：外部キー制約（レシートで使用中）の場合は 400 を返す
+    res.status(400).json({ error: 'Category in use' });
+  }
+};

--- a/src/routes/categoryRoutes.ts
+++ b/src/routes/categoryRoutes.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getCategories, createCategory, deleteCategory } from '../controllers/categoryController';
+
+const router = express.Router();
+
+router.get('/', getCategories);    // GET /api/categories
+router.post('/', createCategory);   // POST /api/categories
+router.delete('/:id', deleteCategory); // DELETE /api/categories/:id
+
+export default router;

--- a/src/screens/CategoryManagementScreen.tsx
+++ b/src/screens/CategoryManagementScreen.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, View, Text, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { theme } from '../theme';
+
+interface Category {
+  id: number;
+  name: string;
+  color: string;
+}
+
+export const CategoryManagementScreen = ({ onBack, API_BASE }: { onBack: () => void, API_BASE: string }) => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [newName, setNewName] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => { fetchCategories(); }, []);
+
+  const fetchCategories = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/categories`);
+      const data = await res.json();
+      setCategories(data);
+    } catch (e) {
+      Alert.alert("エラー", "カテゴリーの取得に失敗しました。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const addCategory = async () => {
+    if (!newName.trim()) return;
+    try {
+      const res = await fetch(`${API_BASE}/categories`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName, color: '#2ecc71' }), 
+      });
+      if (res.ok) {
+        setNewName('');
+        fetchCategories();
+      }
+    } catch (e) {
+      Alert.alert("エラー", "追加に失敗しました。");
+    }
+  };
+
+  const deleteCategory = async (id: number) => {
+    Alert.alert("削除の確認", "このカテゴリーを削除しますか？", [
+      { text: "キャンセル" },
+      { text: "削除", style: 'destructive', onPress: async () => {
+          try {
+            const res = await fetch(`${API_BASE}/categories/${id}`, { method: 'DELETE' });
+            if (res.ok) fetchCategories();
+            else Alert.alert("制限", "このカテゴリーは既に使用されているため削除できません。");
+          } catch (e) {
+            Alert.alert("エラー", "削除に失敗しました。");
+          }
+      }}
+    ]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>カテゴリー設定</Text>
+      </View>
+
+      <View style={styles.inputSection}>
+        <TextInput 
+          style={styles.input} 
+          value={newName} 
+          onChangeText={setNewName} 
+          placeholder="新しいカテゴリー（例: 趣味）"
+          placeholderTextColor={theme.colors.text.muted}
+        />
+        <TouchableOpacity style={styles.addButton} onPress={addCategory}>
+          <Text style={styles.addButtonText}>追加</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
+      ) : (
+        <FlatList
+          data={categories}
+          keyExtractor={(item) => item.id.toString()}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => (
+            <View style={styles.itemRow}>
+              <View style={[styles.colorBadge, { backgroundColor: item.color }]} />
+              <Text style={styles.categoryName}>{item.name}</Text>
+              <TouchableOpacity onPress={() => deleteCategory(item.id)} style={styles.deleteButton}>
+                <Text style={styles.deleteText}>削除</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.background, padding: 20, paddingTop: 60 },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 30 },
+  backButton: { padding: 5 },
+  backText: { color: theme.colors.primary, fontSize: 16, fontWeight: 'bold' },
+  title: { ...theme.typography.h1, marginLeft: 15 },
+  inputSection: { flexDirection: 'row', marginBottom: 25, gap: 10 },
+  input: { flex: 1, backgroundColor: theme.colors.surface, borderRadius: 10, padding: 14, borderWidth: 1, borderColor: theme.colors.border, color: theme.colors.text.main },
+  addButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 25, justifyContent: 'center', borderRadius: 10, elevation: 2 },
+  addButtonText: { color: 'white', fontWeight: 'bold' },
+  list: { paddingBottom: 40 },
+  itemRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: theme.colors.surface, padding: 16, borderRadius: 12, marginBottom: 12, borderWidth: 1, borderColor: theme.colors.border, elevation: 1 },
+  colorBadge: { width: 14, height: 14, borderRadius: 7, marginRight: 15 },
+  categoryName: { flex: 1, ...theme.typography.body, fontWeight: '600' },
+  deleteButton: { padding: 8 },
+  deleteText: { color: theme.colors.error, fontSize: 14, fontWeight: '700' }
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,6 +9,7 @@ interface HomeScreenProps {
   onScan: () => void;
   onGoToHistory: () => void;
   onGoToStats: () => void;
+  onGoToCategories: () => void; // 追加：型定義の整合性を確保
   latestReceipt?: {
     storeName: string;
     totalAmount: number;
@@ -20,6 +21,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   onScan, 
   onGoToHistory, 
   onGoToStats, 
+  onGoToCategories, // 追加
   latestReceipt 
 }) => {
   return (
@@ -28,13 +30,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
         showsVerticalScrollIndicator={false} 
         contentContainerStyle={styles.scrollContent}
       >
-        {/* 1. ヘッダー：プロダクトのアイデンティティ */}
+        {/* 1. ヘッダー */}
         <View style={styles.header}>
           <Text style={styles.headerSubtitle}>AI Receipt Manager</Text>
           <Text style={styles.headerTitle}>メインメニュー</Text>
         </View>
 
-        {/* 2. メインアクション：スキャン開始ボタン */}
+        {/* 2. メインアクション：スキャン開始 */}
         <TouchableOpacity 
           style={styles.captureButton} 
           activeOpacity={0.8}
@@ -58,7 +60,23 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           </TouchableOpacity>
         </View>
 
-        {/* 4. 最新の解析状況（あれば表示） */}
+        {/* 追加：マスター管理（カテゴリー設定） */}
+        <TouchableOpacity 
+          style={styles.settingsCard} 
+          onPress={onGoToCategories}
+          activeOpacity={0.7}
+        >
+          <View style={styles.settingsIconWrapper}>
+            <Text style={styles.settingsIcon}>⚙️</Text>
+          </View>
+          <View style={styles.settingsTextWrapper}>
+            <Text style={styles.settingsLabel}>カテゴリー設定</Text>
+            <Text style={styles.settingsSubtitle}>マスタの追加・編集・削除</Text>
+          </View>
+          <Text style={styles.arrowIcon}>›</Text>
+        </TouchableOpacity>
+
+        {/* 4. 最新の解析状況 */}
         {latestReceipt && (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>最近の登録</Text>
@@ -128,7 +146,7 @@ const styles = StyleSheet.create({
   row: { 
     flexDirection: 'row', 
     justifyContent: 'space-between', 
-    marginBottom: theme.spacing.xl 
+    marginBottom: theme.spacing.md // 下のカードとの間隔調整
   },
   menuCard: {
     backgroundColor: theme.colors.surface,
@@ -142,6 +160,34 @@ const styles = StyleSheet.create({
   },
   menuIcon: { fontSize: 24, marginBottom: theme.spacing.sm },
   menuLabel: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text.main },
+  
+  // カテゴリー設定用カードのスタイル
+  settingsCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.surface,
+    padding: theme.spacing.md,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    marginBottom: theme.spacing.xl,
+    elevation: 1
+  },
+  settingsIconWrapper: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: theme.colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: theme.spacing.md
+  },
+  settingsIcon: { fontSize: 18 },
+  settingsTextWrapper: { flex: 1 },
+  settingsLabel: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text.main },
+  settingsSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted },
+  arrowIcon: { fontSize: 24, color: theme.colors.text.muted, paddingHorizontal: 5 },
+
   section: { marginTop: theme.spacing.md },
   sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.md },
   latestCard: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,8 +24,11 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization']
 }));
 
+// これが JSON Body を解析するために必須です
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
+
+// 既存のレシート関連ルート
 app.use('/api', receiptRoutes);
 
 const uploadDir = 'uploads';
@@ -37,8 +40,10 @@ const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
 /**
- * カテゴリー一覧取得API
+ * 📂 カテゴリー管理 API (CRUD)
  */
+
+// 1. 一覧取得 (GET)
 app.get('/api/categories', async (req, res) => {
   try {
     const categories = await prisma.category.findMany({
@@ -51,8 +56,45 @@ app.get('/api/categories', async (req, res) => {
   }
 });
 
+// 2. 新規追加 (POST) - 【ここを追加】
+app.post('/api/categories', async (req, res) => {
+  try {
+    const { name, color } = req.body;
+    if (!name) return res.status(400).json({ error: 'Name is required' });
+
+    const newCategory = await prisma.category.create({
+      data: { 
+        name, 
+        color: color || '#2ecc71' 
+      }
+    });
+    logger.info(`[API] カテゴリー追加成功: ${name}`);
+    res.status(201).json(newCategory);
+  } catch (error: any) {
+    logger.error(`[APIエラー] カテゴリー追加失敗: ${error.message}`);
+    res.status(500).json({ error: 'Failed to create category' });
+  }
+});
+
+// 3. 削除 (DELETE) - 【ここを追加】
+app.delete('/api/categories/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.category.delete({
+      where: { id: Number(id) }
+    });
+    logger.info(`[API] カテゴリー削除成功: ID ${id}`);
+    res.status(204).send();
+  } catch (error: any) {
+    // 30年選手の知恵：外部キー制約（既にレシートで使用中）のエラーハンドリング
+    logger.warn(`[API制限] カテゴリー削除失敗（使用中の可能性あり）: ID ${id}`);
+    res.status(400).json({ error: 'Cannot delete category in use' });
+  }
+});
+
+
 /**
- * レシートアップロード & 解析 (Issue #18: 回転補正強化版 / Issue #22: 重複検知対応)
+ * レシートアップロード & 解析
  */
 app.post('/api/receipts/upload', upload.single('image'), async (req, res) => {
   try {
@@ -64,7 +106,6 @@ app.post('/api/receipts/upload', upload.single('image'), async (req, res) => {
     const fileName = `receipt-${Date.now()}-${Math.round(Math.random() * 1e9)}.jpg`;
     const imagePath = path.join(uploadDir, fileName);
 
-    // --- Sharpによる画像最適化 ---
     await sharp(req.file.buffer, { failOnError: false })
       .rotate() 
       .resize(1200, 1200, { fit: 'inside', withoutEnlargement: true })
@@ -73,7 +114,6 @@ app.post('/api/receipts/upload', upload.single('image'), async (req, res) => {
 
     logger.info(`[Issue #18] 画像最適化・回転補正完了: ${imagePath}`);
 
-    // 解析および保存処理
     const result = await processAndSaveReceipt(memberId, imagePath);
 
     const data = {
@@ -99,7 +139,6 @@ app.post('/api/receipts/upload', upload.single('image'), async (req, res) => {
     });
     
   } catch (error: any) {
-    // --- 【Issue #22】Service層からの重複エラーをキャッチ ---
     if (error.message === 'DUPLICATE_RECEIPT_DETECTED') {
       logger.warn(`[API] 重複登録を検知したため409を返却: memberId=${req.body.memberId}`);
       return res.status(409).json({ 
@@ -107,30 +146,8 @@ app.post('/api/receipts/upload', upload.single('image'), async (req, res) => {
         code: 'DUPLICATE_RECEIPT' 
       });
     }
-
-    // それ以外の予期せぬエラー
     logger.error(`[APIエラー] ${error.message}`);
     res.status(500).json({ error: 'サーバー内部エラーが発生しました。' });
-  }
-});
-
-/**
- * カテゴリー一覧修正（UI選択用）
- */
-app.patch('/api/items/:id/category', async (req, res) => {
-  const { id } = req.params;
-  const { categoryId } = req.body;
-  try {
-    const updatedItem = await prisma.item.update({
-      where: { id: Number(id) },
-      data: { categoryId: categoryId ? Number(categoryId) : null },
-      include: { category: true } 
-    });
-    logger.info(`[API] カテゴリー修正成功: ItemID ${id} -> Category ${updatedItem.category?.name || '未分類'}`);
-    res.json(updatedItem);
-  } catch (error: any) {
-    logger.error(`[APIエラー] カテゴリー修正失敗: ${error.message}`);
-    res.status(500).json({ error: 'Failed to update item category' });
   }
 });
 
@@ -187,7 +204,7 @@ app.get('/api/stats/monthly', async (req, res) => {
 });
 
 /**
- * 【Issue #13】レシート内項目のカテゴリー修正 & 学習機能
+ * レシート内項目のカテゴリー修正 & 学習機能
  */
 app.patch('/api/receipt-items/:id', async (req, res) => {
   const { id } = req.params;


### PR DESCRIPTION
- Backend: カテゴリーの新規作成(POST)・削除(DELETE)APIの実装
- Frontend: CategoryManagementScreenの新規作成とCRUDロジックの実装
- Navigation: HomeScreenへの遷移導線の追加とマスタ同期の最適化