### PR TITLE
GitHub Actions(Self-hosted Runner)によるT320へのCDパイプライン構築 #46

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: T320 CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, t320]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Sync to Stable directory
+        run: |
+          mkdir -p ~/stable/receipt-ai-app
+          rsync -av --delete --exclude '.git' ./ ~/stable/receipt-ai-app/
+
+      - name: Create Stable .env
+        run: |
+          cd ~/stable/receipt-ai-app
+          # GitHub Secretsから.envを生成
+          echo "UID=$(id -u)" > .env
+          echo "GID=$(id -g)" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "COMPOSE_PROJECT_NAME=receipt-stable" >> .env
+          echo "BACKEND_PORT=${{ secrets.STABLE_BACKEND_PORT }}" >> .env
+          echo "FRONTEND_PORT=${{ secrets.STABLE_FRONTEND_PORT }}" >> .env
+          echo "DB_PORT=${{ secrets.STABLE_DB_PORT }}" >> .env
+          echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
+          echo "T320_IP=192.168.1.32" >> .env
+          
+          # 各サービスディレクトリの.envもシンボリックリンクまたはコピーで対応
+          cp .env ./backend/.env
+          cp .env ./frontend/.env
+
+      - name: Docker Deploy
+        run: |
+          cd ~/stable/receipt-ai-app
+          docker compose up -d --build
+          
+      - name: Cleanup
+        run: docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./backend:/app
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "3000:3000"
+      - "${BACKEND_PORT:-3000}:3000" # ホスト側ポートを可変に
     stdin_open: true
     tty: true
     env_file:
@@ -34,9 +34,9 @@ services:
       - ./frontend:/app
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "8081:8081"
-      - "19000:19000"
-      - "19001:19001"
+      - "${FRONTEND_PORT:-8081}:8081"   # 開発用:8081 / Stable用:8082等
+      - "${EXPO_PORT_1:-19000}:19000"
+      - "${EXPO_PORT_2:-19001}:19001"
     stdin_open: true
     tty: true
     env_file:
@@ -44,23 +44,24 @@ services:
     environment:
       - TZ=Asia/Tokyo
       - EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
-      - REACT_NATIVE_PACKAGER_HOSTNAME=192.168.1.32 # T320の物理IPを指定
+      - REACT_NATIVE_PACKAGER_HOSTNAME=${T320_IP:-192.168.1.32}
 
   # --- Database (PostgreSQL) ---
   db:
     image: postgres:latest
+    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-db" # プロジェクト名で識別
     environment:
       - TZ=Asia/Tokyo
-      - POSTGRES_USER=cntadm
-      - POSTGRES_DB=receipt_db
+      - POSTGRES_USER=${DB_USER:-cntadm}
+      - POSTGRES_DB=${DB_NAME:-receipt_db}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432" # ホスト側ポートを可変に
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U cntadm -d receipt_db"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-cntadm} -d ${DB_NAME:-receipt_db}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -68,14 +69,14 @@ services:
   # --- Redis (BullMQ Backend) ---
   redis:
     image: redis:7-alpine
-    container_name: receipt-redis
+    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-redis" # 固定名を回避
     environment:
       - TZ=Asia/Tokyo
     volumes:
       - redis_data:/data
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -83,5 +84,6 @@ services:
       retries: 5
 
 volumes:
+  # 名前付きボリュームはプロジェクトごとに独立するため、データは混ざりません
   postgres_data:
   redis_data:


### PR DESCRIPTION
概要

GitHub Actions と自宅サーバー（Dell PowerEdge T320）上の Self-hosted Runner を連携させ、main ブランチへの push/merge をトリガーとした自動デプロイ（CD）環境を構築しました。
変更内容

    GitHub Actions ワークフローの追加

        .github/workflows/deploy.yml を作成。T320 内の ~/stable/ ディレクトリへ最新コードを同期し、Docker コンテナを再構築・起動するフローを定義。

    マルチ環境対応のための Docker Compose 構成変更

        docker-compose.yml 内のホスト側ポート、コンテナ名、プロジェクト名を環境変数化。

        同一ホスト内で「開発用（dev）」と「自動デプロイ用（stable）」のコンテナ群を完全に分離して並行稼働できる設計に変更。

    環境変数の整理

        開発用 .env にプロジェクト名とポート定義を追加。

技術的詳細（T320 構成）

    Runner方式: Self-hosted Runner (常駐サービス化済み)

    環境分離戦略:

        Development: Port 3000 (Backend) / 8081 (Frontend) / 5432 (DB)

        Stable (CD): Port 3001 (Backend) / 8082 (Frontend) / 5433 (DB)

    データ永続化: 各プロジェクトごとに独立した Docker Volume を使用。

確認事項

    [x] T320 上で Self-hosted Runner が Idle 状態で待機していること。

    [x] 開発環境（~/dev/...）が既存のポートで正常に動作すること。

    [x] （マージ後）~/stable/... ディレクトリが生成され、コンテナが正常に立ち上がること。