### PR TITLE
node_modules不在による起動失敗の修正 #46-2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Sync to Stable directory
         run: |
           mkdir -p ~/stable/receipt-ai-app
-          rsync -av --delete --exclude '.git' ./ ~/stable/receipt-ai-app/
+          rsync -av --delete --exclude '.git' --exclude 'node_modules' ./ ~/stable/receipt-ai-app/
 
       - name: Create Stable .env
         run: |
@@ -27,11 +27,8 @@ jobs:
           echo "COMPOSE_PROJECT_NAME=receipt-stable" >> .env
           echo "BACKEND_PORT=${{ secrets.STABLE_BACKEND_PORT }}" >> .env
           echo "FRONTEND_PORT=${{ secrets.STABLE_FRONTEND_PORT }}" >> .env
-          
-          # Expo用ポートの競合回避設定を追加
           echo "EXPO_PORT_1=${{ secrets.STABLE_EXPO_PORT_1 }}" >> .env
           echo "EXPO_PORT_2=${{ secrets.STABLE_EXPO_PORT_2 }}" >> .env
-          
           echo "DB_PORT=${{ secrets.STABLE_DB_PORT }}" >> .env
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
@@ -39,6 +36,13 @@ jobs:
           # 各サービスディレクトリへ展開
           cp .env ./backend/.env
           cp .env ./frontend/.env
+
+      - name: Install dependencies
+        run: |
+          cd ~/stable/receipt-ai-app/backend
+          npm install
+          cd ../frontend
+          npm install
 
       - name: Docker Deploy
         run: |


### PR DESCRIPTION
## 概要
ホスト側（T320）の ~/stable 配下に node_modules が存在しないため、
コンテナ起動時に tsx や expo コマンドが見つからず、
backend/frontend が Exited (127/1) となる問題を修正しました。

## 変更内容
- deploy.yml に Install dependencies ステップを追加。
- Docker Deploy 前に backend/frontend 各ディレクトリで npm install を実行するよう変更。
- rsync の除外設定に node_modules を追加。