### PR TITLE
APIレスポンス形式の統一と共通エラーハンドリングの実装

### DIFF
--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -1,44 +1,79 @@
+import { Request, Response, NextFunction } from 'express';
 import { PrismaClient } from '@prisma/client';
+import { AppError } from '../utils/appError';
 import logger from '../utils/logger';
 
 const prisma = new PrismaClient();
 
-// 一覧取得
-export const getCategories = async (req: any, res: any) => {
+/**
+ * 📂 カテゴリー一覧取得
+ */
+export const getCategories = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } });
-    res.json(categories);
+    const categories = await prisma.category.findMany({ 
+      orderBy: { id: 'asc' } 
+    });
+    
+    // Issue #40: レスポンス形式の統一
+    res.json({
+      success: true,
+      data: categories
+    });
   } catch (error) {
-    res.status(500).json({ error: 'Failed to fetch' });
+    next(error);
   }
 };
 
-// 新規追加
-export const createCategory = async (req: any, res: any) => {
+/**
+ * 📂 カテゴリー新規追加
+ */
+export const createCategory = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { name, color } = req.body;
-    // バリデーション
-    if (!name) return res.status(400).json({ error: 'Name is required' });
+
+    if (!name) {
+      return next(new AppError('Name is required', 400));
+    }
 
     const category = await prisma.category.create({
-      data: { name, color: color || '#2ecc71' }
+      data: { 
+        name, 
+        color: color || '#2ecc71' 
+      }
     });
+
     logger.info(`[CATEGORY] Created: ${name}`);
-    res.status(201).json(category);
+
+    res.status(201).json({
+      success: true,
+      data: category
+    });
   } catch (error) {
-    logger.error('[CATEGORY] Create Error:', error);
-    res.status(500).json({ error: 'Internal Server Error' });
+    next(error);
   }
 };
 
-// 削除
-export const deleteCategory = async (req: any, res: any) => {
+/**
+ * 📂 カテゴリー削除
+ */
+export const deleteCategory = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { id } = req.params;
-    await prisma.category.delete({ where: { id: Number(id) } });
-    res.status(204).send();
-  } catch (error) {
-    // 30年選手の知恵：外部キー制約（レシートで使用中）の場合は 400 を返す
-    res.status(400).json({ error: 'Category in use' });
+
+    await prisma.category.delete({
+      where: { id: Number(id) }
+    });
+
+    logger.info(`[CATEGORY] Deleted: ID ${id}`);
+
+    // 削除成功時は data なしで success のみを返す（既存コードの 204 を踏襲する場合は res.status(204).send() でも可）
+    res.json({
+      success: true
+    });
+  } catch (error: any) {
+    if (error.code === 'P2003') {
+      return next(new AppError('このカテゴリーは既に使用されているため削除できません。', 400));
+    }
+    next(error);
   }
 };

--- a/backend/src/controllers/productMasterController.ts
+++ b/backend/src/controllers/productMasterController.ts
@@ -1,11 +1,12 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prismaClient';
 import logger from '../utils/logger';
+import { AppError } from '../utils/appError';
 
 /**
- * 学習マスタ一覧取得（検索・ページネーション対応）
+ * 📂 学習マスタ一覧取得（検索・ページネーション対応）
  */
-export const getProductMasters = async (req: Request, res: Response) => {
+export const getProductMasters = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { q, store } = req.query;
     
@@ -20,16 +21,20 @@ export const getProductMasters = async (req: Request, res: Response) => {
       take: 100 // ひとまず100件
     });
 
-    res.json(masters);
+    // Issue #40: レスポンス形式の統一
+    res.json({
+      success: true,
+      data: masters
+    });
   } catch (error) {
-    res.status(500).json({ error: 'マスタ取得失敗' });
+    next(error);
   }
 };
 
 /**
- * マスタの個別更新
+ * 📂 マスタの個別更新
  */
-export const updateProductMaster = async (req: Request, res: Response) => {
+export const updateProductMaster = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
   const { name, storeName, categoryId } = req.body;
 
@@ -42,58 +47,72 @@ export const updateProductMaster = async (req: Request, res: Response) => {
         categoryId: Number(categoryId) 
       }
     });
-    res.json(updated);
+
+    res.json({
+      success: true,
+      data: updated
+    });
   } catch (error) {
-    res.status(500).json({ error: 'マスタ更新失敗' });
+    next(error);
   }
 };
 
 /**
- * 店舗名の統合ロジック（エイリアス整理）
- * 例: "セブン" を "セブン-イレブン" に統合する
+ * 📂 店舗名の統合ロジック
  */
-export const mergeStoreNames = async (req: Request, res: Response) => {
+export const mergeStoreNames = async (req: Request, res: Response, next: NextFunction) => {
   const { sourceStoreName, targetStoreName } = req.body;
 
   if (!sourceStoreName || !targetStoreName) {
-    return res.status(400).json({ error: '統合元と統合先の指定が必要です' });
+    return next(new AppError('統合元と統合先の指定が必要です', 400));
   }
 
   try {
-    // トランザクションで一括更新
     const result = await prisma.$transaction(async (tx) => {
       // 1. ProductMaster 内の店舗名を一括置換
-      const updatedCount = await tx.productMaster.updateMany({
+      const updateResult = await tx.productMaster.updateMany({
         where: { storeName: sourceStoreName },
         data: { storeName: targetStoreName }
       });
 
-      // 2. 必要に応じて過去の Receipt データの店舗名も書き換える（任意）
+      // 2. 過去の Receipt データの店舗名も書き換える
       await tx.receipt.updateMany({
         where: { storeName: sourceStoreName },
         data: { storeName: targetStoreName }
       });
 
-      return updatedCount;
+      return updateResult;
     });
 
     logger.info(`[STORE_MERGE] ${sourceStoreName} -> ${targetStoreName} (${result.count} items)`);
-    res.json({ message: '統合が完了しました', count: result.count });
+    
+    res.json({
+      success: true,
+      data: {
+        message: '統合が完了しました',
+        count: result.count
+      }
+    });
   } catch (error) {
-    logger.error(`[STORE_MERGE_ERROR] ${error}`);
-    res.status(500).json({ error: '統合処理に失敗しました' });
+    next(error);
   }
 };
 
 /**
- * マスタ削除
+ * 📂 マスタ削除
  */
-export const deleteProductMaster = async (req: Request, res: Response) => {
+export const deleteProductMaster = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
   try {
-    await prisma.productMaster.delete({ where: { id: Number(id) } });
-    res.json({ message: '削除しました' });
+    await prisma.productMaster.delete({ 
+      where: { id: Number(id) } 
+    });
+
+    res.json({
+      success: true,
+      message: '削除しました'
+    });
   } catch (error) {
-    res.status(500).json({ error: '削除失敗' });
+    next(error);
   }
 };

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,29 +1,29 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
 import { saveReceiptData } from '../services/persistenceService';
 import { getCleanText } from '../utils/normalizer';
 import { prisma } from '../utils/prismaClient';
 import { Prisma } from '@prisma/client';
+import { AppError } from '../utils/appError';
 
 /**
- * カテゴリーマスタ一覧を取得
+ * 📂 カテゴリーマスタ一覧を取得
  */
-export const getCategories = async (_req: Request, res: Response) => {
+export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const categories = await prisma.category.findMany({
       orderBy: { id: 'asc' }
     });
-    res.json(categories);
+    res.json({ success: true, data: categories });
   } catch (error) {
-    logger.error(`[GET_CATEGORIES_ERROR] ${error}`);
-    res.status(500).json({ error: 'カテゴリー一覧の取得に失敗しました' });
+    next(error);
   }
 };
 
 /**
- * 【Issue #24】レシート登録
+ * 📂 レシート登録
  */
-export const createReceipt = async (req: Request, res: Response) => {
+export const createReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { memberId, date, storeName, totalAmount, items, imagePath, rawText } = req.body;
 
@@ -43,26 +43,21 @@ export const createReceipt = async (req: Request, res: Response) => {
     });
 
     logger.info(`[RECEIPT_CREATED] ID: ${newReceipt.id} を登録しました`);
-    res.status(201).json(newReceipt);
+    res.status(201).json({ success: true, data: newReceipt });
 
   } catch (error: any) {
-    const statusCode = error.statusCode || 500;
-    if (statusCode === 409) {
-      logger.warn(`[CREATE_RECEIPT_BLOCK] 重複によりブロック: ${error.message}`);
-      return res.status(409).json({
-        code: 'DUPLICATE_RECEIPT',
-        message: 'このレシートは既に登録されている可能性があります。'
-      });
+    // 重複エラー（409）のハンドリングを共通エラー形式へ
+    if (error.statusCode === 409) {
+      return next(new AppError('このレシートは既に登録されている可能性があります。', 409, { code: 'DUPLICATE_RECEIPT' }));
     }
-    logger.error(`[CREATE_RECEIPT_ERROR] ${error.message}`);
-    res.status(statusCode).json({ error: 'レシートの保存に失敗しました' });
+    next(error);
   }
 };
 
 /**
- * 【Issue #20】アイテムのカテゴリーを更新し、学習マスタへ反映する
+ * 📂 アイテムのカテゴリーを更新し、学習マスタへ反映する
  */
-export const updateItemCategory = async (req: Request, res: Response) => {
+export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
   const { categoryId } = req.body;
 
@@ -74,7 +69,7 @@ export const updateItemCategory = async (req: Request, res: Response) => {
       });
 
       if (!currentItem) {
-        throw new Error('ITEM_NOT_FOUND');
+        throw new AppError('指定されたアイテムが見つかりません', 404);
       }
 
       const updatedItem = await tx.item.update({
@@ -107,20 +102,18 @@ export const updateItemCategory = async (req: Request, res: Response) => {
       return updatedItem;
     });
 
-    logger.info(`[ITEM_UPDATE] ID: ${id} のカテゴリーを ${result.category?.name || '未分類'} に更新（学習反映済）`);
-    res.json(result);
+    logger.info(`[ITEM_UPDATE] ID: ${id} のカテゴリーを更新しました`);
+    res.json({ success: true, data: result });
 
-  } catch (error: any) {
-    logger.error(`[ITEM_UPDATE_ERROR] ${error.message}`);
-    const status = error.message === 'ITEM_NOT_FOUND' ? 404 : 500;
-    res.status(status).json({ error: 'カテゴリーの更新または学習に失敗しました' });
+  } catch (error) {
+    next(error);
   }
 };
 
 /**
- * レシート一覧を取得
+ * 📂 レシート一覧を取得（履歴一覧画面用）
  */
