### PR TITLE
世帯分離UIの実装（自分／その他） (#35)

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,9 +1,10 @@
 import { Request, Response } from 'express';
 import logger from '../utils/logger';
 import { saveReceiptData } from '../services/persistenceService';
-import { getCleanText } from '../utils/normalizer'; // 正規化関数をインポート
+import { getCleanText } from '../utils/normalizer';
 import { prisma } from '../utils/prismaClient';
-import { Prisma } from '@prisma/client'; // 型定義だけは直接インポートが必要
+import { Prisma } from '@prisma/client';
+
 /**
  * カテゴリーマスタ一覧を取得
  */
@@ -20,7 +21,7 @@ export const getCategories = async (_req: Request, res: Response) => {
 };
 
 /**
- * 【Issue #24】レシート登録（共通保存サービスへの統合）
+ * 【Issue #24】レシート登録
  */
 export const createReceipt = async (req: Request, res: Response) => {
   try {
@@ -62,13 +63,11 @@ export const createReceipt = async (req: Request, res: Response) => {
  * 【Issue #20】アイテムのカテゴリーを更新し、学習マスタへ反映する
  */
 export const updateItemCategory = async (req: Request, res: Response) => {
-  const { id } = req.params; // Item ID
+  const { id } = req.params;
   const { categoryId } = req.body;
 
   try {
-    // 1. トランザクションで「カテゴリー更新」と「学習マスタ登録」を同時に行う
     const result = await prisma.$transaction(async (tx) => {
-      // 2. 現在のアイテムと親レシートの情報を取得（学習用）
       const currentItem = await tx.item.findUnique({
         where: { id: Number(id) },
         include: { receipt: true }
@@ -78,14 +77,12 @@ export const updateItemCategory = async (req: Request, res: Response) => {
         throw new Error('ITEM_NOT_FOUND');
       }
 
-      // 3. アイテムのカテゴリーを更新
       const updatedItem = await tx.item.update({
         where: { id: Number(id) },
         data: { categoryId: categoryId ? Number(categoryId) : null },
         include: { category: true }
       });
 
-      // 4. 【学習】ProductMaster へ Upsert
       if (categoryId) {
         const cleanItemName = getCleanText(currentItem.name);
         const cleanStoreName = getCleanText(currentItem.receipt.storeName);
@@ -172,7 +169,52 @@ export const getReceipts = async (req: Request, res: Response) => {
 };
 
 /**
- * レシートを削除する（連動して物理ファイルも削除される）
+ * 【Issue #35】最新のレシート1件を取得
+ */
+export const getLatestReceipt = async (req: Request, res: Response) => {
+  try {
+    const { memberId } = req.query;
+    
+    if (!memberId) {
+      return res.status(400).json({ error: 'memberId が必要です' });
+    }
+
+    const latest = await prisma.receipt.findFirst({
+      where: { memberId: Number(memberId) },
+      select: {
+        id: true,
+        memberId: true,
+        storeName: true,
+        date: true,
+        totalAmount: true,
+        imagePath: true,
+        items: {
+          select: {
+            id: true,
+            name: true,
+            price: true,
+            quantity: true,
+            categoryId: true,
+            category: {
+              select: { id: true, name: true, color: true }
+            }
+          }
+        }
+      },
+      orderBy: [{ date: 'desc' }, { createdAt: 'desc' }]
+    });
+
+    // データがない場合は null を返す（フロントエンドで 404 エラー扱いにならないよう配慮）
+    res.json(latest || null);
+
+  } catch (error: any) {
+    logger.error(`[GET_LATEST_ERROR] ${error.message}`);
+    res.status(500).json({ error: '最新レシートの取得に失敗しました' });
+  }
+};
+
+/**
+ * レシートを削除する
  */
 export const deleteReceipt = async (req: Request, res: Response) => {
   const { id } = req.params;

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -3,16 +3,12 @@ import {
   getCategories, 
   updateItemCategory, 
   getReceipts, 
-  deleteReceipt 
+  deleteReceipt,
+  getLatestReceipt // ← 追加
 } from '../controllers/receiptController';
-import { authMiddleware } from '../middlewares/auth'; // 認証ミドルウェアをインポート
+import { authMiddleware } from '../middlewares/auth';
 
 const router = Router();
-
-/**
- * 全てのエンドポイントに authMiddleware を適用し、
- * 有効なJWTトークンがないリクエストを遮断します。
- */
 
 // GET /api/categories
 router.get('/categories', authMiddleware, getCategories);
@@ -20,10 +16,14 @@ router.get('/categories', authMiddleware, getCategories);
 // PATCH /api/items/:id/category
 router.patch('/items/:id/category', authMiddleware, updateItemCategory);
 
+// --- [Issue #35] 最新レシート取得を追加 ---
+// ※ /receipts/:id 形式のルートより上に記述してください
+router.get('/receipts/latest', authMiddleware, getLatestReceipt);
+
 // レシート一覧取得 (フィルタリング対応)
 router.get('/receipts', authMiddleware, getReceipts);
 
-// [Issue #19] レシート削除 (物理ファイル削除フック連動)
+// [Issue #19] レシート削除
 router.delete('/receipts/:id', authMiddleware, deleteReceipt);
 
 export default router;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -37,6 +37,9 @@ export default function App() {
   const [currentView, setCurrentView] = useState<ViewType>('main');
   const [isReady, setIsReady] = useState(false);
 
+  // --- Issue #35: 世帯管理の状態を追加 (1: 自分, 2: その他) ---
+  const [currentMemberId, setCurrentMemberId] = useState<number>(1);
+
   // --- Issue #30: ファイル削除ロジック ---
   const deleteTempFile = async (uri: string | null) => {
     if (!uri) return;
@@ -140,18 +143,17 @@ export default function App() {
     }
   };
 
-  // --- Issue #34 & #39 修正箇所 ---
+  // --- Issue #35: 選択中の memberId を送信するように修正 ---
   const uploadImage = async (uri: string) => {
     const formData = new FormData();
     formData.append('image', { uri, name: 'receipt.jpg', type: 'image/jpeg' } as any);
-    formData.append('memberId', '1');
+    formData.append('memberId', currentMemberId.toString());
 
     try {
       const response = await apiClient.post('/receipts/upload', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
 
-      // 防御的コーディング：階層構造をチェックし、安全にデータをセット
       const responseData = response.data;
       if (responseData && responseData.data) {
         setResultData(responseData.data);
@@ -199,16 +201,34 @@ export default function App() {
     }
   };
 
+  // --- Issue #35: 世帯切替UI ---
+  const HouseholdSwitcher = () => (
+    <View style={styles.switcherContainer}>
+      <TouchableOpacity 
+        style={[styles.switchButton, currentMemberId === 1 && styles.activeSwitch]} 
+        onPress={() => setCurrentMemberId(1)}
+      >
+        <Text style={[styles.switchText, currentMemberId === 1 && styles.activeSwitchText]}>自分</Text>
+      </TouchableOpacity>
+      <TouchableOpacity 
+        style={[styles.switchButton, currentMemberId === 2 && styles.activeSwitch]} 
+        onPress={() => setCurrentMemberId(2)}
+      >
+        <Text style={[styles.switchText, currentMemberId === 2 && styles.activeSwitchText]}>その他</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
   const renderContent = () => {
     if (!isReady) return <View style={styles.loadingContainer}><ActivityIndicator size="large" color={theme.colors.primary} /></View>;
 
     switch (currentView) {
       case 'history':
-        return <HistoryScreen onBack={() => setCurrentView('main')} />;
+        return <HistoryScreen onBack={() => setCurrentView('main')} currentMemberId={currentMemberId}/>;
       case 'stats':
         return (
           <View style={{ flex: 1 }}>
-            <StatisticsScreen />
+            <StatisticsScreen currentMemberId={currentMemberId}/>
             <TouchableOpacity style={styles.floatingBackButton} onPress={() => setCurrentView('main')}>
               <Text style={styles.floatingBackButtonText}>ホームに戻る</Text>
             </TouchableOpacity>
@@ -226,7 +246,9 @@ export default function App() {
       default:
         return (
           <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
-            {/* resultData および resultData.items が存在する場合のみ表示 */}
+            {/* 解析中やプレビュー中でない時のみ切替スイッチを表示 */}
+            {!resultData && !image && <HouseholdSwitcher />}
+
             {resultData && resultData.items ? (
               <ScrollView contentContainerStyle={styles.resultContainer}>
                 <Text style={styles.resultHeader}>解析結果</Text>
@@ -281,7 +303,8 @@ export default function App() {
                 onGoToHistory={() => setCurrentView('history')}
                 onGoToStats={() => setCurrentView('stats')}
                 onGoToCategories={() => setCurrentView('category_mgr')}
-                latestReceipt={undefined}
+                // HomeScreenにも現在の世帯IDを渡す
+                currentMemberId={currentMemberId}
               />
             )}
           </View>
@@ -319,5 +342,36 @@ const styles = StyleSheet.create({
   pickerWrapper: { width: 120, height: 40, backgroundColor: theme.colors.background, borderRadius: theme.borderRadius.sm, overflow: 'hidden' },
   picker: { width: '100%' },
   doneButton: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.borderRadius.md, alignItems: 'center', marginTop: theme.spacing.xl },
-  doneButtonText: { color: 'white', fontWeight: 'bold', fontSize: 16 }
+  doneButtonText: { color: 'white', fontWeight: 'bold', fontSize: 16 },
+
+  // 世帯切替UIスタイル
+  switcherContainer: {
+    flexDirection: 'row',
+    paddingTop: 50, // SafeArea相当の余白
+    paddingBottom: 15,
+    backgroundColor: theme.colors.surface,
+    justifyContent: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  switchButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 40,
+    borderRadius: 20,
+    marginHorizontal: 8,
+    backgroundColor: theme.colors.background,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  activeSwitch: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  switchText: {
+    color: theme.colors.text.muted,
+    fontWeight: 'bold',
+  },
+  activeSwitchText: {
+    color: '#fff',
+  },
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -1,23 +1,28 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { StyleSheet, Text, View, FlatList, TouchableOpacity, ActivityIndicator, Image, ScrollView, Modal, Platform, Alert } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
-import apiClient from '../utils/apiClient'; // apiClient をインポート
+import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
 
-// Props から API_BASE を削除
-export default function HistoryScreen({ onBack }: { onBack: () => void }) {
+interface HistoryScreenProps {
+  onBack: () => void;
+  currentMemberId: number; // App.tsx から受け取る
+}
+
+export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreenProps) {
   const [loading, setLoading] = useState(true);
   const [receipts, setReceipts] = useState<any[]>([]);
   const [categories, setCategories] = useState<any[]>([]);
   const [selectedReceipt, setSelectedReceipt] = useState<any | null>(null);
   
   const [selectedMonth, setSelectedMonth] = useState('');
-  const [selectedMember, setSelectedMember] = useState('1');
+  // 初期値を App.tsx で選択されている世帯 ID に設定
+  const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
 
   const cacheKey = useMemo(() => Date.now(), []);
   const months = ['2026-03', '2026-02', '2026-01', '2025-12'];
 
-  // 画像表示用ベースURLの構築
+  // 画像表示用ベースURL
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
@@ -38,7 +43,6 @@ export default function HistoryScreen({ onBack }: { onBack: () => void }) {
   const fetchReceipts = useCallback(async () => {
     try {
       setLoading(true);
-      // axios の params を利用してクエリパラメータを渡す
       const res = await apiClient.get('/receipts', {
         params: {
           memberId: selectedMember,
@@ -58,6 +62,11 @@ export default function HistoryScreen({ onBack }: { onBack: () => void }) {
     fetchReceipts();
   }, [fetchReceipts]);
 
+  // App.tsx 側で世帯が切り替わった場合、履歴画面の選択状態も同期させる
+  useEffect(() => {
+    setSelectedMember(currentMemberId.toString());
+  }, [currentMemberId]);
+
   // 明細のカテゴリー更新
   const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
     if (!categoryId) return;
@@ -67,7 +76,7 @@ export default function HistoryScreen({ onBack }: { onBack: () => void }) {
       });
       const updatedItem = response.data;
 
-      // 詳細モーダルのステート更新
+      // ステート更新
       setSelectedReceipt((prev: any) =>
         prev ? {
           ...prev,
@@ -77,7 +86,6 @@ export default function HistoryScreen({ onBack }: { onBack: () => void }) {
         } : prev
       );
 
-      // 一覧側のステート更新
       setReceipts(prev => prev.map(r => ({
         ...r,
         items: r.items.map((item: any) =>
@@ -146,8 +154,9 @@ export default function HistoryScreen({ onBack }: { onBack: () => void }) {
             style={styles.filterPicker}
             dropdownIconColor={theme.colors.primary}
           >
-            <Picker.Item label="メンバー1" value="1" />
-            <Picker.Item label="メンバー2" value="2" />
+            {/* ラベルを「自分」「その他」に変更 */}
+            <Picker.Item label="自分" value="1" />
+            <Picker.Item label="その他" value="2" />
           </Picker>
         </View>
       </View>

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Platform, Dimensions } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Platform, Dimensions, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { theme } from '../theme';
+import apiClient from '../utils/apiClient';
 
 const { width } = Dimensions.get('window');
 
@@ -10,11 +11,7 @@ interface HomeScreenProps {
   onGoToHistory: () => void;
   onGoToStats: () => void;
   onGoToCategories: () => void; 
-  latestReceipt?: {
-    storeName: string;
-    totalAmount: number;
-    date: string;
-  };
+  currentMemberId: number; // App.tsx から受け取る
 }
 
 export const HomeScreen: React.FC<HomeScreenProps> = ({ 
@@ -22,8 +19,31 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   onGoToHistory, 
   onGoToStats, 
   onGoToCategories,
-  latestReceipt 
+  currentMemberId 
 }) => {
+  const [latestReceipt, setLatestReceipt] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 世帯 ID に基づいて最新のレシートを取得
+  const fetchLatestReceipt = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await apiClient.get('/receipts/latest', {
+        params: { memberId: currentMemberId }
+      });
+      setLatestReceipt(response.data);
+    } catch (error) {
+      console.error('最新レシート取得失敗:', error);
+      setLatestReceipt(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentMemberId]);
+
+  useEffect(() => {
+    fetchLatestReceipt();
+  }, [fetchLatestReceipt]);
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView 
@@ -32,7 +52,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
       >
         <View style={styles.header}>
           <Text style={styles.headerSubtitle}>AI Receipt Manager</Text>
-          <Text style={styles.headerTitle}>メインメニュー</Text>
+          <Text style={styles.headerTitle}>
+            {currentMemberId === 1 ? '自分のメニュー' : 'その他のメニュー'}
+          </Text>
         </View>
 
         <TouchableOpacity 
@@ -72,9 +94,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           <Text style={styles.arrowIcon}>›</Text>
         </TouchableOpacity>
 
-        {latestReceipt && (
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>最近の登録</Text>
+        {/* 最近の登録セクション（動的取得） */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>最近の登録</Text>
+          {loading ? (
+            <ActivityIndicator color={theme.colors.primary} style={{ marginTop: 10 }} />
+          ) : latestReceipt ? (
             <View style={styles.latestCard}>
               <View style={styles.cardInfo}>
                 <Text style={styles.storeName} numberOfLines={1}>{latestReceipt.storeName}</Text>
@@ -82,8 +107,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
               </View>
               <Text style={styles.amountText}>¥{latestReceipt.totalAmount.toLocaleString()}</Text>
             </View>
-          </View>
-        )}
+          ) : (
+            <View style={[styles.latestCard, { justifyContent: 'center' }]}>
+              <Text style={styles.dateText}>表示できるデータがありません</Text>
+            </View>
+          )}
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Imag
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import { Picker } from '@react-native-picker/picker';
-import apiClient from '../utils/apiClient'; // axios から apiClient に変更
+import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
 
 const screenWidth = Dimensions.get('window').width;
@@ -48,7 +48,12 @@ interface MonthlyData {
   latestReceipt: ReceiptInfo | null;
 }
 
-export const StatisticsScreen: React.FC = () => {
+// Props インターフェースを追加
+interface StatisticsScreenProps {
+  currentMemberId: number;
+}
+
+export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId }) => {
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7)); // YYYY-MM
   const [data, setData] = useState<MonthlyData | null>(null);
@@ -58,23 +63,26 @@ export const StatisticsScreen: React.FC = () => {
   const [isPickerVisible, setPickerVisible] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<number | null>(null);
 
-  // 画像表示用にベースURLを保持（末尾の /api を除去）
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
-  // 過去12ヶ月の選択肢生成
   const monthOptions = Array.from({ length: 12 }).map((_, i) => {
     const d = new Date();
     d.setMonth(d.getMonth() - i);
     return d.toISOString().slice(0, 7);
   });
 
+  // memberId をクエリパラメータに追加
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
-      // apiClient を使用。baseURL が設定されているため相対パスで指定。
       const [statsRes, catRes] = await Promise.all([
-        apiClient.get<MonthlyData>(`/stats/monthly?month=${selectedMonth}`),
+        apiClient.get<MonthlyData>(`/stats/monthly`, {
+          params: { 
+            month: selectedMonth,
+            memberId: currentMemberId 
+          }
+        }),
         apiClient.get<Category[]>('/categories')
       ]);
       setData(statsRes.data);
@@ -85,7 +93,7 @@ export const StatisticsScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [selectedMonth]);
+  }, [selectedMonth, currentMemberId]); // currentMemberId を依存配列に追加
 
   useEffect(() => {
     fetchData();
@@ -94,7 +102,6 @@ export const StatisticsScreen: React.FC = () => {
   const handleUpdateCategory = async (categoryId: number) => {
     if (!selectedItemId) return;
     try {
-      // apiClient.patch を使用
       await apiClient.patch(`/receipt-items/${selectedItemId}`, { categoryId });
       setPickerVisible(false);
       await fetchData();
@@ -119,7 +126,9 @@ export const StatisticsScreen: React.FC = () => {
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         
         <View style={styles.header}>
-          <Text style={styles.headerSubtitle}>収支分析レポート</Text>
+          <Text style={styles.headerSubtitle}>
+            {currentMemberId === 1 ? '自分の収支分析レポート' : 'その他の収支分析レポート'}
+          </Text>
           <View style={styles.monthPickerContainer}>
             <Picker
               selectedValue={selectedMonth}


### PR DESCRIPTION
App.tsxに世帯切替スイッチを導入し、Home/History/Statsの各画面でmemberIdによるフィルタリングを実装。バックエンドに/receipts/latestエンドポイントを追加しました。