### PR TITLE
統計画面のレスポンシブ最適化(2カラム化)とモバイル表示の修正 (#49-6)

### DIFF
--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -1,17 +1,14 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Image, TouchableOpacity, Modal, Alert, FlatList } from 'react-native';
+import { View, Text, StyleSheet, Dimensions, ScrollView, ActivityIndicator, Image, TouchableOpacity, Modal, Alert, FlatList, useWindowDimensions, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
 
-const screenWidth = Dimensions.get('window').width;
-
 // --- interface 定義 ---
 interface Category { id: number; name: string; color: string; }
 interface StatItem { categoryId: number | null; categoryName: string; totalAmount: number | string; color: string; }
-// [Issue #65] quantity を追加
 interface ReceiptItem { id: number; name: string; price: number; quantity: number; categoryId: number; category?: { name: string; color: string }; }
 interface ReceiptInfo { id: number; imagePath: string | null; storeName: string; totalAmount: number; items: ReceiptItem[]; }
 interface MonthlyData { month: string; totalAmount: number; prevTotal: number; diffAmount: number; diffPercentage: number; stats: StatItem[]; latestReceipt: ReceiptInfo | null; }
@@ -26,6 +23,9 @@ interface StatisticsScreenProps {
 }
 
 export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId, onBack }) => {
+  const { width: windowWidth } = useWindowDimensions();
+  const isWide = windowWidth > 768; // iPad/Web 判定
+
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
   const [data, setData] = useState<MonthlyData | null>(null);
@@ -49,11 +49,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   const fetchData = useCallback(async () => {
     if (!currentMemberId) return;
-    
     try {
       setLoading(true);
       const headers = { 'x-member-id': currentMemberId.toString() };
-
       const [statsRes, advRes, catRes] = await Promise.all([
         apiClient.get(`/stats/monthly`, { params: { month: selectedMonth }, headers }),
         apiClient.get(`/stats/advanced`, { headers }),
@@ -67,9 +65,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
           setData({
             month: target?.month || selectedMonth,
             totalAmount: Number(target?.total || 0),
-            prevTotal: 0,
-            diffAmount: 0,
-            diffPercentage: 0,
+            prevTotal: 0, diffAmount: 0, diffPercentage: 0,
             stats: target?.stats || [], 
             latestReceipt: target?.latestReceipt || null
           });
@@ -77,10 +73,8 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
           setData(raw);
         }
       }
-
       if (advRes.data?.success) setAdvancedData(advRes.data.data);
       if (catRes.data?.success) setAllCategories(catRes.data.data);
-
     } catch (error: any) {
       console.error('[DEBUG-STATS] Fetch Error:', error);
       Alert.alert("エラー", "データの取得に失敗しました");
@@ -89,9 +83,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
     }
   }, [selectedMonth, currentMemberId]);
 
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+  useEffect(() => { fetchData(); }, [fetchData]);
 
   const handleUpdateCategory = async (categoryId: number) => {
     if (!selectedItemId) return;
@@ -105,7 +97,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   const chartData = useMemo(() => {
     if (!data?.stats || !Array.isArray(data.stats)) return [];
-    
     return data.stats
       .map(s => {
         const val = Number(s.totalAmount);
@@ -120,6 +111,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       .filter(s => s.population > 0);
   }, [data?.stats]);
 
+  // チャートの幅を計算（ワイド時は固定、モバイル時は画面幅）
+  const chartWidth = isWide ? 400 : windowWidth - 60;
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
@@ -133,7 +127,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.topInfo}>
           <Text style={styles.headerSubtitle}>{currentMemberId === 1 ? 'PERSONAL REPORT' : 'FAMILY REPORT'}</Text>
-          <View style={styles.monthPickerContainer}>
+          <View style={[styles.monthPickerContainer, isWide && { width: 300 }]}>
             <Picker selectedValue={selectedMonth} onValueChange={(val) => setSelectedMonth(val)} style={styles.monthPicker}>
               {monthOptions.map(m => (
                 <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
@@ -145,132 +139,148 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         {loading && !data ? (
           <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
         ) : (
-          <>
-            <View style={styles.summaryCard}>
-              <Text style={styles.summaryLabel}>当月合計支出</Text>
-              <Text style={styles.totalValue}>¥{(Number(data?.totalAmount) || 0).toLocaleString()}</Text>
-              <View style={styles.comparisonRow}>
-                <Text style={styles.comparisonLabel}>前月比:</Text>
-                <Text style={[styles.diffValue, { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success }]}>
-                  {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥{Math.abs(data?.diffAmount || 0).toLocaleString()} ({data?.diffPercentage || 0}%)
-                </Text>
+          <View style={isWide ? styles.dashboardGrid : null}>
+            
+            {/* --- 左カラム (サマリー & チャート) --- */}
+            <View style={isWide ? styles.leftColumn : null}>
+              <View style={styles.summaryCard}>
+                <Text style={styles.summaryLabel}>当月合計支出</Text>
+                <Text style={styles.totalValue}>¥{(Number(data?.totalAmount) || 0).toLocaleString()}</Text>
+                <View style={styles.comparisonRow}>
+                  <Text style={styles.comparisonLabel}>前月比:</Text>
+                  <Text style={[styles.diffValue, { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success }]}>
+                    {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥{Math.abs(data?.diffAmount || 0).toLocaleString()} ({data?.diffPercentage || 0}%)
+                  </Text>
+                </View>
               </View>
-            </View>
 
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>月次推移 (MoM Trend)</Text>
-              <View style={styles.statsCard}>
-                {advancedData?.trend.map((t, i) => {
-                  const diff = t.prev_total ? t.total - t.prev_total : 0;
-                  return (
-                    <View key={i} style={styles.trendRow}>
-                      <Text style={styles.trendPeriod}>{t.period}</Text>
-                      <Text style={styles.trendAmount}>¥{t.total.toLocaleString()}</Text>
-                      <Text style={[styles.trendDiff, { color: diff > 0 ? theme.colors.error : theme.colors.success }]}>
-                        {t.prev_total !== null ? `${diff > 0 ? '+' : ''}${diff.toLocaleString()}` : '-'}
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>支出内訳</Text>
+                <View style={styles.chartCard}>
+                  {chartData.length > 0 ? (
+                    <PieChart
+                      data={chartData}
+                      width={chartWidth}
+                      height={220}
+                      chartConfig={{ color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})` }}
+                      accessor={"population"}
+                      backgroundColor={"transparent"}
+                      paddingLeft={"15"}
+                      absolute
+                    />
+                  ) : <Text style={styles.noDataText}>カテゴリー別データがありません</Text>}
+                </View>
+              </View>
+
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>最新の解析レシート</Text>
+                {data?.latestReceipt?.imagePath ? (
+                  <TouchableOpacity style={styles.receiptPreviewCard} onPress={() => setMainModalVisible(true)}>
+                    <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.receiptImage} resizeMode="cover" />
+                    <View style={styles.receiptInfoOverlay}>
+                      {/* ★店名を flex: 1 で包んで金額を保護 */}
+                      <View style={{ flex: 1, marginRight: 10 }}>
+                        <Text style={styles.receiptStoreName} numberOfLines={1}>
+                          {data.latestReceipt.storeName || '店名不明'}
+                        </Text>
+                      </View>
+                      <Text style={styles.receiptAmount}>
+                        ¥{data.latestReceipt.totalAmount.toLocaleString()}
                       </Text>
                     </View>
-                  );
-                })}
+                  </TouchableOpacity>
+                ) : <View style={styles.noImageBox}><Text style={styles.noDataText}>画像なし</Text></View>}
               </View>
             </View>
 
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>費目別パレート分析 (Pareto)</Text>
-              <View style={styles.statsCard}>
-                {advancedData?.pareto.map((p, i) => (
-                  <View key={i} style={styles.paretoWrapper}>
-                    <View style={styles.paretoTextRow}>
-                      <Text style={styles.paretoName}>{p.name}</Text>
-                      <Text style={styles.paretoValue}>¥{p.amount.toLocaleString()} ({p.ratio}%)</Text>
+            {/* --- 右カラム (トレンド & パレート) --- */}
+            <View style={isWide ? styles.rightColumn : null}>
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>月次推移 (MoM Trend)</Text>
+                <View style={styles.statsCard}>
+                  {advancedData?.trend.map((t, i) => {
+                    const diff = t.prev_total ? t.total - t.prev_total : 0;
+                    return (
+                      <View key={i} style={styles.trendRow}>
+                        <Text style={styles.trendPeriod}>{t.period}</Text>
+                        <Text style={styles.trendAmount}>¥{t.total.toLocaleString()}</Text>
+                        <Text style={[styles.trendDiff, { color: diff > 0 ? theme.colors.error : theme.colors.success }]}>
+                          {t.prev_total !== null ? `${diff > 0 ? '+' : ''}${diff.toLocaleString()}` : '-'}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>費目別分析 (Pareto 80/20)</Text>
+                <View style={styles.statsCard}>
+                  {advancedData?.pareto.map((p, i) => (
+                    <View key={i} style={styles.paretoWrapper}>
+                      <View style={styles.paretoTextRow}>
+                        <Text style={styles.paretoName}>{p.name}</Text>
+                        <Text style={styles.paretoValue}>¥{p.amount.toLocaleString()} ({p.ratio}%)</Text>
+                      </View>
+                      <View style={styles.paretoBarContainer}>
+                        <View style={[
+                          styles.paretoBar, 
+                          { width: `${p.ratio}%`, backgroundColor: p.cumulative_ratio <= 80 ? theme.colors.primary : '#CED4DA' }
+                        ]} />
+                        <Text style={styles.cumText}>{p.cumulative_ratio}%</Text>
+                      </View>
                     </View>
-                    <View style={styles.paretoBarContainer}>
-                      <View style={[
-                        styles.paretoBar, 
-                        { width: `${p.ratio}%`, backgroundColor: p.cumulative_ratio <= 80 ? theme.colors.primary : '#CED4DA' }
-                      ]} />
-                      <Text style={styles.cumText}>{p.cumulative_ratio}%</Text>
-                    </View>
-                  </View>
-                ))}
+                  ))}
+                </View>
               </View>
             </View>
 
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>支出内訳</Text>
-              <View style={styles.chartCard}>
-                {chartData.length > 0 ? (
-                  <PieChart
-                    data={chartData}
-                    width={screenWidth - 60}
-                    height={220}
-                    chartConfig={{ color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})` }}
-                    accessor={"population"}
-                    backgroundColor={"transparent"}
-                    paddingLeft={"15"}
-                    absolute
-                  />
-                ) : <Text style={styles.noDataText}>カテゴリー別データがありません</Text>}
-              </View>
-            </View>
-
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>最新の解析レシート</Text>
-              {data?.latestReceipt?.imagePath ? (
-                <TouchableOpacity style={styles.receiptPreviewCard} onPress={() => setMainModalVisible(true)}>
-                  <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.receiptImage} resizeMode="cover" />
-                  <View style={styles.receiptInfoOverlay}>
-                    <Text style={styles.receiptStoreName}>{data.latestReceipt.storeName}</Text>
-                    <Text style={styles.receiptAmount}>¥{data.latestReceipt.totalAmount.toLocaleString()}</Text>
-                  </View>
-                </TouchableOpacity>
-              ) : <View style={styles.noImageBox}><Text style={styles.noDataText}>画像なし</Text></View>}
-            </View>
-          </>
+          </View>
         )}
       </ScrollView>
 
-      <Modal visible={isMainModalVisible} animationType="slide">
-        <SafeAreaView style={styles.modalContainer}>
-          <View style={styles.modalHeader}>
-            <Text style={styles.modalTitle}>詳細明細</Text>
-            <TouchableOpacity onPress={() => setMainModalVisible(false)}>
-              <Text style={styles.modalCloseText}>閉じる</Text>
-            </TouchableOpacity>
-          </View>
-          <ScrollView style={styles.modalScroll}>
-            {data?.latestReceipt?.imagePath && (
-              <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.modalImage} resizeMode="contain" />
-            )}
-            <View style={styles.itemListContainer}>
-              {data?.latestReceipt?.items.map((item) => (
-                <View key={item.id} style={styles.itemRow}>
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.itemName}>{item.name}</Text>
-                    {/* [Issue #65] 単価・数量・小計の表示 */}
-                    <View style={styles.itemPriceDetailRow}>
-                      <Text style={styles.itemPrice}>¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}</Text>
-                      <Text style={styles.itemSubText}>
-                        （¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）
-                      </Text>
-                    </View>
-                  </View>
-                  <TouchableOpacity 
-                    style={[styles.categoryBadge, { backgroundColor: item.category?.color || theme.colors.secondary }]}
-                    onPress={() => { setSelectedItemId(item.id); setPickerVisible(true); }}
-                  >
-                    <Text style={styles.categoryBadgeText}>{item.category?.name || '未分類'}</Text>
-                  </TouchableOpacity>
-                </View>
-              ))}
+      {/* 詳細 Modal */}
+      <Modal visible={isMainModalVisible} animationType="slide" transparent={isWide}>
+        <View style={isWide ? styles.modalOverlay : styles.modalContainer}>
+          <SafeAreaView style={[styles.modalContainer, isWide && styles.wideModal]}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>解析レシート詳細</Text>
+              <TouchableOpacity onPress={() => setMainModalVisible(false)}>
+                <Text style={styles.modalCloseText}>閉じる</Text>
+              </TouchableOpacity>
             </View>
-          </ScrollView>
-        </SafeAreaView>
+            <ScrollView style={styles.modalScroll}>
+              {data?.latestReceipt?.imagePath && (
+                <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.modalImage} resizeMode="contain" />
+              )}
+              <View style={styles.itemListContainer}>
+                {data?.latestReceipt?.items.map((item) => (
+                  <View key={item.id} style={styles.itemRow}>
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.itemName}>{item.name}</Text>
+                      <View style={styles.itemPriceDetailRow}>
+                        <Text style={styles.itemPrice}>¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}</Text>
+                        <Text style={styles.itemSubText}>（¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）</Text>
+                      </View>
+                    </View>
+                    <TouchableOpacity 
+                      style={[styles.categoryBadge, { backgroundColor: item.category?.color || theme.colors.secondary }]}
+                      onPress={() => { setSelectedItemId(item.id); setPickerVisible(true); }}
+                    >
+                      <Text style={styles.categoryBadgeText}>{item.category?.name || '未分類'}</Text>
+                    </TouchableOpacity>
+                  </View>
+                ))}
+              </View>
+            </ScrollView>
+          </SafeAreaView>
+        </View>
       </Modal>
 
+      {/* カテゴリ変更 Modal */}
       <Modal visible={isPickerVisible} transparent={true} animationType="fade">
         <View style={styles.pickerOverlay}>
-          <View style={styles.pickerWindow}>
+          <View style={[styles.pickerWindow, isWide && { width: 400 }]}>
             <Text style={styles.pickerHeader}>カテゴリー変更</Text>
             <FlatList
               data={allCategories}
@@ -302,6 +312,12 @@ const styles = StyleSheet.create({
   headerSubtitle: { fontSize: 10, color: theme.colors.text.muted, letterSpacing: 1 },
   monthPickerContainer: { backgroundColor: theme.colors.surface, borderRadius: 10, marginTop: 8, borderWidth: 1, borderColor: theme.colors.border, height: 50, justifyContent: 'center' },
   monthPicker: { width: '100%' },
+
+  // --- Dashboard Grid (iPad/Web用) ---
+  dashboardGrid: { flexDirection: 'row', justifyContent: 'space-between' },
+  leftColumn: { flex: 1.2, marginRight: 20 },
+  rightColumn: { flex: 1 },
+
   summaryCard: { backgroundColor: theme.colors.surface, padding: 20, borderRadius: 15, marginBottom: 25, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border, elevation: 3 },
   summaryLabel: { fontSize: 12, color: theme.colors.text.muted },
   totalValue: { fontSize: 36, fontWeight: 'bold', color: theme.colors.primary, marginVertical: 4 },
@@ -309,9 +325,9 @@ const styles = StyleSheet.create({
   comparisonLabel: { fontSize: 12, marginRight: 8 },
   diffValue: { fontWeight: '700', fontSize: 16 },
   section: { marginBottom: 25 },
-  sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 15, borderLeftWidth: 4, borderLeftColor: theme.colors.primary, paddingLeft: 8 },
+  sectionTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, borderLeftWidth: 4, borderLeftColor: theme.colors.primary, paddingLeft: 8 },
   statsCard: { backgroundColor: theme.colors.surface, borderRadius: 12, padding: 15, borderWidth: 1, borderColor: theme.colors.border },
-  trendRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: theme.colors.background },
+  trendRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: theme.colors.background },
   trendPeriod: { flex: 1, fontWeight: '700' },
   trendAmount: { flex: 1, textAlign: 'right' },
   trendDiff: { flex: 1, textAlign: 'right', fontSize: 12, fontWeight: '600' },
@@ -326,20 +342,26 @@ const styles = StyleSheet.create({
   noDataText: { fontSize: 12, color: theme.colors.text.muted },
   receiptPreviewCard: { backgroundColor: theme.colors.surface, borderRadius: 12, overflow: 'hidden', borderWidth: 1, borderColor: theme.colors.border },
   receiptImage: { width: '100%', height: 160, backgroundColor: theme.colors.border },
-  receiptInfoOverlay: { padding: 15, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  receiptStoreName: { fontWeight: '700' },
-  receiptAmount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary },
+  
+  // --- 修正: レシート情報のオーバーレイ ---
+  receiptInfoOverlay: { padding: 15, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', minHeight: 60 },
+  receiptStoreName: { fontWeight: '700', color: theme.colors.text.main },
+  receiptAmount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary, minWidth: 80, textAlign: 'right' },
+
   noImageBox: { height: 100, backgroundColor: theme.colors.border, borderRadius: 12, justifyContent: 'center', alignItems: 'center' },
+
+  // --- Modal Adjustments ---
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
   modalContainer: { flex: 1, backgroundColor: theme.colors.background },
+  wideModal: { width: 600, maxHeight: '80%', borderRadius: 20, overflow: 'hidden' },
   modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   modalTitle: { fontSize: 18, fontWeight: 'bold' },
   modalCloseText: { color: theme.colors.error, fontWeight: '600' },
   modalScroll: { flex: 1 },
   modalImage: { width: '100%', height: 300, marginVertical: 15 },
-  itemListContainer: { paddingHorizontal: 20 },
+  itemListContainer: { paddingHorizontal: 20, paddingBottom: 30 },
   itemRow: { flexDirection: 'row', paddingVertical: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border, alignItems: 'center' },
   itemName: { flex: 1, fontSize: 14 },
-  // [Issue #65] 小計と詳細を並べるスタイル
   itemPriceDetailRow: { flexDirection: 'row', alignItems: 'baseline', marginTop: 2 },
   itemPrice: { fontWeight: '700', color: theme.colors.primary },
   itemSubText: { fontSize: 10, color: theme.colors.text.muted, marginLeft: 4 },


### PR DESCRIPTION
## 概要
iPadやPCブラウザでの閲覧に最適化するため、統計画面（StatisticsScreen）のレイアウトを大幅に刷新しました。
また、スマホ表示において店名が長い場合に金額が切れてしまうバグを修正しました。

## 変更内容
- **レスポンシブ・ダッシュボード化**:
  - 画面幅768px以上（iPad/Web）で2カラムレイアウトを導入。
  - 左カラムにサマリーとチャート、右カラムにトレンドとパレート分析を配置し、スクロールなしでの視認性を向上。
- **チャートの最適化**:
  - 広い画面での円グラフの巨大化を抑制（最大幅400pxに制限）。
- **モバイル表示のバグ修正**:
  - 最新レシートプレビューにて、店名が長い場合に合計金額が画面外に押し出される問題を修正。
  - `flex: 1` と `numberOfLines={1}` を適用し、店名を適切に省略しつつ金額を保護。
- **モーダルのWeb最適化**:
  - Web/iPadでは詳細モーダルを全画面ではなく中央ダイアログ形式に変更。
- **表示の整合性**:
  - 詳細明細内の単価×数量の表示形式を他の画面と統一。

## 確認事項
- [x] iPad/Webサイズで2列に表示が切り替わること
- [x] スマホサイズで店名が長いレシートがあっても合計金額が右端に正しく表示されること
- [x] カテゴリ変更モーダルが正常に動作し、統計データが再取得されること