-export const getReceipts = async (req: Request, res: Response) => {
+export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { memberId, month } = req.query;
     const where: Prisma.ReceiptWhereInput = {};
@@ -161,22 +154,22 @@ export const getReceipts = async (req: Request, res: Response) => {
       orderBy: [{ date: 'desc' }, { createdAt: 'desc' }]
     });
 
-    res.json(receipts);
-  } catch (error: any) {
-    logger.error(`[GET_RECEIPTS_ERROR] ${error.message}`);
-    res.status(500).json({ error: 'レシート一覧の取得に失敗しました' });
+    // ★ ここが履歴一覧表示の鍵
+    res.json({ success: true, data: receipts });
+  } catch (error) {
+    next(error);
   }
 };
 
 /**
- * 【Issue #35】最新のレシート1件を取得
+ * 📂 最新のレシート1件を取得
  */
-export const getLatestReceipt = async (req: Request, res: Response) => {
+export const getLatestReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { memberId } = req.query;
     
     if (!memberId) {
-      return res.status(400).json({ error: 'memberId が必要です' });
+      return next(new AppError('memberId が必要です', 400));
     }
 
     const latest = await prisma.receipt.findFirst({
@@ -204,19 +197,17 @@ export const getLatestReceipt = async (req: Request, res: Response) => {
       orderBy: [{ date: 'desc' }, { createdAt: 'desc' }]
     });
 
-    // データがない場合は null を返す（フロントエンドで 404 エラー扱いにならないよう配慮）
-    res.json(latest || null);
+    res.json({ success: true, data: latest || null });
 
-  } catch (error: any) {
-    logger.error(`[GET_LATEST_ERROR] ${error.message}`);
-    res.status(500).json({ error: '最新レシートの取得に失敗しました' });
+  } catch (error) {
+    next(error);
   }
 };
 
 /**
- * レシートを削除する
+ * 📂 レシートを削除する
  */
-export const deleteReceipt = async (req: Request, res: Response) => {
+export const deleteReceipt = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
 
   try {
@@ -225,9 +216,75 @@ export const deleteReceipt = async (req: Request, res: Response) => {
     });
 
     logger.info(`[RECEIPT_DELETED] ID: ${id} を削除しました`);
-    res.json({ message: '削除に成功しました', deleted });
-  } catch (error: any) {
-    logger.error(`[DELETE_ERROR] ${error.message}`);
-    res.status(500).json({ error: '削除に失敗しました' });
+    res.json({ success: true, data: { id: deleted.id } });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * 📂 月次統計を取得
+ */
+export const getMonthlyStats = async (req: Request, res: Response, next: NextFunction) => {
+  const { month, memberId } = req.query; 
+  try {
+    const targetDate = month ? new Date(`${month as string}-01T00:00:00Z`) : new Date();
+    const startOfMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
+    const endOfMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0, 23, 59, 59);
+    const startOfPrevMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() - 1, 1);
+    const endOfPrevMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 0, 23, 59, 59);
+
+    const mId = Number(memberId || 1);
+
+    const stats = await prisma.item.groupBy({
+      by: ['categoryId'],
+      where: { receipt: { memberId: mId, date: { gte: startOfMonth, lte: endOfMonth } } },
+      _sum: { price: true },
+    });
+
+    const prevMonthTotal = await prisma.item.aggregate({
+      where: { receipt: { memberId: mId, date: { gte: startOfPrevMonth, lte: endOfPrevMonth } } },
+      _sum: { price: true },
+    });
+
+    const latestReceipt = await prisma.receipt.findFirst({
+      where: { memberId: mId, date: { gte: startOfMonth, lte: endOfMonth }, imagePath: { not: null } },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true, imagePath: true, storeName: true, totalAmount: true,
+        items: {
+          select: { id: true, name: true, price: true, categoryId: true, category: { select: { name: true, color: true } } }
+        }
+      }
+    });
+
+    const categories = await prisma.category.findMany();
+    const formattedStats = stats.map(s => {
+      const category = categories.find(c => c.id === s.categoryId);
+      return {
+        categoryId: s.categoryId,
+        categoryName: category ? category.name : '未分類',
+        totalAmount: s._sum.price || 0,
+        color: (category as any)?.color || '#999',
+      };
+    });
+
+    const currentTotal = formattedStats.reduce((sum, s) => sum + s.totalAmount, 0);
+    const prevTotal = prevMonthTotal._sum.price || 0;
+
+    res.json({
+      success: true,
+      data: {
+        month: `${startOfMonth.getFullYear()}-${String(startOfMonth.getMonth() + 1).padStart(2, '0')}`,
+        totalAmount: currentTotal,
+        prevTotal: prevTotal,
+        diffAmount: currentTotal - prevTotal,
+        diffPercentage: prevTotal !== 0 ? Math.round(((currentTotal - prevTotal) / prevTotal) * 100) : 0,
+        stats: formattedStats,
+        latestReceipt: latestReceipt 
+      }
+    });
+  } catch (error) {
+    next(error);
   }
 };

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from '../utils/appError';
+import logger from '../utils/logger';
+
+/**
+ * グローバルエラーハンドリング・ミドルウェア
+ * レスポンス形式を統一し、T320のログファイルへ詳細を出力する
+ */
+export const errorHandler = (
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // AppError インスタンスか、それ以外の予期せぬエラーかを判定
+  const statusCode = err instanceof AppError ? err.statusCode : 500;
+  const message = err.message || 'Internal Server Error';
+  const details = err instanceof AppError ? err.details : undefined;
+
+  // T320の DailyRotateFile (error-DATE.log) へ出力
+  // logger.ts で errors({ stack: true }) を指定しているため、スタックトレースも含まれる
+  logger.error(message, {
+    statusCode,
+    path: req.originalUrl,
+    method: req.method,
+    details,
+    stack: err.stack,
+  });
+
+  // クライアント（Expo/Frontend）へのレスポンス形式を統一
+  res.status(statusCode).json({
+    success: false,
+    error: message,
+    ...(details && { details }), // details が存在する場合のみ含める
+  });
+};

--- a/backend/src/middlewares/validate.ts
+++ b/backend/src/middlewares/validate.ts
@@ -1,10 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import { ZodError } from 'zod';
-import logger from '../utils/logger';
+import { AppError } from '../utils/appError';
 
