### PR TITLE
デプロイフロー（deploy.yml）への Gemini API キー追加 (#46-10)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Sync to Stable directory
         run: |
           mkdir -p ~/stable/receipt-ai-app
-          # ★修正: 永続化データ(pgdata, redisdata, uploads)を同期(削除)対象から除外
+          # 永続化データ(pgdata, redisdata, uploads)を同期(削除)対象から除外
           rsync -av --delete \
             --exclude '.git' \
             --exclude 'node_modules' \
@@ -45,9 +45,9 @@ jobs:
           echo "EXPO_PUBLIC_API_URL=http://192.168.1.32:${{ secrets.STABLE_BACKEND_PORT }}/api" >> .env
           echo "ALLOWED_ORIGINS=http://192.168.1.32:8082,http://localhost:8082" >> .env
 
-          # 実行用シークレット
+          # 実行用シークレット (GOOGLE_API_KEY に修正)
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
-          echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> .env
+          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" >> .env
           echo "NODE_ENV=production" >> .env
 
           # 2. 各サービスへ展開


### PR DESCRIPTION
説明

【概要】
Stable 環境のデプロイプロセスにおいて、Gemini API の呼び出しに必要な環境変数 GOOGLE_API_KEY が不足していたため、これを追加しました。

【変更内容】

    .github/workflows/deploy.yml のバックエンド .env 生成セクションに GOOGLE_API_KEY を追加。

    GitHub Secrets の ${{ secrets.GOOGLE_API_KEY }} から値を注入するように設定。

【確認事項】

    [x] GitHub Actions の実行後、サーバー上の backend/.env にキーが正しく書き込まれていること。

    [x] スマホアプリからの解析リクエストが正常に成功すること（手動修正版で確認済み）。