### PR TITLE
Discord通知機能の追加とバックアップ監視の実装(#61)

### DIFF
--- a/scripts/backup-stable.sh
+++ b/scripts/backup-stable.sh
@@ -7,10 +7,33 @@ BACKUP_DIR="/mnt/raid_1t/backups/receipt-app"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RETENTION_DAYS=7
 
+# ★ Discord 設定 (取得したURLをここに貼り付け)
+WEBHOOK_URL="https://discord.com/api/webhooks/1494659784304230442/Hh4scCNNv0hga2AtqMbUufCdaAaZUmmRrltAo4Ke5Pjq7QlS1iO1PIDIz5MAK399sY2Z"
+
 # Docker設定
-CONTAINER_NAME="receipt-stable-db"
+CONTAINER_NAME="receipt-stable-db" # 前回の成功時が「-1」付きなら修正してください
 DB_USER="cntadm"
 DB_NAME="receipt_db"
+
+# --- 通知関数 ---
+send_discord_alert() {
+    local status=$1    # SUCCESS or ERROR
+    local message=$2
+    local color=32768  # 緑 (Success)
+    [ "$status" = "ERROR" ] && color=16711680 # 赤 (Error)
+
+    curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{
+                \"embeds\": [{
+                    \"title\": \"[$status] T320 Backup Alert\",
+                    \"description\": \"$message\",
+                    \"color\": $color,
+                    \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+                }]
+                }" \
+            "$WEBHOOK_URL" > /dev/null 2>&1
+}
 
 # 1. バックアップ先ディレクトリ作成
 mkdir -p "${BACKUP_DIR}/db"
@@ -21,7 +44,9 @@ DOTENV_FILE="${PROJECT_ROOT}/.env"
 if [ -f "${DOTENV_FILE}" ]; then
     DB_PASS=$(grep '^DB_PASSWORD=' "${DOTENV_FILE}" | cut -d '=' -f 2-)
 else
-    echo "[$(date)] [ERROR] .env file not found at ${DOTENV_FILE}"
+    msg="[ERROR] .env file not found at ${DOTENV_FILE}"
+    echo "[$(date)] $msg"
+    send_discord_alert "ERROR" "$msg"
     exit 1
 fi
 
@@ -31,10 +56,19 @@ echo "[$(date)] Backup started."
 
 # 3. DBバックアップ
 if [ ! "$(docker ps -q -f name=${CONTAINER_NAME})" ]; then
-    echo "  -> [ERROR] Container ${CONTAINER_NAME} is NOT running."
+    msg="Container ${CONTAINER_NAME} is NOT running. DB Backup aborted."
+    echo "  -> [ERROR] $msg"
+    send_discord_alert "ERROR" "$msg"
 else
     docker exec -e PGPASSWORD="${DB_PASS}" ${CONTAINER_NAME} pg_dump -U ${DB_USER} ${DB_NAME} | gzip > "${BACKUP_DIR}/db/db_backup_${TIMESTAMP}.sql.gz"
-    [ ${PIPESTATUS[0]} -eq 0 ] && echo "  -> DB Backup SUCCESS." || echo "  -> [ERROR] DB Backup FAILED."
+    
+    if [ ${PIPESTATUS[0]} -eq 0 ]; then
+        echo "  -> DB Backup SUCCESS."
+    else
+        msg="PostgreSQL Dump FAILED."
+        echo "  -> [ERROR] $msg"
+        send_discord_alert "ERROR" "$msg"
+    fi
 fi
 
 # 4. 画像バックアップ
@@ -42,11 +76,16 @@ if [ -d "${SOURCE_UPLOADS_DIR}" ]; then
     tar -czf "${BACKUP_DIR}/uploads/uploads_backup_${TIMESTAMP}.tar.gz" -C "${PROJECT_ROOT}/backend" "uploads"
     echo "  -> Uploads Backup SUCCESS."
 else
-    echo "  -> [ERROR] Uploads directory NOT found."
+    msg="Uploads directory NOT found at ${SOURCE_UPLOADS_DIR}."
+    echo "  -> [ERROR] $msg"
+    send_discord_alert "ERROR" "$msg"
 fi
 
 # 5. 世代管理
 find "${BACKUP_DIR}/db" -name "*.gz" -mtime +${RETENTION_DAYS} -delete
 find "${BACKUP_DIR}/uploads" -name "*.tar.gz" -mtime +${RETENTION_DAYS} -delete
+
+# 6. 完了通知 (成功時も通知したい場合はコメントアウトを外してください)
+# send_discord_alert "SUCCESS" "Daily backup completed successfully on T320."
 
 echo "[$(date)] Backup completed."

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# --- 設定項目 ---
+# Discord の Webhook URL (後ほど取得して貼り付けます)
+WEBHOOK_URL="https://discord.com/api/webhooks/1494659784304230442/Hh4scCNNv0hga2AtqMbUufCdaAaZUmmRrltAo4Ke5Pjq7QlS1iO1PIDIz5MAK399sY2Z"
+
+# 通知関数
+send_notification() {
+    local status=$1    # SUCCESS or ERROR
+    local message=$2
+    local color=32768  # Green (Success)
+    
+    if [ "$status" = "ERROR" ]; then
+        color=16711680 # Red (Error)
+    fi
+
+    # Discord への送信 (JSON形式)
+    curl -H "Content-Type: application/json" \
+         -X POST \
+         -d "{
+               \"embeds\": [{
+                 \"title\": \"[$status] T320 Server Alert\",
+                 \"description\": \"$message\",
+                 \"color\": $color,
+                 \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+               }]
+             }" \
+         $WEBHOOK_URL
+}


### PR DESCRIPTION
## 概要
バックアップ処理の信頼性を高めるため、Discord Webhook を利用したリアルタイム通知機能を導入しました。

## 変更内容
- `scripts/backup-stable.sh` に Discord 通知関数 `send_discord_alert` を実装。
- 以下のケースにおいて Discord へアラート（赤色）が飛ぶように修正：
  - `.env` ファイルの欠落
  - DBコンテナが起動していない
  - PostgreSQL のダンプ出力失敗
  - アップロード画像ディレクトリの欠落
- T320 サーバー実機からの疎通確認（テスト送信）済み。

## 動作確認
- 手動実行により、意図したタイミングで Discord への通知が届くことを確認しました。