### PR TITLE
PostgreSQL Window関数を活用した高度な家計分析（推移・構成比）の実装 #44

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -290,3 +290,53 @@ export const getMonthlyStats = async (req: Request, res: Response, next: NextFun
     next(error);
   }
 };
+
+/**
+ * 📂 高度な家計分析統計の取得
+ */
+export const getAdvancedStats = async (req: Request, res: Response, next: NextFunction) => {
+  const { memberId } = req.query;
+  const mId = Number(memberId || 1);
+
+  try {
+    // 1. 前月比推移 (MoM)
+    const trend = await prisma.$queryRaw`
+      SELECT 
+        TO_CHAR(date_trunc('month', date), 'YYYY-MM') AS period,
+        SUM("totalAmount")::int AS total,
+        LAG(SUM("totalAmount")) OVER (ORDER BY date_trunc('month', date))::int AS prev_total
+      FROM "Receipt"
+      WHERE "memberId" = ${mId}
+      GROUP BY date_trunc('month', date)
+      ORDER BY period DESC
+      LIMIT 6;
+    `;
+
+    // 2. 費目別Pareto分析 (当月)
+    const pareto = await prisma.$queryRaw`
+      WITH CategoryTotals AS (
+        SELECT c.name, SUM(i.price) as amount
+        FROM "Item" i
+        JOIN "Category" c ON i."categoryId" = c.id
+        JOIN "Receipt" r ON i."receiptId" = r.id
+        WHERE r.date >= date_trunc('month', CURRENT_DATE) AND r."memberId" = ${mId}
+        GROUP BY c.name
+      ),
+      TotalSum AS (SELECT SUM(amount) FROM CategoryTotals)
+      SELECT 
+        name, 
+        amount::int,
+        ROUND(amount * 100.0 / (SELECT * FROM TotalSum), 1)::float as ratio,
+        ROUND(SUM(amount) OVER (ORDER BY amount DESC) * 100.0 / (SELECT * FROM TotalSum), 1)::float as cumulative_ratio
+      FROM CategoryTotals
+      ORDER BY amount DESC;
+    `;
+
+    res.json({
+      success: true,
+      data: { trend, pareto }
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -6,8 +6,9 @@ import {
   getLatestReceipt, 
   updateItemCategory,
   getMonthlyStats,
-  getJobStatus // ★ [Issue #43] 追加
+  getJobStatus
 } from '../controllers/receiptController';
+import { getAdvancedStats } from '../controllers/receiptController';
 
 const router = express.Router();
 
@@ -37,5 +38,8 @@ router.delete('/receipts/:id', deleteReceipt);
 
 // PATCH /api/receipt-items/:id (明細カテゴリ修正)
 router.patch('/receipt-items/:id', updateItemCategory);
+
+//
+router.get('/stats/advanced', getAdvancedStats);
 
 export default router;

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Image, TouchableOpacity, Modal, Alert, FlatList, Platform } from 'react-native';
+import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Image, TouchableOpacity, Modal, Alert, FlatList } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import { Picker } from '@react-native-picker/picker';
@@ -15,7 +15,11 @@ interface ReceiptItem { id: number; name: string; price: number; categoryId: num
 interface ReceiptInfo { id: number; imagePath: string | null; storeName: string; totalAmount: number; items: ReceiptItem[]; }
 interface MonthlyData { month: string; totalAmount: number; prevTotal: number; diffAmount: number; diffPercentage: number; stats: StatItem[]; latestReceipt: ReceiptInfo | null; }
 
-// ★ Props に onBack を追加
+// ★ [Issue #44] 追加分インターフェース
+interface TrendData { period: string; total: number; prev_total: number | null; }
+interface ParetoData { name: string; amount: number; ratio: number; cumulative_ratio: number; }
+interface AdvancedStats { trend: TrendData[]; pareto: ParetoData[]; }
+
 interface StatisticsScreenProps { 
   currentMemberId: number; 
   onBack: () => void;
@@ -25,6 +29,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
   const [data, setData] = useState<MonthlyData | null>(null);
+  const [advancedData, setAdvancedData] = useState<AdvancedStats | null>(null); // ★ 追加
   const [allCategories, setAllCategories] = useState<Category[]>([]);
   
   const [isMainModalVisible, setMainModalVisible] = useState(false);
@@ -34,7 +39,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
-  // 12ヶ月分の日付リストを生成
   const monthOptions = useMemo(() => {
     return Array.from({ length: 12 }).map((_, i) => {
       const d = new Date();
@@ -46,24 +50,15 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
-      const [statsRes, catRes] = await Promise.all([
-        apiClient.get(`/stats/monthly`, {
-          params: { month: selectedMonth, memberId: currentMemberId }
-        }),
+      const [statsRes, advRes, catRes] = await Promise.all([
+        apiClient.get(`/stats/monthly`, { params: { month: selectedMonth, memberId: currentMemberId } }),
+        apiClient.get(`/stats/advanced`, { params: { memberId: currentMemberId } }), // ★ 追加エンドポイント
         apiClient.get('/categories')
       ]);
 
-      /**
-       * ★ 修正ポイント: [Issue #40] 
-       * res.data.data を参照
-       */
-      if (statsRes.data && statsRes.data.success) {
-        setData(statsRes.data.data);
-      }
-      
-      if (catRes.data && catRes.data.success) {
-        setAllCategories(catRes.data.data);
-      }
+      if (statsRes.data?.success) setData(statsRes.data.data);
+      if (advRes.data?.success) setAdvancedData(advRes.data.data);
+      if (catRes.data?.success) setAllCategories(catRes.data.data);
 
     } catch (error) {
       console.error('Fetch error:', error);
@@ -101,27 +96,21 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* ★ 他画面と統一したヘッダー構成 */}
       <View style={styles.header}>
         <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
           <Text style={styles.backButton}>← 戻る</Text>
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>収支統計</Text>
+        <Text style={styles.headerTitle}>家計分析レポート</Text>
         <View style={{ width: 40 }} />
       </View>
 
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
+        
+        {/* --- 1. 月次サマリー & 円グラフ --- */}
         <View style={styles.topInfo}>
-          <Text style={styles.headerSubtitle}>
-            {currentMemberId === 1 ? '自分の分析レポート' : 'その他の分析レポート'}
-          </Text>
+          <Text style={styles.headerSubtitle}>{currentMemberId === 1 ? 'PERSONAL REPORT' : 'FAMILY REPORT'}</Text>
           <View style={styles.monthPickerContainer}>
-            <Picker
-              selectedValue={selectedMonth}
-              onValueChange={(val) => setSelectedMonth(val)}
-              style={styles.monthPicker}
-              dropdownIconColor={theme.colors.primary}
-            >
+            <Picker selectedValue={selectedMonth} onValueChange={(val) => setSelectedMonth(val)} style={styles.monthPicker}>
               {monthOptions.map(m => (
                 <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
               ))}
@@ -134,139 +123,147 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         ) : (
           <>
             <View style={styles.summaryCard}>
-              <Text style={styles.summaryLabel}>合計支出</Text>
+              <Text style={styles.summaryLabel}>当月合計支出</Text>
               <Text style={styles.totalValue}>¥{(data?.totalAmount || 0).toLocaleString()}</Text>
-              
               <View style={styles.comparisonRow}>
                 <Text style={styles.comparisonLabel}>前月比:</Text>
-                <Text style={[
-                  styles.diffValue, 
-                  { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success }
-                ]}>
-                  {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥{Math.abs(data?.diffAmount || 0).toLocaleString()} 
-                  ({(data?.diffPercentage || 0) > 0 ? '+' : ''}{data?.diffPercentage || 0}%)
+                <Text style={[styles.diffValue, { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success }]}>
+                  {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥{Math.abs(data?.diffAmount || 0).toLocaleString()} ({data?.diffPercentage}% )
                 </Text>
               </View>
             </View>
 
+            {/* --- 2. [Issue #44] トレンド分析 (Window関数利用) --- */}
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>カテゴリー別支出</Text>
+              <Text style={styles.sectionTitle}>月次推移 (MoM Trend)</Text>
+              <View style={styles.statsCard}>
+                {advancedData?.trend.map((t, i) => {
+                  const diff = t.prev_total ? t.total - t.prev_total : 0;
+                  return (
+                    <View key={i} style={styles.trendRow}>
+                      <Text style={styles.trendPeriod}>{t.period}</Text>
+                      <Text style={styles.trendAmount}>¥{t.total.toLocaleString()}</Text>
+                      <Text style={[styles.trendDiff, { color: diff > 0 ? theme.colors.error : theme.colors.success }]}>
+                        {t.prev_total ? `${diff > 0 ? '+' : ''}${diff.toLocaleString()}` : '-'}
+                      </Text>
+                    </View>
+                  );
+                })}
+              </View>
+            </View>
+
+            {/* --- 3. [Issue #44] パレート分析 (累積構成比) --- */}
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>費目別パレート分析 (Pareto)</Text>
+              <View style={styles.statsCard}>
+                {advancedData?.pareto.map((p, i) => (
+                  <View key={i} style={styles.paretoWrapper}>
+                    <View style={styles.paretoTextRow}>
+                      <Text style={styles.paretoName}>{p.name}</Text>
+                      <Text style={styles.paretoValue}>¥{p.amount.toLocaleString()} ({p.ratio}%)</Text>
+                    </View>
+                    <View style={styles.paretoBarContainer}>
+                      <View style={[
+                        styles.paretoBar, 
+                        { width: `${p.ratio}%`, backgroundColor: p.cumulative_ratio <= 80 ? theme.colors.primary : '#CED4DA' }
+                      ]} />
+                      <Text style={styles.cumText}>{p.cumulative_ratio}%</Text>
+                    </View>
+                  </View>
+                ))}
+                <Text style={styles.paretoNote}>※ 青色の費目が全体支出の80%を占める主要項目です</Text>
+              </View>
+            </View>
+
+            {/* --- 4. 既存: 円グラフ --- */}
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>支出内訳</Text>
               <View style={styles.chartCard}>
                 {chartData.length > 0 ? (
                   <PieChart
                     data={chartData}
-                    width={screenWidth - theme.spacing.lg * 2 - 40}
-                    height={220}
+                    width={screenWidth - 60}
+                    height={200}
                     chartConfig={{ color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})` }}
                     accessor={"population"}
                     backgroundColor={"transparent"}
                     paddingLeft={"15"}
                     absolute
                   />
-                ) : (
-                  <View style={styles.emptyContainer}>
-                    <Text style={styles.noDataText}>集計データがありません</Text>
-                  </View>
-                )}
+                ) : <Text style={styles.noDataText}>データなし</Text>}
               </View>
             </View>
 
+            {/* --- 5. 既存: 直近レシート --- */}
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>直近の解析レシート</Text>
+              <Text style={styles.sectionTitle}>最新の解析レシート</Text>
               {data?.latestReceipt?.imagePath ? (
-                <TouchableOpacity 
-                  style={styles.receiptPreviewCard} 
-                  onPress={() => setMainModalVisible(true)}
-                  activeOpacity={0.8}
-                >
-                  <Image
-                    source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }}
-                    style={styles.receiptImage}
-                    resizeMode="cover"
-                  />
+                <TouchableOpacity style={styles.receiptPreviewCard} onPress={() => setMainModalVisible(true)}>
+                  <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.receiptImage} resizeMode="cover" />
                   <View style={styles.receiptInfoOverlay}>
-                    <Text style={styles.receiptStoreName}>{data.latestReceipt.storeName || '店名不明'}</Text>
-                    <Text style={styles.receiptAmount}>¥{(data.latestReceipt.totalAmount || 0).toLocaleString()}</Text>
+                    <Text style={styles.receiptStoreName}>{data.latestReceipt.storeName}</Text>
+                    <Text style={styles.receiptAmount}>¥{data.latestReceipt.totalAmount.toLocaleString()}</Text>
                   </View>
                 </TouchableOpacity>
-              ) : (
-                <View style={styles.noImageBox}>
-                  <Text style={styles.noDataText}>この月の解析済み画像はありません</Text>
-                </View>
-              )}
+              ) : <View style={styles.noImageBox}><Text style={styles.noDataText}>画像なし</Text></View>}
             </View>
           </>
         )}
       </ScrollView>
 
-      {/* モーダル類は以前と同様 */}
+      {/* 詳細モーダル (既存維持) */}
       <Modal visible={isMainModalVisible} animationType="slide">
         <SafeAreaView style={styles.modalContainer}>
           <View style={styles.modalHeader}>
-            <Text style={styles.modalTitle}>レシート詳細</Text>
+            <Text style={styles.modalTitle}>詳細明細</Text>
             <TouchableOpacity onPress={() => setMainModalVisible(false)}>
               <Text style={styles.modalCloseText}>閉じる</Text>
             </TouchableOpacity>
           </View>
-
-          <ScrollView style={styles.modalScroll} showsVerticalScrollIndicator={false}>
+          <ScrollView style={styles.modalScroll}>
             {data?.latestReceipt?.imagePath && (
-              <View style={styles.modalImageWrapper}>
-                <Image
-                  source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }}
-                  style={styles.modalImage}
-                  resizeMode="contain"
-                />
-              </View>
+              <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.modalImage} resizeMode="contain" />
             )}
-
             <View style={styles.itemListContainer}>
-              <Text style={styles.itemListTitle}>明細一覧</Text>
               {data?.latestReceipt?.items.map((item) => (
                 <View key={item.id} style={styles.itemRow}>
                   <View style={{ flex: 1 }}>
                     <Text style={styles.itemName}>{item.name}</Text>
-                    <Text style={styles.itemPrice}>¥{(item.price || 0).toLocaleString()}</Text>
+                    <Text style={styles.itemPrice}>¥{item.price.toLocaleString()}</Text>
                   </View>
                   <TouchableOpacity 
                     style={[styles.categoryBadge, { backgroundColor: item.category?.color || theme.colors.secondary }]}
-                    onPress={() => {
-                      setSelectedItemId(item.id);
-                      setPickerVisible(true);
-                    }}
+                    onPress={() => { setSelectedItemId(item.id); setPickerVisible(true); }}
                   >
                     <Text style={styles.categoryBadgeText}>{item.category?.name || '未分類'}</Text>
                   </TouchableOpacity>
                 </View>
               ))}
             </View>
-            <View style={{ height: 100 }} />
           </ScrollView>
         </SafeAreaView>
+      </Modal>
 
-        <Modal visible={isPickerVisible} transparent={true} animationType="fade">
-          <View style={styles.pickerOverlay}>
-            <View style={styles.pickerWindow}>
-              <Text style={styles.pickerHeader}>カテゴリーを選択</Text>
-              <FlatList
-                data={allCategories}
-                keyExtractor={(item) => item.id.toString()}
-                renderItem={({ item }) => (
-                  <TouchableOpacity 
-                    style={styles.pickerItem} 
-                    onPress={() => handleUpdateCategory(item.id)}
-                  >
-                    <View style={[styles.colorDot, { backgroundColor: item.color }]} />
-                    <Text style={styles.pickerItemText}>{item.name}</Text>
-                  </TouchableOpacity>
-                )}
-              />
-              <TouchableOpacity style={styles.pickerCancel} onPress={() => setPickerVisible(false)}>
-                <Text style={styles.pickerCancelText}>キャンセル</Text>
-              </TouchableOpacity>
-            </View>
+      {/* カテゴリ選択ピッカー (既存維持) */}
+      <Modal visible={isPickerVisible} transparent={true} animationType="fade">
+        <View style={styles.pickerOverlay}>
+          <View style={styles.pickerWindow}>
+            <Text style={styles.pickerHeader}>カテゴリー変更</Text>
+            <FlatList
+              data={allCategories}
+              keyExtractor={(item) => item.id.toString()}
+              renderItem={({ item }) => (
+                <TouchableOpacity style={styles.pickerItem} onPress={() => handleUpdateCategory(item.id)}>
+                  <View style={[styles.colorDot, { backgroundColor: item.color }]} />
+                  <Text style={styles.pickerItemText}>{item.name}</Text>
+                </TouchableOpacity>
+              )}
+            />
+            <TouchableOpacity style={styles.pickerCancel} onPress={() => setPickerVisible(false)}>
+              <Text style={styles.pickerCancelText}>キャンセル</Text>
+            </TouchableOpacity>
           </View>
-        </Modal>
+        </View>
       </Modal>
     </SafeAreaView>
   );
@@ -274,110 +271,61 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
-  // ヘッダースタイル（他画面と統一）
-  header: { 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    alignItems: 'center', 
-    paddingHorizontal: theme.spacing.lg, 
-    paddingVertical: theme.spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border
-  },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.md, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   backButton: { ...theme.typography.body, color: theme.colors.primary, fontWeight: '700' },
   headerTitle: { ...theme.typography.h2, color: theme.colors.text.main },
-  
   scrollContent: { padding: theme.spacing.lg },
   topInfo: { marginBottom: theme.spacing.md },
-  headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, textTransform: 'uppercase', letterSpacing: 1 },
-  monthPickerContainer: { 
-    backgroundColor: theme.colors.surface, 
-    borderRadius: theme.borderRadius.md, 
-    marginTop: 8,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    height: 50,
-    justifyContent: 'center'
-  },
+  headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, letterSpacing: 1 },
+  monthPickerContainer: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, marginTop: 8, borderWidth: 1, borderColor: theme.colors.border, height: 50, justifyContent: 'center' },
   monthPicker: { width: '100%' },
-  summaryCard: {
-    backgroundColor: theme.colors.surface,
-    padding: theme.spacing.lg,
-    borderRadius: theme.borderRadius.lg,
-    marginBottom: theme.spacing.xl,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    elevation: 3,
-  },
+  summaryCard: { backgroundColor: theme.colors.surface, padding: theme.spacing.lg, borderRadius: theme.borderRadius.lg, marginBottom: theme.spacing.xl, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border, elevation: 3 },
   summaryLabel: { ...theme.typography.caption, color: theme.colors.text.muted },
   totalValue: { ...theme.typography.h1, fontSize: 36, color: theme.colors.primary, marginVertical: 4 },
   comparisonRow: { flexDirection: 'row', alignItems: 'center' },
   comparisonLabel: { ...theme.typography.caption, marginRight: 8 },
   diffValue: { fontWeight: '700', fontSize: 16 },
   section: { marginBottom: theme.spacing.xl },
-  sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.md },
-  chartCard: { 
-    backgroundColor: theme.colors.surface, 
-    borderRadius: theme.borderRadius.md, 
-    padding: theme.spacing.md, 
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-  },
-  emptyContainer: { height: 220, justifyContent: 'center', alignItems: 'center' },
-  receiptPreviewCard: {
-    backgroundColor: theme.colors.surface, 
-    borderRadius: theme.borderRadius.md, 
-    overflow: 'hidden',
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    elevation: 4
-  },
+  sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.md, borderLeftWidth: 4, borderLeftColor: theme.colors.primary, paddingLeft: 8 },
+  statsCard: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.md, borderWidth: 1, borderColor: theme.colors.border },
+  trendRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: theme.colors.background },
+  trendPeriod: { flex: 1, fontWeight: '700' },
+  trendAmount: { flex: 1, textAlign: 'right' },
+  trendDiff: { flex: 1, textAlign: 'right', fontSize: 12, fontWeight: '600' },
+  paretoWrapper: { marginBottom: 12 },
+  paretoTextRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 },
+  paretoName: { fontWeight: '700', fontSize: 14 },
+  paretoValue: { fontSize: 12, color: theme.colors.text.muted },
+  paretoBarContainer: { height: 16, backgroundColor: '#E9ECEF', borderRadius: 8, flexDirection: 'row', alignItems: 'center', overflow: 'hidden' },
+  paretoBar: { height: '100%' },
+  cumText: { fontSize: 10, position: 'absolute', right: 8, fontWeight: '700', color: theme.colors.text.main },
+  paretoNote: { fontSize: 11, color: theme.colors.text.muted, marginTop: 8, fontStyle: 'italic' },
+  chartCard: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.md, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border },
+  receiptPreviewCard: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, overflow: 'hidden', borderWidth: 1, borderColor: theme.colors.border, elevation: 4 },
   receiptImage: { width: '100%', height: 160, backgroundColor: theme.colors.border },
-  receiptInfoOverlay: {
-    padding: theme.spacing.md,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  receiptStoreName: { ...theme.typography.body, fontWeight: '700', color: theme.colors.text.main },
+  receiptInfoOverlay: { padding: theme.spacing.md, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  receiptStoreName: { ...theme.typography.body, fontWeight: '700' },
   receiptAmount: { ...theme.typography.h2, color: theme.colors.primary },
   noImageBox: { height: 100, backgroundColor: theme.colors.border, borderRadius: theme.borderRadius.md, justifyContent: 'center', alignItems: 'center' },
   noDataText: { ...theme.typography.caption, color: theme.colors.text.muted },
   modalContainer: { flex: 1, backgroundColor: theme.colors.background },
-  modalHeader: { 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    alignItems: 'center', 
-    padding: theme.spacing.lg,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border
-  },
-  modalTitle: { ...theme.typography.h2, color: theme.colors.text.main },
-  modalCloseText: { ...theme.typography.body, color: theme.colors.error, fontWeight: '600' },
+  modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: theme.spacing.lg, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  modalTitle: { ...theme.typography.h2 },
+  modalCloseText: { color: theme.colors.error, fontWeight: '600' },
   modalScroll: { flex: 1 },
-  modalImageWrapper: { padding: theme.spacing.lg, alignItems: 'center' },
-  modalImage: { width: '100%', height: 300, borderRadius: theme.borderRadius.md },
+  modalImage: { width: '100%', height: 300, marginVertical: theme.spacing.md },
   itemListContainer: { paddingHorizontal: theme.spacing.lg },
-  itemListTitle: { ...theme.typography.caption, fontWeight: '700', color: theme.colors.secondary, marginBottom: theme.spacing.sm, textTransform: 'uppercase' },
-  itemRow: { 
-    flexDirection: 'row', 
-    paddingVertical: theme.spacing.md, 
-    borderBottomWidth: 1, 
-    borderBottomColor: theme.colors.border, 
-    alignItems: 'center' 
-  },
-  itemName: { ...theme.typography.body, color: theme.colors.text.main },
+  itemRow: { flexDirection: 'row', paddingVertical: theme.spacing.md, borderBottomWidth: 1, borderBottomColor: theme.colors.border, alignItems: 'center' },
+  itemName: { ...theme.typography.body },
   itemPrice: { ...theme.typography.body, fontWeight: '700', color: theme.colors.primary },
   categoryBadge: { paddingHorizontal: theme.spacing.md, paddingVertical: 6, borderRadius: theme.borderRadius.round },
-  categoryBadgeText: { color: theme.colors.text.inverse, fontWeight: '700', fontSize: 12 },
+  categoryBadgeText: { color: 'white', fontWeight: '700', fontSize: 12 },
   pickerOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center' },
-  pickerWindow: { width: '85%', maxHeight: '70%', backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.lg, padding: theme.spacing.lg, elevation: 10 },
+  pickerWindow: { width: '85%', maxHeight: '70%', backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.lg, padding: theme.spacing.lg },
   pickerHeader: { ...theme.typography.h2, marginBottom: theme.spacing.md, textAlign: 'center' },
   pickerItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: theme.spacing.md, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   colorDot: { width: 14, height: 14, borderRadius: 7, marginRight: theme.spacing.md },
-  pickerItemText: { ...theme.typography.body, color: theme.colors.text.main },
+  pickerItemText: { ...theme.typography.body },
   pickerCancel: { marginTop: theme.spacing.md, alignItems: 'center' },
-  pickerCancelText: { ...theme.typography.body, color: theme.colors.error, fontWeight: '700' }
+  pickerCancelText: { color: theme.colors.error, fontWeight: '700' }
 });


### PR DESCRIPTION
概要
単なる月次集計から一歩踏み込み、家計の「急所」を特定するための分析機能を実装しました。

主な変更点

    Backend (PostgreSQL / Prisma):

        $queryRaw を用い、LAG() 関数による前月比推移（MoM）および SUM() OVER() による累積構成比（Pareto）の算出ロジックを実装。

        アプリケーション層ではなく DB レイヤーで Window 関数を走らせることで、T320 の計算リソースを最適化。

        新規エンドポイント GET /api/stats/advanced を追加。

    Frontend (Expo):

        StatisticsScreen.tsx を刷新。

        累積構成比 80% までの項目を強調表示し、パレートの法則（80/20の法則）に基づいた支出の可視化を実現。

        前月比推移における増減額のカラーリング表示。

技術的ポイント

    $queryRaw 内でのバインドパラメータによる SQL インジェクション対策。

    PostgreSQL 側での型キャスト（::int, ::float）による、JS 側での数値処理の簡略化。

動作確認

    Expo 上で指定期間の推移および費目別パレート図が表示されることを確認済み。