### PR TITLE
Stable環境の完全独立化とCI/CDパイプラインの最適化 (#46-6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,19 @@ jobs:
       - name: Sync to Stable directory
         run: |
           mkdir -p ~/stable/receipt-ai-app
-          rsync -av --delete --exclude '.git' --exclude 'node_modules' ./ ~/stable/receipt-ai-app/
+          # ★修正: 永続化データ(pgdata, redisdata, uploads)を同期(削除)対象から除外
+          rsync -av --delete \
+            --exclude '.git' \
+            --exclude 'node_modules' \
+            --exclude 'pgdata' \
+            --exclude 'redisdata' \
+            --exclude 'uploads' \
+            ./ ~/stable/receipt-ai-app/
 
       - name: Create Stable .env
         run: |
           cd ~/stable/receipt-ai-app
-          # 1. ルートの.env生成（Docker Composeがポートマッピングに使用）
+          # 1. 共通の.env生成
           echo "UID=$(id -u)" > .env
           echo "GID=$(id -g)" >> .env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
@@ -33,16 +40,23 @@ jobs:
           echo "REDIS_PORT=${{ secrets.STABLE_REDIS_PORT }}" >> .env
           echo "T320_IP=192.168.1.32" >> .env
           
+          # Expo / CORS 用
+          echo "EXPO_PACKAGER_PROXY_URL=http://192.168.1.32:8082" >> .env
+          echo "EXPO_PUBLIC_API_URL=http://192.168.1.32:${{ secrets.STABLE_BACKEND_PORT }}" >> .env
+          echo "ALLOWED_ORIGINS=http://192.168.1.32:8082,http://localhost:8082" >> .env
+
+          # 実行用シークレット
+          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+          echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> .env
+          echo "NODE_ENV=production" >> .env
+
           # 2. 各サービスへ展開
           cp .env ./frontend/.env
           cp .env ./backend/.env
 
           # 3. バックエンド用の設定をコンテナ内部通信用に最適化
-          # Prisma用URLの追記
           echo "DATABASE_URL=postgresql://postgres:${{ secrets.DB_PASSWORD }}@db:5432/postgres?schema=public" >> ./backend/.env
-          # Redis接続設定の上書き
           echo "REDIS_HOST=redis" >> ./backend/.env
-          # ホスト公開用(6380)を、コンテナ内部の標準ポート(6379)へ置換
           sed -i 's/^REDIS_PORT=.*/REDIS_PORT=6379/' ./backend/.env
 
       - name: Install dependencies
@@ -56,6 +70,12 @@ jobs:
         run: |
           cd ~/stable/receipt-ai-app
           docker compose up -d --build
+
+      - name: Prisma Migrate (Stable DB)
+        run: |
+          cd ~/stable/receipt-ai-app
+          # コンテナ内でマイグレーションを実行
+          docker compose exec -T backend npx prisma migrate deploy
           
       - name: Cleanup
         run: docker image prune -f

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,7 +18,7 @@ import { tenantMiddleware } from './middleware/tenantMiddleware';
 import { getFamilyGroupId, getMemberId } from './utils/context';
 
 // --- ルーター ---
-import authRoutes from './routes/authRoutes'; // ★追加: ログイン用
+import authRoutes from './routes/authRoutes'; 
 import receiptRoutes from './routes/receiptRoutes';
 import productMasterRoutes from './routes/productMasterRoutes'; 
 import categoryRoutes from './routes/categoryRoutes';
@@ -36,8 +36,19 @@ const port = process.env.PORT || 3000;
 const host = process.env.HOST || '0.0.0.0'; 
 
 // --- 1. 基本ミドルウェア設定 ---
+const allowedOrigins = process.env.ALLOWED_ORIGINS 
+  ? process.env.ALLOWED_ORIGINS.split(',') 
+  : [];
+
 app.use(cors({
-  origin: (origin, callback) => callback(null, true),
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      logger.warn(`[CORS] Rejected origin: ${origin}`);
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'x-member-id'],
   credentials: true
@@ -46,24 +57,9 @@ app.use(cors({
 app.use(express.json());
 app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
 
-// --- 2. [Issue #52] ルート登録：認証の「境界線」を定義 ---
-
-/**
- * A. 認証不要ルート (Public API)
- * ログインエンドポイントなどは、authMiddleware の前に定義します。
- */
+// --- 2. [Issue #52] ルート登録 ---
 app.use('/api/auth', authRoutes);
-
-/**
- * B. 認証・世帯分離ミドルウェアの適用
- * これ以降に登録される /api 配下の全ルートに、一括でガードを適用します。
- */
 app.use('/api', authMiddleware, tenantMiddleware);
-
-/**
- * C. 認証済みルート (Protected API)
- * ここに登録するルートは、有効な JWT がなければ到達できません。
- */
 app.use('/api/categories', categoryRoutes);
 app.use('/api/product-master', productMasterRoutes);
 app.use('/api', receiptRoutes);
@@ -76,9 +72,6 @@ if (!fs.existsSync(uploadDir)) {
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
-/**
- * 📂 [Issue #43 & #45 & #51] レシートアップロード
- */
 app.post(
   '/api/receipts/upload', 
   upload.single('image'), 
@@ -124,7 +117,6 @@ app.post(
   }
 );
 
-// --- 4. エラーハンドリング ---
 app.use((req, res, next) => next(new AppError(`Not Found - ${req.originalUrl}`, 404)));
 app.use(errorHandler);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,10 @@ services:
     volumes:
       - ./backend:/app
       - /etc/localtime:/etc/localtime:ro
+      # レシート画像の永続化（明示的なバインドマウント）
+      - ./uploads:/app/uploads
     ports:
-      - "${BACKEND_PORT:-3000}:3000" # ホスト側ポートを可変に
+      - "${BACKEND_PORT:-3000}:3000"
     stdin_open: true
     tty: true
     env_file:
@@ -34,7 +36,7 @@ services:
       - ./frontend:/app
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "${FRONTEND_PORT:-8081}:8081"   # 開発用:8081 / Stable用:8082等
+      - "${FRONTEND_PORT:-8081}:8081"
       - "${EXPO_PORT_1:-19000}:19000"
       - "${EXPO_PORT_2:-19001}:19001"
     stdin_open: true
@@ -49,17 +51,18 @@ services:
   # --- Database (PostgreSQL) ---
   db:
     image: postgres:latest
-    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-db" # プロジェクト名で識別
+    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-db"
     environment:
       - TZ=Asia/Tokyo
       - POSTGRES_USER=${DB_USER:-cntadm}
       - POSTGRES_DB=${DB_NAME:-receipt_db}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql
+      # 名前付きボリュームではなく、カレントディレクトリの pgdata に保存
+      - ./pgdata:/var/lib/postgresql/data
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "${DB_PORT:-5432}:5432" # ホスト側ポートを可変に
+      - "${DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-cntadm} -d ${DB_NAME:-receipt_db}"]
       interval: 5s
@@ -69,11 +72,12 @@ services:
   # --- Redis (BullMQ Backend) ---
   redis:
     image: redis:7-alpine
-    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-redis" # 固定名を回避
+    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-redis"
     environment:
       - TZ=Asia/Tokyo
     volumes:
-      - redis_data:/data
+      # redisdata ディレクトリに永続化
+      - ./redisdata:/data
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "${REDIS_PORT:-6379}:6379"
@@ -83,7 +87,4 @@ services:
       timeout: 5s
       retries: 5
 
-volumes:
-  # 名前付きボリュームはプロジェクトごとに独立するため、データは混ざりません
-  postgres_data:
-  redis_data:
+# 名前付きボリューム定義は不要になったため削除


### PR DESCRIPTION
説明

【概要】
T320上の開発環境（Dev）と安定版環境（Stable）を完全に分離し、GitHub Actions による自動デプロイとデータの永続化を担保する基盤を構築しました。

【主な変更点】

    インフラ構成の分離 (docker-compose.yml):

        名前付きボリュームを廃止し、ホストディレクトリへのバインドマウント (./pgdata, ./uploads 等) に変更。

        プロジェクトごとに独立した物理ディレクトリでのデータ管理を実現。

    CI/CDパイプラインの強化 (deploy.yml):

        rsync 時のデータディレクトリ除外設定を追加し、デプロイによる既存データの消失を防止。

        JWT_SECRET, GEMINI_API_KEY 等の実行時シークレットを .env へ自動注入。

        デプロイ後の Prisma Migrate deploy 自動実行ステップを追加。

    バックエンド構成の動態化 (server.ts):

        CORSの許可リストを環境変数 (ALLOWED_ORIGINS) から取得する形式に修正。

        Stable環境（8082ポート）からの API アクセスを許可。

【動作確認内容】

    [x] docker compose up -d による 4 コンテナ（backend, frontend, db, redis）の正常起動を確認。

    [x] docker compose ps にてポートマッピング（3001, 8082, 5433等）の整合性を確認。

    [x] A5M2 から Stable用DB（5433ポート）への接続およびテーブル定義の存在を確認。