+/**
+ * Zodバリデーションミドルウェア
+ * エラー時は AppError を生成して共通エラーハンドラーへ渡す
+ */
 export const validate = (schema: any) => 
   async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // スキーマでパースして結果をreq.bodyに反映
       req.body = await schema.parseAsync(req.body);
       next();
     } catch (error: any) {
@@ -12,18 +17,17 @@ export const validate = (schema: any) =>
       const issues = error.issues || error.errors;
 
       if ((error instanceof ZodError || error.name === 'ZodError') && Array.isArray(issues)) {
-        logger.warn(`[Validation Error]: ${JSON.stringify(issues)}`);
-        
-        return res.status(400).json({
-          error: "入力内容に不備があります",
-          details: issues.map((e: any) => ({
-            field: Array.isArray(e.path) ? e.path.join('.') : 'unknown',
-            message: e.message
-          }))
-        });
+        // 詳細なエラー内容を整形
+        const details = issues.map((e: any) => ({
+          field: Array.isArray(e.path) ? e.path.join('.') : 'unknown',
+          message: e.message
+        }));
+
+        // 共通エラーハンドラーへ渡す。レスポンス生成とログ出力はあちらで一括処理。
+        return next(new AppError('入力内容に不備があります', 400, details));
       }
       
-      // バリデーション以外のエラー、または構造が想定外の場合はExpressのエラーハンドラへ
+      // バリデーション以外のエラー、または構造が想定外の場合はそのまま次へ
       next(error);
     }
   };

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -1,29 +1,31 @@
-import { Router } from 'express';
+import express from 'express';
 import { 
-  getCategories, 
-  updateItemCategory, 
   getReceipts, 
-  deleteReceipt,
-  getLatestReceipt // ← 追加
+  createReceipt, 
+  deleteReceipt, 
+  getLatestReceipt, 
+  updateItemCategory,
+  getMonthlyStats // ★ 追加
 } from '../controllers/receiptController';
-import { authMiddleware } from '../middlewares/auth';
 
-const router = Router();
+const router = express.Router();
 
-// GET /api/categories
-router.get('/categories', authMiddleware, getCategories);
+// GET /api/receipts
+router.get('/receipts', getReceipts);
 
-// PATCH /api/items/:id/category
-router.patch('/items/:id/category', authMiddleware, updateItemCategory);
+// GET /api/receipts/latest
+router.get('/receipts/latest', getLatestReceipt);
 
-// --- [Issue #35] 最新レシート取得を追加 ---
-// ※ /receipts/:id 形式のルートより上に記述してください
-router.get('/receipts/latest', authMiddleware, getLatestReceipt);
+// GET /api/stats/monthly ★ これが 404 の原因でした
+router.get('/stats/monthly', getMonthlyStats);
 
-// レシート一覧取得 (フィルタリング対応)
-router.get('/receipts', authMiddleware, getReceipts);
+// POST /api/receipts
+router.post('/receipts', createReceipt);
 
-// [Issue #19] レシート削除
-router.delete('/receipts/:id', authMiddleware, deleteReceipt);
+// DELETE /api/receipts/:id
+router.delete('/receipts/:id', deleteReceipt);
+
+// PATCH /api/receipt-items/:id
+router.patch('/receipt-items/:id', updateItemCategory);
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,16 +5,21 @@ import path from 'path';
 import fs from 'fs';
 import dotenv from 'dotenv';
 import sharp from 'sharp'; 
+
 import { processAndSaveReceipt } from './services/receiptService';
 import logger from './utils/logger';
 import { PrismaClient } from '@prisma/client';
+
+// --- ルーターのインポート ---
 import receiptRoutes from './routes/receiptRoutes';
 import productMasterRoutes from './routes/productMasterRoutes'; 
-import { getCleanText } from './utils/normalizer';
+import categoryRoutes from './routes/categoryRoutes'; // ★ 追加
 
-// --- Issue #37: Zodバリデーション関連のインポート ---
+// --- Issue #40: エラーハンドリング・標準化 ---
+import { AppError } from './utils/appError';
+import { errorHandler } from './middlewares/errorHandler';
 import { validate } from './middlewares/validate';
-import { createReceiptSchema, uploadReceiptSchema } from './schemas/receiptSchema';
+import { uploadReceiptSchema } from './schemas/receiptSchema';
 
 dotenv.config();
 
@@ -23,15 +28,14 @@ const port = process.env.PORT || 3000;
 const host = process.env.HOST || '0.0.0.0'; 
 const prisma = new PrismaClient();
 
-// --- Issue #34: CORS 制限の厳格化 ---
+// --- CORS 制限 ---
 const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || [];
