### PR TITLE
環境変数名をコードの定義 (GEMINI_API_KEY) に統一 (#46-11)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,9 @@ jobs:
           echo "EXPO_PUBLIC_API_URL=http://192.168.1.32:${{ secrets.STABLE_BACKEND_PORT }}/api" >> .env
           echo "ALLOWED_ORIGINS=http://192.168.1.32:8082,http://localhost:8082" >> .env
 
-          # 実行用シークレット (GOOGLE_API_KEY に修正)
+          # 実行用シークレット
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
-          echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}" >> .env
+          echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> .env
           echo "NODE_ENV=production" >> .env
 
           # 2. 各サービスへ展開


### PR DESCRIPTION
説明

【概要】
deploy.yml で生成していた環境変数名が GOOGLE_API_KEY となっており、バックエンドコード（geminiService.ts）で参照している GEMINI_API_KEY と不整合を起こしていたため修正しました。

【変更内容】

    .github/workflows/deploy.yml 内の記述を GOOGLE_API_KEY から GEMINI_API_KEY へ変更。

    これにより、GitHub Secrets の GEMINI_API_KEY から正しく値が注入されるようになります。

【確認事項】

    [x] backend/src/services/geminiService.ts 内の process.env.GEMINI_API_KEY と名称が一致していること。

    [x] GitHub Secrets に GEMINI_API_KEY という名前でキーが登録されていること（要確認）。