### PR TITLE
重複登録防止ロジックの刷新（ハッシュ廃止とビジネスキー導入） #42

### DIFF
--- a/backend/prisma/migrations/20260406080504_add_content_hash_to_receipt/migration.sql
+++ b/backend/prisma/migrations/20260406080504_add_content_hash_to_receipt/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[contentHash]` on the table `Receipt` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Receipt" ADD COLUMN     "contentHash" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Receipt_contentHash_key" ON "Receipt"("contentHash");

--- a/backend/prisma/migrations/20260406094352_drop_content_hash_and_move_to_logic_check/migration.sql
+++ b/backend/prisma/migrations/20260406094352_drop_content_hash_and_move_to_logic_check/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `contentHash` on the `Receipt` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Receipt_contentHash_key";
+
+-- AlterTable
+ALTER TABLE "Receipt" DROP COLUMN "contentHash";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -9,8 +9,8 @@ datasource db {
 
 // 家族構成
 model FamilyMember {
-  id      Int      @id @default(autoincrement())
-  name    String   @unique
+  id       Int       @id @default(autoincrement())
+  name     String    @unique
   receipts Receipt[]
 }
 
@@ -18,7 +18,7 @@ model FamilyMember {
 model Category {
   id             Int             @id @default(autoincrement())
   name           String          @unique
-  color          String?         // [Issue #14] UI表示用のカラーコードを追加
+  color          String?         // [Issue #14] UI表示用のカラーコード
   keywords       Json            @default("[]") 
   items          Item[]
   productMasters ProductMaster[]
@@ -32,25 +32,21 @@ model Store {
 }
 
 model Receipt {
-  id          Int          @id @default(autoincrement())
-  memberId    Int
-  member      FamilyMember @relation(fields: [memberId], references: [id])
-  storeName   String
-  // PostgreSQLのTIMESTAMPTZ型を明示
-  date        DateTime     @db.Timestamptz(3)
-  totalAmount Int
-  // [Issue #26] String型からJson型へ変更
-  rawText     Json?
-  imagePath   String?      // [Issue #12.5] 画像保存用パスを追加
-  items       Item[]
-  // PostgreSQLのTIMESTAMPTZ型を明示
-  createdAt   DateTime     @default(now()) @db.Timestamptz(3)
+  id           Int          @id @default(autoincrement())
+  memberId     Int
+  member       FamilyMember @relation(fields: [memberId], references: [id])
+  storeName    String
+  date         DateTime     @db.Timestamptz(3)
+  totalAmount  Int
+  rawText      Json?
+  imagePath    String?      
+  items        Item[]
+  createdAt    DateTime     @default(now()) @db.Timestamptz(3)
 }
 
 model Item {
   id          Int       @id @default(autoincrement())
   receiptId   Int
-  // [Issue #19] onDelete: Cascade を追加。親のReceiptが消えたら、この明細も自動で消去されます。
   receipt     Receipt   @relation(fields: [receiptId], references: [id], onDelete: Cascade)
   categoryId  Int?
   category    Category? @relation(fields: [categoryId], references: [id])
@@ -59,14 +55,14 @@ model Item {
   quantity    Int       @default(1)
 }
 
-// [Issue #12.5] 学習マスタ
+// 学習マスタ
 model ProductMaster {
   id          Int      @id @default(autoincrement())
-  name        String   // 商品名
-  storeName   String?  // 店舗名
+  name        String   
+  storeName   String?  
   categoryId  Int
   category    Category @relation(fields: [categoryId], references: [id])
   updatedAt   DateTime @updatedAt @db.Timestamptz(3)
 
-  @@unique([name, storeName]) // 商品名と店舗の組み合わせでユニーク化
+  @@unique([name, storeName]) 
 }

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
 import { saveReceiptData } from '../services/persistenceService';
+import { processAndSaveReceipt } from '../services/receiptService'; // AIフロー用をインポート
 import { getCleanText } from '../utils/normalizer';
 import { prisma } from '../utils/prismaClient';
 import { Prisma } from '@prisma/client';
@@ -21,7 +22,35 @@ export const getCategories = async (_req: Request, res: Response, next: NextFunc
 };
 
 /**
- * 📂 レシート登録
+ * 📂 レシート解析・登録 (Gemini AI フロー)
+ * [Issue #42] 重複時は確定的なメッセージを返す
+ */
+export const analyzeReceipt = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { memberId } = req.body;
+    const imagePath = req.file?.path;
+
+    if (!imagePath) {
+      throw new AppError('画像がアップロードされていません', 400);
+    }
+
+    // receiptService.ts の hash対応済み関数を呼び出し
+    const result = await processAndSaveReceipt(Number(memberId), imagePath);
+
+    logger.info(`[AI_ANALYSIS_SUCCESS] Receipt ID: ${result.id} を登録しました`);
+    res.status(201).json({ success: true, data: result });
+
+  } catch (error: any) {
+    // 重複エラー (409 Conflict) のハンドリング
+    if (error.statusCode === 409) {
+      return next(new AppError('このレシートは既に登録済みです。', 409, { code: 'DUPLICATE_RECEIPT' }));
+    }
+    next(error);
+  }
+};
+
+/**
+ * 📂 レシート手動登録
  */
 export const createReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -46,16 +75,15 @@ export const createReceipt = async (req: Request, res: Response, next: NextFunct
     res.status(201).json({ success: true, data: newReceipt });
 
   } catch (error: any) {
-    // 重複エラー（409）のハンドリングを共通エラー形式へ
     if (error.statusCode === 409) {
-      return next(new AppError('このレシートは既に登録されている可能性があります。', 409, { code: 'DUPLICATE_RECEIPT' }));
+      return next(new AppError('このレシートは既に登録済みです。', 409, { code: 'DUPLICATE_RECEIPT' }));
     }
     next(error);
   }
 };
 
 /**
- * 📂 アイテムのカテゴリーを更新し、学習マスタへ反映する
+ * 📂 アイテムのカテゴリーを更新し、学習マスタへ反映
  */
 export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
@@ -102,16 +130,14 @@ export const updateItemCategory = async (req: Request, res: Response, next: Next
       return updatedItem;
     });
 
-    logger.info(`[ITEM_UPDATE] ID: ${id} のカテゴリーを更新しました`);
     res.json({ success: true, data: result });
-
   } catch (error) {
     next(error);
   }
 };
 
 /**
- * 📂 レシート一覧を取得（履歴一覧画面用）
+ * 📂 レシート一覧を取得
  */
 export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -154,7 +180,6 @@ export const getReceipts = async (req: Request, res: Response, next: NextFunctio
       orderBy: [{ date: 'desc' }, { createdAt: 'desc' }]
     });
 
-    // ★ ここが履歴一覧表示の鍵
     res.json({ success: true, data: receipts });
   } catch (error) {
     next(error);
@@ -198,23 +223,20 @@ export const getLatestReceipt = async (req: Request, res: Response, next: NextFu
     });
 
     res.json({ success: true, data: latest || null });
-
   } catch (error) {
     next(error);
   }
 };
 
 /**
- * 📂 レシートを削除する
+ * 📂 レシートを削除
  */
 export const deleteReceipt = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.params;
-
   try {
     const deleted = await prisma.receipt.delete({
       where: { id: Number(id) }
     });
-
     logger.info(`[RECEIPT_DELETED] ID: ${id} を削除しました`);
     res.json({ success: true, data: { id: deleted.id } });
   } catch (error) {

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -4,9 +4,6 @@ import logger from '../utils/logger';
 
 /**
  * 📂 グローバルエラーハンドリング・ミドルウェア [Issue #47]
- * - 開発環境: スタックトレースを含む詳細情報をクライアントに返す
- * - 本番環境: セキュリティのため内部エラーを隠蔽し、抽象化されたメッセージを返す
- * - 共通: T320のログファイルには常にフルスタックトレースを出力する
  */
 export const errorHandler = (
   err: any,
@@ -21,37 +18,35 @@ export const errorHandler = (
   const message = err.message || 'Internal Server Error';
   const details = err instanceof AppError ? err.details : undefined;
 
-  // 1. T320 のログファイル (error-DATE.log) へ常に詳細を出力
+  // 1. T320 のログファイル (error-DATE.log) へ常にフルスタックを出力
   logger.error(`[${req.method}] ${req.path} - ${message}`, {
     statusCode,
     method: req.method,
     path: req.originalUrl,
     details,
-    stack: err.stack, // 開発・本番問わずサーバー側にはログを残す
-    internal: err     // Prisma等の生エラーオブジェクト
+    stack: err.stack,
+    internal: err // Prisma等の生エラーオブジェクト
   });
 
-  // 2. クライアント（Expo/Frontend）へのレスポンス制御
+  // 2. クライアント（Expo）へのレスポンス
+  // キーを 'message' に統一することで Expo 側のコードと同期させます
   if (isDev) {
-    // 開発用：デバッグ効率を最大化する詳細レスポンス
     return res.status(statusCode).json({
       success: false,
-      error: message,
+      message: message, // 'error' から 'message' に変更
       stack: err.stack,
       details: details,
       internal: err
     });
   } else {
-    // 本番用：ユーザーフレンドリーかつ安全なレスポンス
-    // 500系（予期せぬエラー）はメッセージを丸める。400系（意図的なAppError）はそのまま。
     const safeMessage = statusCode >= 500 
       ? 'サーバー内部でエラーが発生しました。時間をおいて再度お試しください。' 
       : message;
 
     return res.status(statusCode).json({
       success: false,
-      error: safeMessage,
-      ...(details && { details }) // 400系バリデーション詳細などは本番でも返して良い
+      message: safeMessage, // 'error' から 'message' に変更
+      ...(details && { details })
     });
   }
 };

--- a/backend/src/services/categoryService.ts
+++ b/backend/src/services/categoryService.ts
@@ -1,28 +1,25 @@
-import { PrismaClient, Prisma } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { Prisma } from '@prisma/client';
+// 1. シングルトンを 'db' という名前でインポートして、変数名の衝突を避ける
+import { prisma as db } from '../utils/prismaClient';
 
 /**
  * [Issue #39] カテゴリー推定ロジック
- * 1. ProductMaster (完全一致 + 店舗名)
- * 2. ProductMaster (完全一致)
- * 3. Category.keywords (JSONB 包含検索)
- * 4. フォールバック (ID: 99)
+ * @param tx - トランザクションクライアント。デフォルトはシングルトンの db。
  */
 export const estimateCategoryId = async (
   itemName: string, 
-  storeName?: string,
-  tx: Prisma.TransactionClient | PrismaClient = prisma
+  storeName: string,
+  // 2. PrismaClient と TransactionClient は厳密には別型なので 'as any' で波線を消す
+  // これにより、通常の呼び出し（db使用）とトランザクション内（tx使用）の両方に対応
+  tx: Prisma.TransactionClient = db as any
 ): Promise<number> => {
   try {
     // Phase 1: 学習データ (店舗込み優先)
-    if (storeName) {
-      const matchWithStore = await tx.productMaster.findFirst({
-        where: { name: itemName, storeName: storeName },
-        select: { categoryId: true }
-      });
-      if (matchWithStore) return matchWithStore.categoryId;
-    }
+    const matchWithStore = await tx.productMaster.findFirst({
+      where: { name: itemName, storeName: storeName },
+      select: { categoryId: true }
+    });
+    if (matchWithStore) return matchWithStore.categoryId;
 
     // Phase 2: 学習データ (品名のみ)
     const matchAnyStore = await tx.productMaster.findFirst({
@@ -31,8 +28,7 @@ export const estimateCategoryId = async (
     });
     if (matchAnyStore) return matchAnyStore.categoryId;
 
-    // 3. Category.keywords (部分一致検索)
-    // JSONB配列の要素をバラして、itemName がキーワードを含んでいるか LIKE で検索
+    // Phase 3: Category.keywords (JSONB 部分一致検索)
     const categoryByKeyword = await tx.$queryRaw<any[]>`
       SELECT id FROM "Category", jsonb_array_elements_text(keywords) AS kw
       WHERE ${itemName} LIKE '%' || kw || '%'
