### PR TITLE
PrismaのDB接続エラー修正（環境変数追加） #46-3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ jobs:
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
           
+          # --- Prisma用の接続URLを追加 ---
+          echo "DATABASE_URL=postgresql://postgres:${{ secrets.DB_PASSWORD }}@db:5432/postgres?schema=public" >> .env
+          
           # 各サービスディレクトリへ展開
           cp .env ./backend/.env
           cp .env ./frontend/.env


### PR DESCRIPTION
stable 環境の .env に DATABASE_URL が不足していたため、Prisma Client が初期化に失敗する問題を修正しました。