### PR TITLE
Redis内部通信用の環境変数設定の修正 #46-4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,13 @@ jobs:
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
           
-          # --- Prisma用の接続URLを追加 ---
+          # --- 内部通信用(DB/Redis)の設定を追加 ---
+          # Prisma用: ホスト名はサービス名、ポートは内部の5432
           echo "DATABASE_URL=postgresql://postgres:${{ secrets.DB_PASSWORD }}@db:5432/postgres?schema=public" >> .env
+          
+          # Redis用: ホスト名はサービス名、ポートは内部の6379
+          echo "REDIS_HOST=redis" >> .env
+          echo "REDIS_PORT_INTERNAL=6379" >> .env
           
           # 各サービスディレクトリへ展開
           cp .env ./backend/.env


### PR DESCRIPTION
概要

Stable環境において、バックエンドからRedisへの接続が ECONNREFUSED で失敗する問題を修正しました。
変更内容

    .github/workflows/deploy.yml の修正

        Create Stable .env ステップに REDIS_HOST と REDIS_PORT_INTERNAL を追加。

        ホスト側の公開ポート（6380）ではなく、Docker内部ネットワークのサービス名（redis）と標準ポート（6379）を使用するように構成。

修正の理由

Dockerコンテナ間通信では、ホストマッピングされたポートではなく、コンテナが内部でリッスンしているポートを指定する必要があるためです。

    誤: 172.20.0.3:6380（ホスト公開用ポート）

    正: redis:6379（コンテナ内部ポート）

動作確認事項

    [ ] マージ後のデプロイ完了時、docker logs receipt-stable-backend-1 で ECONNREFUSED が解消されていること。

    [ ] curl -I http://localhost:3001/api/health でバックエンドが正常にレスポンスを返すこと（認証エラー等のステータスで疎通を確認）。