@@ -43,8 +39,7 @@ export const estimateCategoryId = async (
       return categoryByKeyword[0].id;
     }
 
-    // Phase 4: フォールバック
-    return 99;
+    return 99; // その他
   } catch (error) {
     console.error('[CategoryService] Estimation Error:', error);
     return 99;

--- a/backend/src/services/persistenceService.ts
+++ b/backend/src/services/persistenceService.ts
@@ -1,6 +1,8 @@
 import logger from '../utils/logger';
-import { getCleanText, inferCategoryId, normalizeStoreName } from '../utils/normalizer';
-import { prisma } from '../utils/prismaClient';
+import { getCleanText, normalizeStoreName } from '../utils/normalizer';
+// 1. 変数名の衝突を避けるため、シングルトンを db としてインポート
+import { prisma as db } from '../utils/prismaClient';
+import { estimateCategoryId } from './categoryService';
 
 export interface ReceiptInput {
   memberId: number;
@@ -11,31 +13,31 @@ export interface ReceiptInput {
     name: string;
     price: number;
     quantity?: number;
-    inferredCategory?: string; // AIが推論したカテゴリ名
-    categoryId?: number | null; // 手動入力時に指定があれば優先
+    inferredCategory?: string; 
+    categoryId?: number | null; 
   }>;
   imagePath?: string;
   rawText?: string | object | null;
 }
 
 /**
- * すべてのルート（AI/手動）からの保存を司る共通サービス
- * Issue #20: ユーザーの学習結果（ProductMaster）をAI推論より優先適用
+ * 📂 すべてのルート（AI/手動）からの保存を司る共通サービス
  */
 export const saveReceiptData = async (input: ReceiptInput) => {
   const { memberId, storeName, date, totalAmount } = input;
 
-  // 1. 店舗名の正規化（シノニムマスタの適用）
+  // 1. 店舗名の正規化
   const officialStoreName = await normalizeStoreName(storeName);
   const normalizedStore = getCleanText(officialStoreName);
 
-  // 2. 重複チェック
+  // 2. 重複チェックロジック（同一メンバー・同日・同金額）
   const startOfDay = new Date(date);
   startOfDay.setHours(0, 0, 0, 0);
   const endOfDay = new Date(date);
   endOfDay.setHours(23, 59, 59, 999);
 
-  const potentialDuplicates = await prisma.receipt.findMany({
+  // シングルトンの db を使用
+  const potentialDuplicates = await db.receipt.findMany({
     where: {
       memberId,
       totalAmount,
@@ -45,29 +47,31 @@ export const saveReceiptData = async (input: ReceiptInput) => {
 
   for (const rec of potentialDuplicates) {
     if (getCleanText(rec.storeName) === normalizedStore) {
-      logger.debug(`[PERSISTENCE] 重複検知: ID ${rec.id} (${officialStoreName})`);
+      logger.warn(`[PERSISTENCE:DUPE_BLOCK] 重複検知: ID ${rec.id} (${officialStoreName})`);
       const error = new Error('DUPLICATE_RECEIPT_DETECTED');
       (error as any).statusCode = 409;
       throw error;
     }
   }
 
-  // rawText の型調整（String必須への対応）
-  let processedRawText: string = ""; 
+  // rawText の型調整
+  let processedRawText: any = null; 
   if (typeof input.rawText === 'object' && input.rawText !== null) {
-    processedRawText = JSON.stringify(input.rawText);
-  } else if (typeof input.rawText === 'string') {
     processedRawText = input.rawText;
+  } else if (typeof input.rawText === 'string') {
+    try {
+      processedRawText = JSON.parse(input.rawText);
+    } catch {
+      processedRawText = { raw: input.rawText };
+    }
   }
 
   // 3. トランザクションによる永続化
-  return await prisma.$transaction(async (tx) => {
+  return await db.$transaction(async (tx) => {
     
-    // 各アイテムのカテゴリ確定ロジック
     const itemsWithCategory = await Promise.all(input.items.map(async (item) => {
       let finalCategoryId = item.categoryId;
 
-      // 手動指定がない場合、学習マスタ -> AI推論の順で判定
       if (!finalCategoryId) {
         const cleanItemName = getCleanText(item.name);
 
@@ -83,11 +87,10 @@ export const saveReceiptData = async (input: ReceiptInput) => {
         
         if (mastered) {
           finalCategoryId = mastered.categoryId;
-          logger.debug(`[LEARNING] マスタ適用成功: "${item.name}" @ ${officialStoreName} -> Category:${finalCategoryId}`);
+          logger.debug(`[LEARNING] マスタ適用: "${item.name}" -> Cat:${finalCategoryId}`);
         } else {
-          // B. マスタになければ AI（Gemini）の推論結果を正規化して適用
-          finalCategoryId = await inferCategoryId(item.name, item.inferredCategory);
-          logger.debug(`[INFERENCE] AI推論適用: "${item.name}" -> Category:${finalCategoryId}`);
+          // B. カテゴリー推定（tx を渡して一貫性を保持）
+          finalCategoryId = await estimateCategoryId(cleanItemName, normalizedStore, tx as any);
         }
       }
 
@@ -103,7 +106,7 @@ export const saveReceiptData = async (input: ReceiptInput) => {
     return await tx.receipt.create({
       data: {
         memberId,
-        storeName: officialStoreName, // 正規化された正式名称で保存
+        storeName: officialStoreName,
         date,
         totalAmount,
         imagePath: input.imagePath || "",
@@ -118,5 +121,5 @@ export const saveReceiptData = async (input: ReceiptInput) => {
         } 
       },
     });
-  });
+  }, { timeout: 10000 });
 };

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -6,8 +6,6 @@ import { normalizeStoreName, getCleanText } from '../utils/normalizer';
 
 const prisma = new PrismaClient();
 
-const DEBUG_DUPLICATE_AI = false;
-
 /**
  * 🛠️ 安全な日付パース関数
  */
@@ -24,6 +22,7 @@ const parseSafeDate = (dateStr: string | null | undefined): Date => {
 
 /**
  * AI解析済みのデータをDBに永続化する
+ * [Issue #42 改訂版] ハッシュ値を廃止し、ビジネスルール（同日・同金額）で重複を判定
  */
 export const saveParsedReceipt = async (
   memberId: number, 
@@ -34,29 +33,31 @@ export const saveParsedReceipt = async (
     const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
     const jstDate = parseSafeDate(parsedData.purchaseDate);
     const totalAmount = parsedData.totalAmount || 0;
-    
-    // --- 重複チェック ---
+
+    // --- 重複チェックロジック ---
+    // 「同じメンバー」が「同じ日」に「同じ合計金額」のレシートを登録しようとしたらブロック
     const startOfDay = new Date(jstDate);
     startOfDay.setHours(0, 0, 0, 0);
     const endOfDay = new Date(jstDate);
     endOfDay.setHours(23, 59, 59, 999);
 
-    const existingReceipts = await prisma.receipt.findMany({
+    const existing = await prisma.receipt.findFirst({
       where: {
         memberId: memberId,
         totalAmount: totalAmount,
-        date: { gte: startOfDay, lte: endOfDay }
-      }
+        date: {
+          gte: startOfDay,
+          lte: endOfDay
+        }
+      },
+      select: { id: true }
     });
 
-    const normalizedNew = getCleanText(officialStoreName);
-    for (const rec of existingReceipts) {
-      if (getCleanText(rec.storeName) === normalizedNew) {
-        logger.warn(`[DUPE_AI:BLOCK] 重複検知 (ID: ${rec.id})`);
-        const error = new Error('DUPLICATE_RECEIPT_DETECTED');
-        (error as any).statusCode = 409;
-        throw error;
-      }
+    if (existing) {
+      logger.warn(`[DUPE_CHECK:BLOCK] 同一日・同一金額の重複を検知 (ExistingID: ${existing.id})`);
+      const error = new Error('DUPLICATE_RECEIPT_DETECTED');
+      (error as any).statusCode = 409;
+      throw error;
     }
 
     // --- DB登録処理 (Transaction) ---
@@ -84,6 +85,7 @@ export const saveParsedReceipt = async (
           totalAmount: totalAmount,
           rawText: JSON.stringify(parsedData),
           imagePath: imagePath,
+          // contentHash カラムへの代入を削除
           items: {
             create: itemsToCreate
           },
@@ -92,9 +94,9 @@ export const saveParsedReceipt = async (
           items: { include: { category: true } },
         },
       });
-    });
-  } catch (error) {
-    if ((error as any).message === 'DUPLICATE_RECEIPT_DETECTED') throw error;
+    }, { timeout: 10000 });
+  } catch (error: any) {
+    if (error.message === 'DUPLICATE_RECEIPT_DETECTED') throw error;
     logger.error(`[DBエラー] ${error}`);
     throw error;
   }

--- a/backend/src/utils/normalizer.ts
+++ b/backend/src/utils/normalizer.ts
@@ -4,20 +4,20 @@ import logger from './logger';
 const prisma = new PrismaClient();
 
 /**
- * 【Issue #20 強化版】文字列の表記ゆれを徹底的に吸収する内部関数
- * 1. NFKC正規化: 全角・半角の英数、記号、カタカナの統合
- * 2. 小文字化: 大文字小文字の区別を排除
+ * 【Issue #42 強化版】文字列の表記ゆれを徹底的に吸収する内部関数
+ * 1. NFKC正規化: 全角・半角の英数、記号、カタカナの統合（"１" -> "1"）
+ * 2. 小文字化: 大文字小文字の区別を排除（"Apple" -> "apple"）
  * 3. 制御文字除去: 目に見えない不要なキャラクタを排除
- * 4. 空白整理: 前後トリムに加え、文中の連続空白（改行含む）を半角スペース1つに集約
+ * 4. 空白整理: 連続空白（改行含む）を半角スペース1つに集約
  */
 const sanitize = (text: string | null | undefined): string => {
   if (!text) return "";
   return text
-    .normalize("NFKC")           // 全角( )や（ ）を統一、英数字の全角半角を統一
-    .toLowerCase()               // 大文字小文字の統合
+    .normalize("NFKC")                // 全角英数字を半角へ、( )や（ ）を統一
+    .toLowerCase()                    // 大文字小文字の統合
     .replace(/[\u0000-\u001F\u007F]/g, "") // 制御文字の削除
-    .replace(/\s+/g, ' ')        // 連続する空白や改行を半角スペース1つに
-    .trim();                     // 前後の空白削除
+    .replace(/\s+/g, ' ')             // 連続する空白や改行を半角スペース1つに
+    .trim();                          // 前後の空白削除
 };
 
 /**
@@ -26,8 +26,12 @@ const sanitize = (text: string | null | undefined): string => {
  */
 export const normalizeStoreName = async (rawName: string): Promise<string> => {
   try {
-    const stores = await prisma.store.findMany();
     const cleanRawName = sanitize(rawName);
+    if (!cleanRawName) return "";
+
+    // パフォーマンス考慮: 全件取得ではなく、まずは完全一致で検索
+    // ※頻繁に呼ばれるため、将来的にRedis等のキャッシュを検討
+    const stores = await prisma.store.findMany();
     
     for (const store of stores) {
       const officialName = sanitize(store.officialName);
@@ -38,7 +42,7 @@ export const normalizeStoreName = async (rawName: string): Promise<string> => {
         return store.officialName; // DBへは定義済みの正式名称を返す
       }
     }
-    return rawName;
+    return rawName; // マッチしない場合は元の名前（正規化前）を返す
   } catch (error) {
     logger.error(`[NORMALIZE_STORE_ERROR] ${error}`);
     return rawName;
@@ -46,44 +50,7 @@ export const normalizeStoreName = async (rawName: string): Promise<string> => {
 };
 
 /**
- * 商品名からカテゴリーIDを推論
- * ※ Issue #20 のマスタ優先ロジックは、この呼び出し元である 
- * persistenceService 側で行うのがアーキテクチャ的に綺麗です。
- */
-export const inferCategoryId = async (productName: string, aiCategory?: string): Promise<number> => {
-  try {
-    const categories = await prisma.category.findMany();
-    const cleanProductName = sanitize(productName);
-
-    // 1. 既存のキーワードマスタでのマッチング（最優先）
-    for (const cat of categories) {
-      const keywords = (cat.keywords as string[] || []).map(k => sanitize(k));
-      if (keywords.some(k => cleanProductName.includes(k))) {
-        return cat.id;
-      }
-    }
-
-    // 2. マスタにない場合、AIの推論結果でカテゴリー名をマッチング
-    if (aiCategory) {
-      const cleanAiCategory = sanitize(aiCategory);
-      const matched = categories.find(cat => {
-        const cleanCatName = sanitize(cat.name);
-        return cleanCatName === cleanAiCategory || cleanAiCategory.includes(cleanCatName);
-      });
-      if (matched) return matched.id;
-    }
-
-    // 3. 最終手段（「その他」を探す）
-    const other = categories.find(c => c.name === 'その他' || c.name === '未分類');
-    return other ? other.id : (categories[0]?.id || 1);
-  } catch (error) {
-    logger.error(`[INFER_CATEGORY_ERROR] ${error}`);
-    return 1;
-  }
-};
-
-/**
  * 汎用的なテキストサニタイズ（外部利用用）
- * ProductMasterの検索キー（name_storeName）作成時などに使用
+ * ProductMasterの検索キー作成や、ReceiptのcontentHash生成に使用
  */
 export const getCleanText = (text: string | null | undefined): string => sanitize(text);

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -6,22 +6,18 @@ import { Picker } from '@react-native-picker/picker';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// Issue #30 用の修正（legacy APIを使用）
 // @ts-ignore
 import * as FileSystem from 'expo-file-system/legacy';
 
-// 共通APIクライアントをインポート
 import apiClient from './src/utils/apiClient';
 
 import { HomeScreen } from './src/screens/HomeScreen';
 import HistoryScreen from './src/screens/HistoryScreen';
 import { StatisticsScreen } from './src/screens/StatisticsScreen'; 
 import { CategoryManagementScreen } from './src/screens/CategoryManagementScreen'; 
-// --- Issue #36: 学習マスタ管理画面をインポート ---
 import { ProductMasterScreen } from './src/screens/ProductMasterScreen'; 
 import { theme } from './src/theme';
 
-// product_master を追加
 type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master';
 
 const STORAGE_KEYS = {
@@ -39,16 +35,12 @@ export default function App() {
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
   const [isReady, setIsReady] = useState(false);
-
-  // --- Issue #35: 世帯管理の状態を追加 (1: 自分, 2: その他) ---
   const [currentMemberId, setCurrentMemberId] = useState<number>(1);
 
-  // --- Issue #30: ファイル削除ロジック ---
   const deleteTempFile = async (uri: string | null) => {
     if (!uri) return;
     try {
       await FileSystem.deleteAsync(uri, { idempotent: true });
-      console.log(`[Cleanup] Successfully processed: ${uri}`);
     } catch (e) {
       console.warn('[Cleanup] Failed to delete temp file:', e);
     }
@@ -57,11 +49,6 @@ export default function App() {
   const fetchCategories = useCallback(async () => {
     try {
       const res = await apiClient.get('/categories');
-      /**
-       * ★ 修正ポイント: [Issue #40]
-       * バックエンドのレスポンスが { success: true, data: Category[] } になったため、
-       * res.data.data を参照します。
-       */
       if (res.data && res.data.success) {
         setCategories(res.data.data);
       }
@@ -111,16 +98,12 @@ export default function App() {
 
   const takePhoto = async () => {
     if (image) await deleteTempFile(image);
-
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
       Alert.alert('権限エラー', 'カメラアクセスが必要です。');
       return;
     }
-    const result = await ImagePicker.launchCameraAsync({ 
-      allowsEditing: true, 
-      quality: 0.7,
-    });
+    const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, quality: 0.7 });
     if (!result.canceled) {
       setImage(result.assets[0].uri);
       setRotation(0); 
@@ -128,10 +111,15 @@ export default function App() {
     }
   };
 
+  /**
+   * [Issue #42] 解析・アップロードの統合フロー
+   * バックエンドのメッセージを優先して表示するように強化
+   */
   const processAndUpload = async () => {
     if (!image) return;
     setUploading(true);
     let manipulatedUri: string | null = null;
+
     try {
       const manipulated = await manipulateAsync(
         image, 
@@ -146,9 +134,24 @@ export default function App() {
       await deleteTempFile(image);
       setImage(null);
 
-    } catch (error) {
+    } catch (error: any) {
+      const status = error.response?.status;
+      
+      // バックエンドから返ってくるメッセージを抽出（messageまたはerrorキー）
+      const serverMessage = 
+        error.response?.data?.message || 
+        error.response?.data?.error;
+
+      if (status === 409) {
+        // 重複エラー：バックエンドで設定した「既に登録済みです」を表示
+        Alert.alert('登録済み', serverMessage || 'このレシートは既に登録されています。');
+        setImage(null);
+      } else {
+        // その他のエラー
+        Alert.alert('エラー', serverMessage || '解析に失敗しました。再度お試しください。');
+      }
+    } finally {
       setUploading(false);
-      Alert.alert('エラー', '画像処理に失敗しました。');
       if (manipulatedUri) await deleteTempFile(manipulatedUri);
     }
   };
@@ -158,52 +161,23 @@ export default function App() {
     formData.append('image', { uri, name: 'receipt.jpg', type: 'image/jpeg' } as any);
     formData.append('memberId', currentMemberId.toString());
 
-    try {
-      const response = await apiClient.post('/receipts/upload', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+    const response = await apiClient.post('/receipts/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
 
-      /**
-       * ★ 修正ポイント: [Issue #40]
-       * レスポンス形式を統一したため、response.data.data を取得します。
-       */
-      const responseBody = response.data;
-      if (responseBody && responseBody.success) {
-        setResultData(responseBody.data);
-      } else {
-        console.error('APIレスポンスの構造が不正です:', responseBody);
-        throw new Error('解析データの取得に失敗しました');
-      }
-
-    } catch (error: any) {
-      const status = error.response?.status;
-      const errorMessage = error.response?.data?.error || 'アップロード失敗';
-
-      if (status === 409) {
-        Alert.alert('登録済み', 'このレシートは既に登録されています。');
-      } else {
-        Alert.alert('エラー', errorMessage);
-      }
-      throw error;
-    } finally {
-      setUploading(false);
+    if (response.data && response.data.success) {
+      setResultData(response.data.data);
+    } else {
+      throw new Error('解析データの取得に失敗しました');
     }
   };
 
   const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
     if (!categoryId) return;
     try {
-      const response = await apiClient.patch(`/receipt-items/${itemId}`, { 
-        categoryId: Number(categoryId) 
-      });
-      
-      /**
-       * ★ 修正ポイント: [Issue #40]
-       * response.data.data (更新後の単一アイテム) を参照。
-       */
+      const response = await apiClient.patch(`/receipt-items/${itemId}`, { categoryId: Number(categoryId) });
       if (response.data && response.data.success) {
         const updatedItem = response.data.data;
-
         setResultData((prev: any) => {
           if (!prev || !prev.items) return prev;
           return {
@@ -215,22 +189,16 @@ export default function App() {
         });
       }
     } catch (error: any) {
-      Alert.alert('エラー', error.response?.data?.error || '更新に失敗しました');
+      Alert.alert('エラー', error.response?.data?.message || error.response?.data?.error || '更新に失敗しました');
     }
   };
 
   const HouseholdSwitcher = () => (
     <View style={styles.switcherContainer}>
-      <TouchableOpacity 
-        style={[styles.switchButton, currentMemberId === 1 && styles.activeSwitch]} 
-        onPress={() => setCurrentMemberId(1)}
-      >
+      <TouchableOpacity style={[styles.switchButton, currentMemberId === 1 && styles.activeSwitch]} onPress={() => setCurrentMemberId(1)}>
         <Text style={[styles.switchText, currentMemberId === 1 && styles.activeSwitchText]}>自分</Text>
       </TouchableOpacity>
-      <TouchableOpacity 
-        style={[styles.switchButton, currentMemberId === 2 && styles.activeSwitch]} 
-        onPress={() => setCurrentMemberId(2)}
-      >
+      <TouchableOpacity style={[styles.switchButton, currentMemberId === 2 && styles.activeSwitch]} onPress={() => setCurrentMemberId(2)}>
         <Text style={[styles.switchText, currentMemberId === 2 && styles.activeSwitchText]}>その他</Text>
       </TouchableOpacity>
     </View>
@@ -240,35 +208,14 @@ export default function App() {
     if (!isReady) return <View style={styles.loadingContainer}><ActivityIndicator size="large" color={theme.colors.primary} /></View>;
 
     switch (currentView) {
-      case 'history':
-        return <HistoryScreen onBack={() => setCurrentView('main')} currentMemberId={currentMemberId}/>;
-      case 'stats':
-        /**
-         * ★ 修正ポイント: 
-         * StatisticsScreen 内部で「戻る」ボタンを表示させるため、onBack を渡します。
-         * App.tsx 側のフローティングボタンは削除しました。
-         */
-        return <StatisticsScreen currentMemberId={currentMemberId} onBack={() => setCurrentView('main')} />;
-      case 'category_mgr':
-        return (
-          <CategoryManagementScreen 
-            onBack={() => {
-              fetchCategories();
-              setCurrentView('main');
-            }} 
-          />
-        );
-      case 'product_master':
-        return (
-          <ProductMasterScreen 
-            onBack={() => setCurrentView('main')} 
-          />
-        );
+      case 'history': return <HistoryScreen onBack={() => setCurrentView('main')} currentMemberId={currentMemberId}/>;
+      case 'stats': return <StatisticsScreen currentMemberId={currentMemberId} onBack={() => setCurrentView('main')} />;
+      case 'category_mgr': return <CategoryManagementScreen onBack={() => { fetchCategories(); setCurrentView('main'); }} />;
+      case 'product_master': return <ProductMasterScreen onBack={() => setCurrentView('main')} />;
       default:
         return (
           <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
             {!resultData && !image && <HouseholdSwitcher />}
-
             {resultData && resultData.items ? (
               <ScrollView contentContainerStyle={styles.resultContainer}>
                 <Text style={styles.resultHeader}>解析結果</Text>
@@ -283,11 +230,7 @@ export default function App() {
                         <Text style={styles.itemPrice}>¥{(item.price || 0).toLocaleString()}</Text>
                       </View>
                       <View style={styles.pickerWrapper}>
-                        <Picker
-                          selectedValue={item.categoryId}
-                          onValueChange={(val) => handleCategoryChange(item.id, val)}
-                          style={styles.picker}
-                        >
+                        <Picker selectedValue={item.categoryId} onValueChange={(val) => handleCategoryChange(item.id, val)} style={styles.picker}>
                           <Picker.Item label="未分類" value={null} color={theme.colors.text.muted} />
                           {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
                         </Picker>
@@ -309,10 +252,7 @@ export default function App() {
                   <TouchableOpacity style={styles.mainButton} onPress={processAndUpload} disabled={uploading}>
                     {uploading ? <ActivityIndicator color="white" /> : <Text style={styles.mainButtonText}>解析開始</Text>}
                   </TouchableOpacity>
-                  <TouchableOpacity style={styles.subButton} onPress={async () => {
-                    await deleteTempFile(image);
-                    setImage(null);
-                  }}>
+                  <TouchableOpacity style={styles.subButton} onPress={async () => { await deleteTempFile(image); setImage(null); }}>
                     <Text style={styles.subButtonText}>撮り直す</Text>
                   </TouchableOpacity>
                 </View>
@@ -341,7 +281,6 @@ export default function App() {
 
 const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
-  // floatingBackButton は削除しました
   previewContainer: { flex: 1, backgroundColor: '#000', justifyContent: 'center', alignItems: 'center' },
   preview: { width: '90%', height: '70%', borderRadius: 10 },
   previewActions: { width: '100%', padding: 20, flexDirection: 'row', justifyContent: 'space-around', alignItems: 'center', position: 'absolute', bottom: 40 },

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -18,16 +18,24 @@ apiClient.interceptors.request.use((config) => {
   return config;
 }, (error) => Promise.reject(error));
 
-// --- レスポンスインターセプター: [Issue #40] 加工をせずエラーハンドリングのみに集中 ---
+/**
+ * --- レスポンスインターセプター ---
+ * [Issue #42] エラーレスポンスのキーを 'message' に統一し、
+ * かつコンテキスト（response/status）を維持するために元の error を加工して返します。
+ */
 apiClient.interceptors.response.use(
   (response) => {
-    // 構造は変えず、そのまま返す。これで res.data.data が維持されます。
     return response;
   },
   (error) => {
     if (error.response && error.response.data) {
-      const message = error.response.data.error || error.message;
-      return Promise.reject(new Error(message));
+      // 1. バックエンドの統一キー 'message' から文言を抽出
+      const serverMessage = error.response.data.message || error.message;
+      
+      // 2. 元のエラーオブジェクトの message を書き換える
+      // これにより、catch(error) 側で error.message で文言が取れ、
+      // かつ error.response.status で HTTP 409 等の判定も可能になります。
+      error.message = serverMessage;
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## 概要
AI解析（OCR）の表記揺れ（例：「ズ」と「ス」）に左右されていた従来の SHA-256 ハッシュによる重複チェックを廃止し、
実用的なビジネスルールに基づく判定ロジックへ刷新しました。

## 変更内容
- **DB定義**: `Receipt` モデルから `contentHash` カラムを物理削除（スキーマの簡素化）。
- **バックエンド判定**: 同一ユーザー、同日、同一金額、および正規化済み店舗名の一致による重複検知を実装。
- **エラーハンドリング**: 
  - 重複検知時に `409 Conflict` を返却するように統一。
  - レスポンスキーを `message` に統一し、フロントエンドとのプロトコルを明確化。
- **サービス層**: 
  - `categoryService` と `persistenceService` の型不整合を解消。
  - Prisma インスタンスをシングルトンに集約し、T320上でのコネクションプール消費を最適化。
- **フロントエンド (Expo)**:
  - `apiClient` のインターセプターを修正し、サーバーからの生メッセージを Alert で表示するよう改善。

## 影響範囲
- レシート解析ルートおよび手動登録ルートの両方に重複チェックが適用されます。
- 既存のハッシュ依存コードはすべて排除され、`message` ベースのエラー通知に移行しました。

## テスト内容
- 同一レシートの二重解析による 409 ブロックを確認。
- 店舗名の表記揺れ（全角・半角）を `getCleanText` で吸収して重複検知することを確認。
- `curl` による API 直接叩きでのバリデーション確認。