### PR TITLE
Expoポートの競合解消によるCDパイプラインの修正 #46-1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,16 @@ jobs:
           echo "COMPOSE_PROJECT_NAME=receipt-stable" >> .env
           echo "BACKEND_PORT=${{ secrets.STABLE_BACKEND_PORT }}" >> .env
           echo "FRONTEND_PORT=${{ secrets.STABLE_FRONTEND_PORT }}" >> .env
+          
+          # Expo用ポートの競合回避設定を追加
+          echo "EXPO_PORT_1=${{ secrets.STABLE_EXPO_PORT_1 }}" >> .env
+          echo "EXPO_PORT_2=${{ secrets.STABLE_EXPO_PORT_2 }}" >> .env
+          
           echo "DB_PORT=${{ secrets.STABLE_DB_PORT }}" >> .env
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
           
-          # 各サービスディレクトリの.envもシンボリックリンクまたはコピーで対応
+          # 各サービスディレクトリへ展開
           cp .env ./backend/.env
           cp .env ./frontend/.env
 


### PR DESCRIPTION
概要

Issue #46 で構築した CD パイプラインにおいて、Expo のデバッグ用ポート（19000, 19001）が開発環境と衝突し、デプロイが失敗する問題を修正しました。
変更内容

    .github/workflows/deploy.yml の修正

        Create Stable .env ステップに EXPO_PORT_1 および EXPO_PORT_2 の書き出し処理を追加。

        GitHub Secrets から Stable 環境専用のポート番号を注入するよう構成。

    Docker Compose 連携

        docker-compose.yml で定義済みの変数 ${EXPO_PORT_1:-19000} に対し、Secrets 経由で値を上書きすることで、同一ホスト内でのポート重複を回避。

動作確認事項

    [x] GitHub Secrets に STABLE_EXPO_PORT_1 (19002) / STABLE_EXPO_PORT_2 (19003) を登録済み。

    [x] マージ後、GitHub Actions の Docker Deploy ステップが正常終了すること。

    [x] 開発環境（19000番系）と Stable 環境（19002番系）が T320 上で並行稼働すること。