-
 app.use(cors({
   origin: (origin, callback) => {
     if (!origin || allowedOrigins.includes(origin)) {
       callback(null, true);
     } else {
-      logger.warn(`[CORS Blocked]: 許可されていないオリジンからのアクセスです: ${origin}`);
+      logger.warn(`[CORS Blocked]: ${origin}`);
       callback(new Error('Not allowed by CORS'));
     }
   },
@@ -43,9 +47,11 @@ app.use(cors({
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
-// 既存のルート登録
-app.use('/api', receiptRoutes);
-app.use('/api/product-master', productMasterRoutes);
+// --- ルート登録の整理 ---
+// インラインで書いていたハンドラーを各ルーターへ委譲します
+app.use('/api/categories', categoryRoutes);      // /api/categories/*
+app.use('/api/product-master', productMasterRoutes); // /api/product-master/*
+app.use('/api', receiptRoutes);                  // /api/receipts/*, /api/receipt-items/*
 
 const uploadDir = 'uploads';
 if (!fs.existsSync(uploadDir)) {
@@ -56,67 +62,25 @@ const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
 /**
- * 📂 カテゴリー管理 API
- */
-app.get('/api/categories', async (req, res) => {
-  try {
-    const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } });
-    res.json(categories);
-  } catch (error: any) {
-    logger.error(`[APIエラー] カテゴリー取得失敗: ${error.message}`);
-    res.status(500).json({ error: 'Failed to fetch categories' });
-  }
-});
-
-app.post('/api/categories', async (req, res) => {
-  try {
-    const { name, color } = req.body;
-    if (!name) return res.status(400).json({ error: 'Name is required' });
-    const newCategory = await prisma.category.create({ data: { name, color: color || '#2ecc71' } });
-    logger.info(`[API] カテゴリー追加成功: ${name}`);
-    res.status(201).json(newCategory);
-  } catch (error: any) {
-    logger.error(`[APIエラー] カテゴリー追加失敗: ${error.message}`);
-    res.status(500).json({ error: 'Failed to create category' });
-  }
-});
-
-app.delete('/api/categories/:id', async (req, res) => {
-  const { id } = req.params;
-  try {
-    await prisma.category.delete({ where: { id: Number(id) } });
-    logger.info(`[API] カテゴリー削除成功: ID ${id}`);
-    res.status(204).send();
-  } catch (error: any) {
-    logger.warn(`[API制限] カテゴリー削除失敗（使用中の可能性あり）: ID ${id}`);
-    res.status(400).json({ error: 'Cannot delete category in use' });
-  }
-});
-
-/**
- * 📂 レシートアップロード & 解析 (Issue #37: Zodバリデーション適用)
+ * 📂 レシートアップロード & 解析 (この特殊な処理のみ server.ts に残すか、receiptRoutes に移動)
  */
 app.post(
   '/api/receipts/upload', 
   upload.single('image'), 
-  validate(uploadReceiptSchema), // ここでバリデーションと型変換を実行
-  async (req, res) => {
+  validate(uploadReceiptSchema),
+  async (req, res, next) => {
     try {
-      if (!req.file) return res.status(400).json({ error: '画像がアップロードされていません。' });
+      if (!req.file) throw new AppError('画像がアップロードされていません。', 400);
 
-      // validate() 内の parseAsync により、req.body.memberId は既に number 型に変換されています
       const { memberId } = req.body;
 
-      // --- 追加: DB整合性チェック ---
       const memberExists = await prisma.familyMember.findUnique({
         where: { id: memberId }
       });
 
       if (!memberExists) {
-        logger.warn(`[Validation Error]: 存在しない世帯IDです (ID: ${memberId})`);
-        return res.status(400).json({ error: '指定された世帯IDが存在しません。' });
+        throw new AppError('指定された世帯IDが存在しません。', 400);
       }
-      // ----------------------------
 
       const timestamp = Date.now();
       const randomSuffix = Math.round(Math.random() * 1e9);
@@ -129,118 +93,35 @@ app.post(
         .webp({ quality: 75, effort: 6 }) 
         .toFile(imagePath);
 
-      logger.info(`[Issue #30] WebP最適化完了: ${imagePath}`);
-
       const result = await processAndSaveReceipt(memberId, imagePath);
 
+      // Issue #40 形式でレスポンス
       res.status(200).json({
+        success: true,
         message: '解析および保存が完了しました。',
         data: result
       });
       
     } catch (error: any) {
       if (error.message === 'DUPLICATE_RECEIPT_DETECTED') {
-        return res.status(409).json({ error: 'このレシートは既に登録されています。', code: 'DUPLICATE_RECEIPT' });
+        return next(new AppError('このレシートは既に登録されています。', 409, { code: 'DUPLICATE_RECEIPT' }));
       }
-      logger.error(`[APIエラー] ${error.message}`);
-      res.status(500).json({ error: 'サーバー内部エラーが発生しました。' });
+      next(error);
     }
   }
 );
 
 /**
- * 📂 統計 API
+ * 404 ハンドラー
  */
-app.get('/api/stats/monthly', async (req, res) => {
-  const { month, memberId } = req.query; 
-  try {
-    const targetDate = month ? new Date(`${month as string}-01T00:00:00Z`) : new Date();
-    const startOfMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
-    const endOfMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0, 23, 59, 59);
-    const startOfPrevMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() - 1, 1);
-    const endOfPrevMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 0, 23, 59, 59);
-
-    const mId = Number(memberId || 1);
-
-    const stats = await prisma.item.groupBy({
-      by: ['categoryId'],
-      where: { receipt: { memberId: mId, date: { gte: startOfMonth, lte: endOfMonth } } },
-      _sum: { price: true },
-    });
-
-    const prevMonthTotal = await prisma.item.aggregate({
-      where: { receipt: { memberId: mId, date: { gte: startOfPrevMonth, lte: endOfPrevMonth } } },
-      _sum: { price: true },
-    });
-
-    const latestReceipt = await prisma.receipt.findFirst({
-      where: { memberId: mId, date: { gte: startOfMonth, lte: endOfMonth }, imagePath: { not: null } },
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true, imagePath: true, storeName: true, totalAmount: true,
-        items: {
-          select: { id: true, name: true, price: true, categoryId: true, category: { select: { name: true, color: true } } }
-        }
-      }
-    });
-
-    const categories = await prisma.category.findMany();
-    const formattedStats = stats.map(s => {
-      const category = categories.find(c => c.id === s.categoryId);
-      return {
-        categoryId: s.categoryId,
-        categoryName: category ? category.name : '未分類',
-        totalAmount: s._sum.price || 0,
-        color: (category as any)?.color || '#999',
-      };
-    });
-
-    const currentTotal = formattedStats.reduce((sum, s) => sum + s.totalAmount, 0);
-    const prevTotal = prevMonthTotal._sum.price || 0;
-
-    res.json({
-      month: `${startOfMonth.getFullYear()}-${String(startOfMonth.getMonth() + 1).padStart(2, '0')}`,
-      totalAmount: currentTotal,
-      prevTotal: prevTotal,
-      diffAmount: currentTotal - prevTotal,
-      diffPercentage: prevTotal !== 0 ? Math.round(((currentTotal - prevTotal) / prevTotal) * 100) : 0,
-      stats: formattedStats,
-      latestReceipt: latestReceipt 
-    });
-  } catch (error: any) {
-    logger.error(`[APIエラー] 集計失敗: ${error.message}`);
-    res.status(500).json({ error: 'Failed to fetch monthly stats' });
-  }
+app.use((req, res, next) => {
+  next(new AppError(`Not Found - ${req.originalUrl}`, 404));
 });
 
-app.patch('/api/receipt-items/:id', async (req, res) => {
-  const { id } = req.params;
-  const { categoryId } = req.body;
-  try {
-    const result = await prisma.$transaction(async (tx) => {
-      const currentItem = await tx.item.findUnique({ where: { id: Number(id) }, include: { receipt: true } });
-      if (!currentItem) throw new Error('Item not found');
-      const updatedItem = await tx.item.update({
-        where: { id: Number(id) },
-        data: { categoryId: Number(categoryId) },
-        include: { category: true, receipt: true }
-      });
-      const cleanItemName = getCleanText(currentItem.name);
-      const cleanStoreName = getCleanText(currentItem.receipt?.storeName || "");
-      await tx.productMaster.upsert({
-        where: { name_storeName: { name: cleanItemName, storeName: cleanStoreName } },
-        update: { categoryId: Number(categoryId) },
-        create: { name: cleanItemName, storeName: cleanStoreName, categoryId: Number(categoryId) }
-      });
-      return updatedItem;
-    });
-    logger.info(`[学習成功] "${result.name}" をマスタ登録完了`);
-    res.json(result);
-  } catch (error: any) {
-    logger.error(`[APIエラー] カテゴリー修正失敗: ${error.message}`);
-    res.status(500).json({ error: 'Failed to update item' });
-  }
-});
+/**
+ * 📂 グローバルエラーハンドラー (必ず最後に配置)
+ */
+app.use(errorHandler);
 
 app.listen(Number(port), host, () => {
   logger.info(`🚀 API Server running on http://${host}:${port}`);

--- a/backend/src/utils/appError.ts
+++ b/backend/src/utils/appError.ts
@@ -1,0 +1,14 @@
+export class AppError extends Error {
+  public readonly statusCode: number;
+  public readonly isOperational: boolean;
+  public readonly details?: any;
+
+  constructor(message: string, statusCode: number, details?: any) {
+    super(message);
+    this.statusCode = statusCode;
+    this.isOperational = true; // 予測可能な業務エラー
+    this.details = details;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,32 +1,35 @@
 import winston from 'winston';
 import 'winston-daily-rotate-file';
 
-const { combine, timestamp, printf, colorize, errors, json } = winston.format;
+const { combine, timestamp, printf, colorize, errors, json, metadata } = winston.format;
 
 /**
- * [Issue #25] 環境変数からログレベルを取得
- * デフォルトは 'info'。開発時は .env で 'debug' に設定可能。
+ * 環境変数からログレベルを取得
  */
 const logLevel = process.env.LOG_LEVEL || 'info';
 
-// ログフォーマット（コンソール用：人間が読みやすい形式）
+// ログフォーマット（コンソール用：スタックトレースや詳細を表示）
 const consoleFormat = combine(
   colorize(),
   timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-  printf(({ level, message, timestamp, stack }) => {
-    return `${timestamp} [${level}]: ${stack || message}`;
+  errors({ stack: true }), // エラーオブジェクトのパース
+  printf(({ level, message, timestamp, stack, details }) => {
+    // details（Zodのバリデーションエラー等）があれば文字列化して表示
+    const detailStr = details ? `\nDetails: ${JSON.stringify(details, null, 2)}` : '';
+    return `${timestamp} [${level}]: ${stack || message}${detailStr}`;
   })
 );
 
 const logger = winston.createLogger({
-  level: logLevel, // ★ ここを環境変数に連動
+  level: logLevel,
   format: combine(
     timestamp(),
     errors({ stack: true }),
-    json()
+    metadata({ fillExcept: ['message', 'level', 'timestamp', 'label'] }), // 余分なプロパティをmetadataに集約
+    json() // ファイル出力は解析しやすいJSON形式
   ),
   transports: [
-    // エラーログ（常に error レベルのみ）
+    // エラーログ：DailyRotate
     new winston.transports.DailyRotateFile({
       filename: 'logs/error-%DATE%.log',
       datePattern: 'YYYY-MM-DD',
@@ -34,7 +37,7 @@ const logger = winston.createLogger({
       maxSize: '20m',
       maxFiles: '14d',
     }),
-    // 全ログ（指定した logLevel に基づく）
+    // 全ログ：DailyRotate
     new winston.transports.DailyRotateFile({
       filename: 'logs/combined-%DATE%.log',
       datePattern: 'YYYY-MM-DD',
@@ -44,12 +47,11 @@ const logger = winston.createLogger({
   ],
 });
 
-// コンソール出力の判定
-// Docker環境や開発環境では標準出力(stdout)が重要なため、productionでも出力するように調整
+// コンソール出力設定
 if (process.env.NODE_ENV !== 'production' || process.env.CONSOLE_LOG === 'true') {
   logger.add(new winston.transports.Console({
     format: consoleFormat,
-    level: logLevel // コンソールも指定レベルに合わせる
+    level: logLevel
   }));
 }
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -57,7 +57,14 @@ export default function App() {
   const fetchCategories = useCallback(async () => {
     try {
       const res = await apiClient.get('/categories');
-      setCategories(res.data);
+      /**
+       * ★ 修正ポイント: [Issue #40]
+       * バックエンドのレスポンスが { success: true, data: Category[] } になったため、
+       * res.data.data を参照します。
+       */
+      if (res.data && res.data.success) {
+        setCategories(res.data.data);
+      }
     } catch (err) {
       console.error('マスタ取得失敗:', err);
     }
@@ -156,11 +163,15 @@ export default function App() {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
 
-      const responseData = response.data;
-      if (responseData && responseData.data) {
-        setResultData(responseData.data);
+      /**
+       * ★ 修正ポイント: [Issue #40]
+       * レスポンス形式を統一したため、response.data.data を取得します。
+       */
+      const responseBody = response.data;
+      if (responseBody && responseBody.success) {
+        setResultData(responseBody.data);
       } else {
-        console.error('APIレスポンスの構造が不正です:', responseData);
+        console.error('APIレスポンスの構造が不正です:', responseBody);
         throw new Error('解析データの取得に失敗しました');
       }
 
@@ -186,18 +197,23 @@ export default function App() {
         categoryId: Number(categoryId) 
       });
       
-      const updatedItem = response.data;
-      if (!updatedItem) return;
+      /**
+       * ★ 修正ポイント: [Issue #40]
+       * response.data.data (更新後の単一アイテム) を参照。
+       */
+      if (response.data && response.data.success) {
+        const updatedItem = response.data.data;
 
-      setResultData((prev: any) => {
-        if (!prev || !prev.items) return prev;
-        return {
-          ...prev,
-          items: prev.items.map((item: any) =>
-            item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
-          ),
-        };
-      });
+        setResultData((prev: any) => {
+          if (!prev || !prev.items) return prev;
+          return {
+            ...prev,
+            items: prev.items.map((item: any) =>
+              item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
+            ),
+          };
+        });
+      }
     } catch (error: any) {
       Alert.alert('エラー', error.response?.data?.error || '更新に失敗しました');
     }
@@ -227,14 +243,12 @@ export default function App() {
       case 'history':
         return <HistoryScreen onBack={() => setCurrentView('main')} currentMemberId={currentMemberId}/>;
       case 'stats':
-        return (
-          <View style={{ flex: 1 }}>
-            <StatisticsScreen currentMemberId={currentMemberId}/>
-            <TouchableOpacity style={styles.floatingBackButton} onPress={() => setCurrentView('main')}>
-              <Text style={styles.floatingBackButtonText}>ホームに戻る</Text>
-            </TouchableOpacity>
-          </View>
-        );
+        /**
+         * ★ 修正ポイント: 
+         * StatisticsScreen 内部で「戻る」ボタンを表示させるため、onBack を渡します。
+         * App.tsx 側のフローティングボタンは削除しました。
+         */
+        return <StatisticsScreen currentMemberId={currentMemberId} onBack={() => setCurrentView('main')} />;
       case 'category_mgr':
         return (
           <CategoryManagementScreen 
@@ -244,7 +258,6 @@ export default function App() {
             }} 
           />
         );
-      // --- Issue #36: 学習マスタ管理画面のケースを追加 ---
       case 'product_master':
         return (
           <ProductMasterScreen 
@@ -310,7 +323,6 @@ export default function App() {
                 onGoToHistory={() => setCurrentView('history')}
                 onGoToStats={() => setCurrentView('stats')}
                 onGoToCategories={() => setCurrentView('category_mgr')}
-                // --- Issue #36: 学習マスタ画面への遷移を追加 ---
                 onGoToProductMaster={() => setCurrentView('product_master')}
                 currentMemberId={currentMemberId}
               />
@@ -329,8 +341,7 @@ export default function App() {
 
 const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
-  floatingBackButton: { position: 'absolute', bottom: 30, alignSelf: 'center', backgroundColor: theme.colors.primary, paddingVertical: 12, paddingHorizontal: 30, borderRadius: theme.borderRadius.round, elevation: 5 },
-  floatingBackButtonText: { color: 'white', fontWeight: 'bold' },
+  // floatingBackButton は削除しました
   previewContainer: { flex: 1, backgroundColor: '#000', justifyContent: 'center', alignItems: 'center' },
   preview: { width: '90%', height: '70%', borderRadius: 10 },
   previewActions: { width: '100%', padding: 20, flexDirection: 'row', justifyContent: 'space-around', alignItems: 'center', position: 'absolute', bottom: 40 },
@@ -351,11 +362,9 @@ const styles = StyleSheet.create({
   picker: { width: '100%' },
   doneButton: { backgroundColor: theme.colors.primary, padding: 16, borderRadius: theme.borderRadius.md, alignItems: 'center', marginTop: theme.spacing.xl },
   doneButtonText: { color: 'white', fontWeight: 'bold', fontSize: 16 },
-
-  // 世帯切替UIスタイル
   switcherContainer: {
     flexDirection: 'row',
-    paddingTop: 50, // SafeArea相当の余白
+    paddingTop: 50, 
     paddingBottom: 15,
     backgroundColor: theme.colors.surface,
     justifyContent: 'center',

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
-import apiClient from '../utils/apiClient'; // apiClient をインポート
+import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
 
 interface Category {
@@ -9,7 +9,6 @@ interface Category {
   color: string;
 }
 
-// Props から API_BASE を削除
 export const CategoryManagementScreen = ({ onBack }: { onBack: () => void }) => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [newName, setNewName] = useState('');
@@ -23,7 +22,14 @@ export const CategoryManagementScreen = ({ onBack }: { onBack: () => void }) => 
     setLoading(true);
     try {
       const res = await apiClient.get('/categories');
-      setCategories(res.data);
+      /**
+       * ★ 修正ポイント: [Issue #40] 
+       * バックエンドのレスポンス形式 { success: true, data: Category[] } に合わせ、
+       * res.data.data を取得します。
+       */
+      if (res.data && res.data.success) {
+        setCategories(res.data.data || []);
+      }
     } catch (e) {
       Alert.alert("エラー", "カテゴリーの取得に失敗しました。");
     } finally {
@@ -34,7 +40,6 @@ export const CategoryManagementScreen = ({ onBack }: { onBack: () => void }) => 
   const addCategory = async () => {
     if (!newName.trim()) return;
     try {
-      // apiClient を使用 (Content-Type 指定は不要)
       await apiClient.post('/categories', { 
         name: newName, 
         color: '#2ecc71' 
@@ -54,6 +59,7 @@ export const CategoryManagementScreen = ({ onBack }: { onBack: () => void }) => 
             await apiClient.delete(`/categories/${id}`);
             fetchCategories();
           } catch (e: any) {
+            // ステータスコードに応じたエラーハンドリングを維持
             if (e.response?.status === 400 || e.response?.status === 409) {
               Alert.alert("制限", "このカテゴリーは既に使用されているため削除できません。");
             } else {
@@ -93,6 +99,7 @@ export const CategoryManagementScreen = ({ onBack }: { onBack: () => void }) => 
           data={categories}
           keyExtractor={(item) => item.id.toString()}
           contentContainerStyle={styles.list}
+          ListEmptyComponent={<Text style={styles.emptyText}>登録されているカテゴリーはありません</Text>}
           renderItem={({ item }) => (
             <View style={styles.itemRow}>
               <View style={[styles.colorBadge, { backgroundColor: item.color }]} />
@@ -123,5 +130,6 @@ const styles = StyleSheet.create({
   colorBadge: { width: 14, height: 14, borderRadius: 7, marginRight: 15 },
   categoryName: { flex: 1, ...theme.typography.body, fontWeight: '600' },
   deleteButton: { padding: 8 },
-  deleteText: { color: theme.colors.error, fontSize: 14, fontWeight: '700' }
+  deleteText: { color: theme.colors.error, fontSize: 14, fontWeight: '700' },
+  emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted }
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -6,7 +6,7 @@ import { theme } from '../theme';
 
 interface HistoryScreenProps {
   onBack: () => void;
-  currentMemberId: number; // App.tsx から受け取る
+  currentMemberId: number; 
 }
 
 export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreenProps) {
@@ -16,13 +16,23 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
   const [selectedReceipt, setSelectedReceipt] = useState<any | null>(null);
   
   const [selectedMonth, setSelectedMonth] = useState('');
-  // 初期値を App.tsx で選択されている世帯 ID に設定
   const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
 
   const cacheKey = useMemo(() => Date.now(), []);
-  const months = ['2026-03', '2026-02', '2026-01', '2025-12'];
 
-  // 画像表示用ベースURL
+  /**
+   * ★ 修正ポイント: [2026-04 対応]
+   * 現在の日付から過去6ヶ月分を動的に生成します。
+   * これにより 2026-04 が自動的にリストの先頭に現れます。
+   */
+  const months = useMemo(() => {
+    return Array.from({ length: 6 }).map((_, i) => {
+      const d = new Date();
+      d.setMonth(d.getMonth() - i);
+      return d.toISOString().slice(0, 7); // YYYY-MM
+    });
+  }, []);
+
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
@@ -31,7 +41,9 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     const fetchCategories = async () => {
       try {
         const res = await apiClient.get('/categories');
-        setCategories(res.data);
+        if (res.data && res.data.success) {
+          setCategories(res.data.data);
+        }
       } catch (err) {
         console.error('カテゴリー取得失敗', err);
       }
@@ -49,7 +61,13 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
           month: selectedMonth
         }
       });
-      setReceipts(res.data);
+      /**
+       * ★ 修正ポイント: [Issue #40]
+       * res.data.data 階層を正しくセットします。
+       */
+      if (res.data && res.data.success) {
+        setReceipts(res.data.data);
+      }
     } catch (err) {
       console.error('履歴取得失敗', err);
       Alert.alert('エラー', '履歴の取得に失敗しました');
@@ -62,7 +80,6 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     fetchReceipts();
   }, [fetchReceipts]);
 
-  // App.tsx 側で世帯が切り替わった場合、履歴画面の選択状態も同期させる
   useEffect(() => {
     setSelectedMember(currentMemberId.toString());
   }, [currentMemberId]);
@@ -74,24 +91,26 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
       const response = await apiClient.patch(`/receipt-items/${itemId}`, {
         categoryId: Number(categoryId)
       });
-      const updatedItem = response.data;
+      
+      if (response.data && response.data.success) {
+        const updatedItem = response.data.data;
 
-      // ステート更新
-      setSelectedReceipt((prev: any) =>
-        prev ? {
-          ...prev,
-          items: prev.items.map((item: any) =>
+        setSelectedReceipt((prev: any) =>
+          prev ? {
+            ...prev,
+            items: prev.items.map((item: any) =>
+              item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
+            ),
+          } : prev
+        );
+
+        setReceipts(prev => prev.map(r => ({
+          ...r,
+          items: r.items.map((item: any) =>
             item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
           ),
-        } : prev
-      );
-
-      setReceipts(prev => prev.map(r => ({
-        ...r,
-        items: r.items.map((item: any) =>
-          item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
-        ),
-      })));
+        })));
+      }
     } catch (err) {
       console.error('カテゴリー更新失敗', err);
       Alert.alert('エラー', '更新に失敗しました');
@@ -110,16 +129,16 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
       activeOpacity={0.7}
     >
       <View style={styles.cardHeader}>
-        <Text style={styles.date}>{new Date(item.date).toLocaleDateString('ja-JP')}</Text>
-        <Text style={styles.store} numberOfLines={1}>{item.storeName}</Text>
+        <Text style={styles.date}>{item.date ? new Date(item.date).toLocaleDateString('ja-JP') : '日付不明'}</Text>
+        <Text style={styles.store} numberOfLines={1}>{item.storeName || '店名不明'}</Text>
       </View>
       <View style={styles.cardBody}>
         <View>
           <Text style={styles.label}>合計</Text>
-          <Text style={styles.amount}>¥{item.totalAmount.toLocaleString()}</Text>
+          <Text style={styles.amount}>¥{(item.totalAmount || 0).toLocaleString()}</Text>
         </View>
         <View style={styles.itemCountBadge}>
-          <Text style={styles.itemCountText}>{item.items.length} 点</Text>
+          <Text style={styles.itemCountText}>{(item.items?.length || 0)} 点</Text>
         </View>
       </View>
     </TouchableOpacity>
@@ -144,7 +163,9 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
             dropdownIconColor={theme.colors.primary}
           >
             <Picker.Item label="全期間" value="" />
-            {months.map(m => <Picker.Item key={m} label={m} value={m} />)}
+            {months.map(m => (
+              <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
+            ))}
           </Picker>
         </View>
         <View style={styles.pickerBox}>
@@ -154,7 +175,6 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
             style={styles.filterPicker}
             dropdownIconColor={theme.colors.primary}
           >
-            {/* ラベルを「自分」「その他」に変更 */}
             <Picker.Item label="自分" value="1" />
             <Picker.Item label="その他" value="2" />
           </Picker>
@@ -182,7 +202,7 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
       >
         <View style={styles.modalContent}>
           <View style={styles.detailHeader}>
-            <Text style={styles.detailTitle} numberOfLines={1}>{selectedReceipt?.storeName}</Text>
+            <Text style={styles.detailTitle} numberOfLines={1}>{selectedReceipt?.storeName || '店名不明'}</Text>
             <TouchableOpacity onPress={() => setSelectedReceipt(null)} hitSlop={{top: 20, bottom: 20, left: 20, right: 20}}>
               <Text style={styles.detailClose}>✕</Text>
             </TouchableOpacity>
@@ -201,16 +221,16 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
 
             <View style={styles.detailTotalContainer}>
               <Text style={styles.detailTotalLabel}>合計金額（税込）</Text>
-              <Text style={styles.detailTotalValue}>¥{selectedReceipt?.totalAmount.toLocaleString()}</Text>
+              <Text style={styles.detailTotalValue}>¥{(selectedReceipt?.totalAmount || 0).toLocaleString()}</Text>
             </View>
 
             <View style={styles.itemsSection}>
               <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
-              {selectedReceipt?.items.map((item: any) => (
+              {selectedReceipt?.items?.map((item: any) => (
                 <View key={item.id} style={styles.detailItemRow}>
                   <View style={styles.detailItemInfo}>
                     <Text style={styles.detailItemName}>{item.name}</Text>
-                    <Text style={styles.detailItemPrice}>¥{item.price.toLocaleString()}</Text>
+                    <Text style={styles.detailItemPrice}>¥{(item.price || 0).toLocaleString()}</Text>
                   </View>
                   <View style={styles.detailPickerWrapper}>
                     <Picker
@@ -233,59 +253,17 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
   );
 }
 
+// styles は以前と同様のため省略（そのまま使用してください）
 const styles = StyleSheet.create({
-  container: { 
-    flex: 1, 
-    backgroundColor: theme.colors.background, 
-    paddingTop: Platform.OS === 'ios' ? 60 : 20 
-  },
-  header: { 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    alignItems: 'center', 
-    paddingHorizontal: theme.spacing.lg, 
-    marginBottom: theme.spacing.md 
-  },
-  backButton: { 
-    ...theme.typography.body,
-    color: theme.colors.primary, 
-    fontWeight: '700' 
-  },
-  title: { 
-    ...theme.typography.h2,
-    color: theme.colors.text.main 
-  },
-  filterContainer: { 
-    flexDirection: 'row', 
-    paddingHorizontal: theme.spacing.md, 
-    marginBottom: theme.spacing.md, 
-    justifyContent: 'space-between' 
-  },
-  pickerBox: { 
-    flex: 1, 
-    height: 48, 
-    backgroundColor: theme.colors.surface, 
-    borderRadius: theme.borderRadius.sm, 
-    marginHorizontal: theme.spacing.xs, 
-    justifyContent: 'center', 
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    elevation: 1 
-  },
+  container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
+  backButton: { ...theme.typography.body, color: theme.colors.primary, fontWeight: '700' },
+  title: { ...theme.typography.h2, color: theme.colors.text.main },
+  filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, justifyContent: 'space-between' },
+  pickerBox: { flex: 1, height: 48, backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.sm, marginHorizontal: theme.spacing.xs, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, elevation: 1 },
   filterPicker: { width: '100%' },
   list: { paddingHorizontal: theme.spacing.md, paddingBottom: theme.spacing.xl },
-  card: { 
-    backgroundColor: theme.colors.surface, 
-    borderRadius: theme.borderRadius.md, 
-    padding: theme.spacing.md, 
-    marginBottom: theme.spacing.sm, 
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    ...Platform.select({
-      ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.05, shadowRadius: 4 },
-      android: { elevation: 2 }
-    })
-  },
+  card: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.md, marginBottom: theme.spacing.sm, borderWidth: 1, borderColor: theme.colors.border, ...Platform.select({ ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.05, shadowRadius: 4 }, android: { elevation: 2 } }) },
   cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: theme.spacing.sm },
   date: { ...theme.typography.caption, color: theme.colors.text.muted },
   store: { ...theme.typography.body, fontWeight: '700', color: theme.colors.text.main, flex: 1, marginLeft: theme.spacing.sm, textAlign: 'right' },

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -11,7 +11,7 @@ interface HomeScreenProps {
   onGoToHistory: () => void;
   onGoToStats: () => void;
   onGoToCategories: () => void; 
-  onGoToProductMaster: () => void; // --- [Issue #36] 追加 ---
+  onGoToProductMaster: () => void; 
   currentMemberId: number;
 }
 
@@ -20,7 +20,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   onGoToHistory, 
   onGoToStats, 
   onGoToCategories,
-  onGoToProductMaster, // --- [Issue #36] 追加 ---
+  onGoToProductMaster,
   currentMemberId 
 }) => {
   const [latestReceipt, setLatestReceipt] = useState<any>(null);
@@ -32,7 +32,17 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
       const response = await apiClient.get('/receipts/latest', {
         params: { memberId: currentMemberId }
       });
-      setLatestReceipt(response.data);
+
+      /**
+       * ★ 修正ポイント: [Issue #40] 
+       * バックエンドのレスポンス形式 { success: true, data: Receipt } に合わせ、
+       * response.data.data を取得します。
+       */
+      if (response.data && response.data.success) {
+        setLatestReceipt(response.data.data);
+      } else {
+        setLatestReceipt(null);
+      }
     } catch (error) {
       console.error('最新レシート取得失敗:', error);
       setLatestReceipt(null);
@@ -80,7 +90,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           </TouchableOpacity>
         </View>
 
-        {/* カテゴリー設定 */}
         <TouchableOpacity 
           style={styles.settingsCard} 
           onPress={onGoToCategories}
@@ -96,7 +105,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           <Text style={styles.arrowIcon}>›</Text>
         </TouchableOpacity>
 
-        {/* --- [Issue #36] 学習マスタ管理への導線を追加 --- */}
         <TouchableOpacity 
           style={[styles.settingsCard, { marginTop: -15 }]} 
           onPress={onGoToProductMaster}
@@ -119,10 +127,14 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           ) : latestReceipt ? (
             <View style={styles.latestCard}>
               <View style={styles.cardInfo}>
-                <Text style={styles.storeName} numberOfLines={1}>{latestReceipt.storeName}</Text>
-                <Text style={styles.dateText}>{latestReceipt.date}</Text>
+                <Text style={styles.storeName} numberOfLines={1}>{latestReceipt.storeName || '店名不明'}</Text>
+                <Text style={styles.dateText}>
+                  {latestReceipt.date ? new Date(latestReceipt.date).toLocaleDateString('ja-JP') : '日付不明'}
+                </Text>
               </View>
-              <Text style={styles.amountText}>¥{latestReceipt.totalAmount.toLocaleString()}</Text>
+              <Text style={styles.amountText}>
+                ¥{(latestReceipt.totalAmount || 0).toLocaleString()}
+              </Text>
             </View>
           ) : (
             <View style={[styles.latestCard, { justifyContent: 'center' }]}>

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Modal, Platform } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
 
@@ -23,27 +23,49 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [storeFilter, setStoreFilter] = useState('');
-  
   const [categories, setCategories] = useState<Category[]>([]);
 
+  // マスタデータ取得
   const fetchMasters = useCallback(async () => {
     try {
       setLoading(true);
       const res = await apiClient.get('/product-master', {
         params: { q: searchQuery, store: storeFilter }
       });
-      setMasters(res.data);
+      
+      /**
+       * ★ 修正ポイント: [Issue #40] 
+       * バックエンドのレスポンス形式 { success: true, data: T } に合わせ、
+       * res.data.data を取得します。
+       */
+      if (res.data && res.data.success) {
+        setMasters(res.data.data || []);
+      } else {
+        setMasters([]);
+      }
     } catch (err) {
-      console.error(err);
+      console.error('Fetch Masters Error:', err);
       Alert.alert('エラー', 'マスタの取得に失敗しました');
     } finally {
       setLoading(false);
     }
   }, [searchQuery, storeFilter]);
 
+  // 初回ロードとカテゴリー取得
   useEffect(() => {
     fetchMasters();
-    apiClient.get('/categories').then(res => setCategories(res.data));
+    
+    const loadCategories = async () => {
+      try {
+        const res = await apiClient.get('/categories');
+        if (res.data && res.data.success) {
+          setCategories(res.data.data || []);
+        }
+      } catch (err) {
+        console.error('Category fetch error:', err);
+      }
+    };
+    loadCategories();
   }, [fetchMasters]);
 
   const handleDelete = (id: number) => {
@@ -61,8 +83,6 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
   };
 
   const handleMergeStores = () => {
-    // React NativeのAlert.promptはiOSのみ対応です
-    // Androidでも動かす場合はModalで自作が必要ですが、まずは簡易実装にします
     if (Platform.OS === 'ios') {
       Alert.prompt(
         "店舗名の統合",
@@ -102,7 +122,7 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
     <View style={styles.card}>
       <View style={styles.cardInfo}>
         <Text style={styles.itemName}>{item.name}</Text>
-        <Text style={styles.storeName}>店舗: {item.storeName}</Text>
+        <Text style={styles.storeName}>店舗: {item.storeName || '共通'}</Text>
         <View style={[styles.badge, { backgroundColor: item.category?.color || '#ccc' }]}>
           <Text style={styles.badgeText}>{item.category?.name || '未分類'}</Text>
         </View>
@@ -117,6 +137,7 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
 
   return (
     <View style={styles.container}>
+      {/* 他の画面と統一したヘッダーデザイン */}
       <View style={styles.header}>
         <TouchableOpacity onPress={onBack} hitSlop={{top:10, bottom:10, left:10, right:10}}>
           <Text style={styles.backText}>← 戻る</Text>
@@ -134,6 +155,7 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
           value={searchQuery} 
           onChangeText={setSearchQuery} 
           clearButtonMode="while-editing"
+          placeholderTextColor={theme.colors.text.muted}
         />
         <TextInput 
           placeholder="店舗名..." 
@@ -141,6 +163,7 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
           value={storeFilter} 
           onChangeText={setStoreFilter} 
           clearButtonMode="while-editing"
+          placeholderTextColor={theme.colors.text.muted}
         />
       </View>
 
@@ -151,8 +174,9 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
           data={masters}
           keyExtractor={(item) => item.id.toString()}
           renderItem={renderItem}
-          contentContainerStyle={{ paddingBottom: 40 }}
+          contentContainerStyle={styles.listContent}
           ListEmptyComponent={<Text style={styles.empty}>データがありません</Text>}
+          initialNumToRender={15}
         />
       )}
     </View>
@@ -161,13 +185,45 @@ export const ProductMasterScreen = ({ onBack }: { onBack: () => void }) => {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
-  header: { flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 20, paddingBottom: 15, alignItems: 'center', borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  header: { 
+    flexDirection: 'row', 
+    justifyContent: 'space-between', 
+    paddingHorizontal: 20, 
+    paddingBottom: 15, 
+    alignItems: 'center', 
+    borderBottomWidth: 1, 
+    borderBottomColor: theme.colors.border 
+  },
   backText: { color: theme.colors.primary, fontWeight: 'bold', fontSize: 16 },
   title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   mergeText: { color: theme.colors.secondary, fontWeight: 'bold' },
   searchBar: { padding: 10, flexDirection: 'row', backgroundColor: theme.colors.surface },
-  input: { flex: 1, backgroundColor: '#fff', marginHorizontal: 5, padding: 10, borderRadius: 8, borderWidth: 1, borderColor: theme.colors.border },
-  card: { backgroundColor: '#fff', marginHorizontal: 15, marginTop: 10, padding: 15, borderRadius: 10, flexDirection: 'row', justifyContent: 'space-between', borderWidth: 1, borderColor: theme.colors.border },
+  input: { 
+    flex: 1, 
+    backgroundColor: '#fff', 
+    marginHorizontal: 5, 
+    padding: 12, 
+    borderRadius: 8, 
+    borderWidth: 1, 
+    borderColor: theme.colors.border,
+    color: theme.colors.text.main 
+  },
+  listContent: { paddingBottom: 40 },
+  card: { 
+    backgroundColor: '#fff', 
+    marginHorizontal: 15, 
+    marginTop: 10, 
+    padding: 15, 
+    borderRadius: 10, 
+    flexDirection: 'row', 
+    justifyContent: 'space-between', 
+    borderWidth: 1, 
+    borderColor: theme.colors.border,
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.05, shadowRadius: 4 },
+      android: { elevation: 2 }
+    })
+  },
   cardInfo: { flex: 1 },
   itemName: { fontWeight: 'bold', fontSize: 16, color: theme.colors.text.main },
   storeName: { color: theme.colors.text.muted, fontSize: 13, marginVertical: 4 },

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Image, TouchableOpacity, Modal, Alert, FlatList, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
@@ -8,54 +8,22 @@ import { theme } from '../theme';
 
 const screenWidth = Dimensions.get('window').width;
 
-// インターフェース定義
-interface Category {
-  id: number;
-  name: string;
-  color: string;
+// --- interface 定義 ---
+interface Category { id: number; name: string; color: string; }
+interface StatItem { categoryId: number | null; categoryName: string; totalAmount: number; color: string; }
+interface ReceiptItem { id: number; name: string; price: number; categoryId: number; category?: { name: string; color: string }; }
+interface ReceiptInfo { id: number; imagePath: string | null; storeName: string; totalAmount: number; items: ReceiptItem[]; }
+interface MonthlyData { month: string; totalAmount: number; prevTotal: number; diffAmount: number; diffPercentage: number; stats: StatItem[]; latestReceipt: ReceiptInfo | null; }
+
+// ★ Props に onBack を追加
+interface StatisticsScreenProps { 
+  currentMemberId: number; 
+  onBack: () => void;
 }
 
-interface StatItem {
-  categoryId: number | null;
-  categoryName: string;
-  totalAmount: number;
-  color: string;
-}
-
-interface ReceiptItem {
-  id: number;
-  name: string;
-  price: number;
-  categoryId: number;
-  category?: { name: string; color: string };
-}
-
-interface ReceiptInfo {
-  id: number;
-  imagePath: string | null;
-  storeName: string;
-  totalAmount: number;
-  items: ReceiptItem[];
-}
-
-interface MonthlyData {
-  month: string;
-  totalAmount: number;
-  prevTotal: number;
-  diffAmount: number;
-  diffPercentage: number;
-  stats: StatItem[];
-  latestReceipt: ReceiptInfo | null;
-}
-
-// Props インターフェースを追加
-interface StatisticsScreenProps {
-  currentMemberId: number;
-}
-
-export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId }) => {
+export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId, onBack }) => {
   const [loading, setLoading] = useState(true);
-  const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7)); // YYYY-MM
+  const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
   const [data, setData] = useState<MonthlyData | null>(null);
   const [allCategories, setAllCategories] = useState<Category[]>([]);
   
@@ -66,34 +34,44 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
-  const monthOptions = Array.from({ length: 12 }).map((_, i) => {
-    const d = new Date();
-    d.setMonth(d.getMonth() - i);
-    return d.toISOString().slice(0, 7);
-  });
+  // 12ヶ月分の日付リストを生成
+  const monthOptions = useMemo(() => {
+    return Array.from({ length: 12 }).map((_, i) => {
+      const d = new Date();
+      d.setMonth(d.getMonth() - i);
+      return d.toISOString().slice(0, 7);
+    });
+  }, []);
 
-  // memberId をクエリパラメータに追加
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
       const [statsRes, catRes] = await Promise.all([
-        apiClient.get<MonthlyData>(`/stats/monthly`, {
-          params: { 
-            month: selectedMonth,
-            memberId: currentMemberId 
-          }
+        apiClient.get(`/stats/monthly`, {
+          params: { month: selectedMonth, memberId: currentMemberId }
         }),
-        apiClient.get<Category[]>('/categories')
+        apiClient.get('/categories')
       ]);
-      setData(statsRes.data);
-      setAllCategories(catRes.data);
+
+      /**
+       * ★ 修正ポイント: [Issue #40] 
+       * res.data.data を参照
+       */
+      if (statsRes.data && statsRes.data.success) {
+        setData(statsRes.data.data);
+      }
+      
+      if (catRes.data && catRes.data.success) {
+        setAllCategories(catRes.data.data);
+      }
+
     } catch (error) {
       console.error('Fetch error:', error);
       Alert.alert("エラー", "データの取得に失敗しました");
     } finally {
       setLoading(false);
     }
-  }, [selectedMonth, currentMemberId]); // currentMemberId を依存配列に追加
+  }, [selectedMonth, currentMemberId]);
 
   useEffect(() => {
     fetchData();
@@ -123,11 +101,19 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   return (
     <SafeAreaView style={styles.container}>
+      {/* ★ 他画面と統一したヘッダー構成 */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
+          <Text style={styles.backButton}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>収支統計</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
-        
-        <View style={styles.header}>
+        <View style={styles.topInfo}>
           <Text style={styles.headerSubtitle}>
-            {currentMemberId === 1 ? '自分の収支分析レポート' : 'その他の収支分析レポート'}
+            {currentMemberId === 1 ? '自分の分析レポート' : 'その他の分析レポート'}
           </Text>
           <View style={styles.monthPickerContainer}>
             <Picker
@@ -149,7 +135,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
           <>
             <View style={styles.summaryCard}>
               <Text style={styles.summaryLabel}>合計支出</Text>
-              <Text style={styles.totalValue}>¥{data?.totalAmount.toLocaleString()}</Text>
+              <Text style={styles.totalValue}>¥{(data?.totalAmount || 0).toLocaleString()}</Text>
               
               <View style={styles.comparisonRow}>
                 <Text style={styles.comparisonLabel}>前月比:</Text>
@@ -158,7 +144,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                   { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success }
                 ]}>
                   {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥{Math.abs(data?.diffAmount || 0).toLocaleString()} 
-                  ({(data?.diffPercentage || 0) > 0 ? '+' : ''}{data?.diffPercentage}%)
+                  ({(data?.diffPercentage || 0) > 0 ? '+' : ''}{data?.diffPercentage || 0}%)
                 </Text>
               </View>
             </View>
@@ -199,8 +185,8 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                     resizeMode="cover"
                   />
                   <View style={styles.receiptInfoOverlay}>
-                    <Text style={styles.receiptStoreName}>{data.latestReceipt.storeName}</Text>
-                    <Text style={styles.receiptAmount}>¥{data.latestReceipt.totalAmount.toLocaleString()}</Text>
+                    <Text style={styles.receiptStoreName}>{data.latestReceipt.storeName || '店名不明'}</Text>
+                    <Text style={styles.receiptAmount}>¥{(data.latestReceipt.totalAmount || 0).toLocaleString()}</Text>
                   </View>
                 </TouchableOpacity>
               ) : (
@@ -213,6 +199,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         )}
       </ScrollView>
 
+      {/* モーダル類は以前と同様 */}
       <Modal visible={isMainModalVisible} animationType="slide">
         <SafeAreaView style={styles.modalContainer}>
           <View style={styles.modalHeader}>
@@ -239,7 +226,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                 <View key={item.id} style={styles.itemRow}>
                   <View style={{ flex: 1 }}>
                     <Text style={styles.itemName}>{item.name}</Text>
-                    <Text style={styles.itemPrice}>¥{item.price.toLocaleString()}</Text>
+                    <Text style={styles.itemPrice}>¥{(item.price || 0).toLocaleString()}</Text>
                   </View>
                   <TouchableOpacity 
                     style={[styles.categoryBadge, { backgroundColor: item.category?.color || theme.colors.secondary }]}
@@ -287,8 +274,21 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
+  // ヘッダースタイル（他画面と統一）
+  header: { 
+    flexDirection: 'row', 
+    justifyContent: 'space-between', 
+    alignItems: 'center', 
+    paddingHorizontal: theme.spacing.lg, 
+    paddingVertical: theme.spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border
+  },
+  backButton: { ...theme.typography.body, color: theme.colors.primary, fontWeight: '700' },
+  headerTitle: { ...theme.typography.h2, color: theme.colors.text.main },
+  
   scrollContent: { padding: theme.spacing.lg },
-  header: { marginBottom: theme.spacing.md },
+  topInfo: { marginBottom: theme.spacing.md },
   headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, textTransform: 'uppercase', letterSpacing: 1 },
   monthPickerContainer: { 
     backgroundColor: theme.colors.surface, 
@@ -332,10 +332,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     borderWidth: 1,
     borderColor: theme.colors.border,
-    ...Platform.select({
-      ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 8 },
-      android: { elevation: 4 }
-    })
+    elevation: 4
   },
   receiptImage: { width: '100%', height: 160, backgroundColor: theme.colors.border },
   receiptInfoOverlay: {

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -10,14 +10,27 @@ const apiClient = axios.create({
   },
 });
 
-// リクエスト送信前にトークンを自動注入
+// --- リクエストインターセプター ---
 apiClient.interceptors.request.use((config) => {
   if (API_TOKEN) {
     config.headers.Authorization = `Bearer ${API_TOKEN}`;
   }
   return config;
-}, (error) => {
-  return Promise.reject(error);
-});
+}, (error) => Promise.reject(error));
+
+// --- レスポンスインターセプター: [Issue #40] 加工をせずエラーハンドリングのみに集中 ---
+apiClient.interceptors.response.use(
+  (response) => {
+    // 構造は変えず、そのまま返す。これで res.data.data が維持されます。
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.data) {
+      const message = error.response.data.error || error.message;
+      return Promise.reject(new Error(message));
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;


### PR DESCRIPTION
バックエンドの全エンドポイントのレスポンスを { success: true, data: ... } 形式に統一。
グローバルエラーハンドラーを導入し、AppError および next(error) による例外処理を一元化。
フロントエンド（Expo）の各画面において、res.data.data を参照するようにデータアクセス階層を修正。
支出統計画面の「戻る」ボタンのレイアウトを他画面と統一。