### PR TITLE
Redis内部接続ポートの修正 (6380 -> 6379) #46-5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Create Stable .env
         run: |
           cd ~/stable/receipt-ai-app
-          # GitHub Secretsから.envを生成
+          # 1. ルートの.env生成（Docker Composeがポートマッピングに使用）
           echo "UID=$(id -u)" > .env
           echo "GID=$(id -g)" >> .env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
@@ -33,17 +33,17 @@ jobs:
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
           
-          # --- 内部通信用(DB/Redis)の設定を追加 ---
-          # Prisma用: ホスト名はサービス名、ポートは内部の5432
-          echo "DATABASE_URL=postgresql://postgres:${{ secrets.DB_PASSWORD }}@db:5432/postgres?schema=public" >> .env
-          
-          # Redis用: ホスト名はサービス名、ポートは内部の6379
-          echo "REDIS_HOST=redis" >> .env
-          echo "REDIS_PORT_INTERNAL=6379" >> .env
-          
-          # 各サービスディレクトリへ展開
-          cp .env ./backend/.env
+          # 2. 各サービスへ展開
           cp .env ./frontend/.env
+          cp .env ./backend/.env
+
+          # 3. バックエンド用の設定をコンテナ内部通信用に最適化
+          # Prisma用URLの追記
+          echo "DATABASE_URL=postgresql://postgres:${{ secrets.DB_PASSWORD }}@db:5432/postgres?schema=public" >> ./backend/.env
+          # Redis接続設定の上書き
+          echo "REDIS_HOST=redis" >> ./backend/.env
+          # ホスト公開用(6380)を、コンテナ内部の標準ポート(6379)へ置換
+          sed -i 's/^REDIS_PORT=.*/REDIS_PORT=6379/' ./backend/.env
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
概要

Stable環境のバックエンドコンテナからRedisへの接続が ECONNREFUSED で失敗していた問題を修正しました。
変更内容

    .github/workflows/deploy.yml の修正

        backend/.env 生成時に sed コマンドを使用し、REDIS_PORT をホスト公開用の 6380 からコンテナ内部通信用の 6379 へ強制的に書き換える処理を追加しました。

        これにより、Docker Compose（ホスト側）の定義とアプリ（コンテナ内部）の接続設定の整合性を確保しました。

修正の技術的背景

Dockerネットワーク内において、Redisサービスは標準ポート 6379 でリッスンしています。ホストOS側にマッピングした 6380 は外部からのアクセス用であり、コンテナ間通信でこれを使用すると接続拒否（ECONNREFUSED）が発生するため、内部用ポートに修正しました。
動作確認事項

    [ ] デプロイ後、docker logs receipt-stable-backend-1 で ECONNREFUSED が解消されていること。

    [ ] curl -I http://localhost:3001/api/health で 401 Unauthorized が返り、認証ロジックまでリクエストが到達していること。