### PR TITLE
履歴一覧(HistoryScreen)のレスポンシブ対応と2カラムUIの実装 (#49-7)

### DIFF
--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { StyleSheet, Text, View, FlatList, TouchableOpacity, ActivityIndicator, Image, ScrollView, Modal, Platform, Alert } from 'react-native';
+import { StyleSheet, Text, View, FlatList, TouchableOpacity, ActivityIndicator, Image, ScrollView, Modal, Platform, Alert, useWindowDimensions } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
@@ -10,6 +10,9 @@ interface HistoryScreenProps {
 }
 
 export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreenProps) {
+  const { width: windowWidth } = useWindowDimensions();
+  const isWide = windowWidth > 800; 
+
   const [loading, setLoading] = useState(true);
   const [receipts, setReceipts] = useState<any[]>([]);
   const [categories, setCategories] = useState<any[]>([]);
@@ -20,23 +23,17 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
 
   const cacheKey = useMemo(() => Date.now(), []);
 
-  /**
-   * 過去6ヶ月分の月リスト生成
-   */
   const months = useMemo(() => {
     return Array.from({ length: 6 }).map((_, i) => {
       const d = new Date();
       d.setMonth(d.getMonth() - i);
-      return d.toISOString().slice(0, 7); // YYYY-MM
+      return d.toISOString().slice(0, 7);
     });
   }, []);
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
-  /**
-   * [Issue #45] カテゴリーマスタ取得
-   */
   const fetchCategories = useCallback(async () => {
     try {
       const res = await apiClient.get('/categories', {
@@ -50,28 +47,20 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     }
   }, [selectedMember]);
 
-  useEffect(() => {
-    fetchCategories();
-  }, [fetchCategories]);
+  useEffect(() => { fetchCategories(); }, [fetchCategories]);
 
-  /**
-   * [Issue #45] レシート一覧取得
-   */
   const fetchReceipts = useCallback(async () => {
     try {
       setLoading(true);
       const res = await apiClient.get('/receipts', {
-        params: {
-          memberId: selectedMember,
-          month: selectedMonth
-        },
-        headers: {
-          'x-member-id': selectedMember
-        }
+        params: { memberId: selectedMember, month: selectedMonth },
+        headers: { 'x-member-id': selectedMember }
       });
-
       if (res.data && res.data.success) {
         setReceipts(res.data.data);
+        if (isWide && res.data.data.length > 0 && !selectedReceipt) {
+          setSelectedReceipt(res.data.data[0]);
+        }
       }
     } catch (err) {
       console.error('履歴取得失敗', err);
@@ -79,19 +68,10 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     } finally {
       setLoading(false);
     }
-  }, [selectedMonth, selectedMember]);
+  }, [selectedMonth, selectedMember, isWide]);
 
-  useEffect(() => {
-    fetchReceipts();
-  }, [fetchReceipts]);
+  useEffect(() => { fetchReceipts(); }, [fetchReceipts]);
 
-  useEffect(() => {
-    setSelectedMember(currentMemberId.toString());
-  }, [currentMemberId]);
-
-  /**
-   * [Issue #45] 明細のカテゴリー更新
-   */
   const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
     if (!categoryId) return;
     try {
@@ -102,22 +82,22 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
       
       if (response.data && response.data.success) {
         const updatedItem = response.data.data;
-
-        setSelectedReceipt((prev: any) =>
-          prev ? {
-            ...prev,
-            items: prev.items.map((item: any) =>
-              item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
-            ),
-          } : prev
-        );
-
-        setReceipts(prev => prev.map(r => ({
+        const updateInList = (prev: any[]) => prev.map(r => ({
           ...r,
           items: r.items.map((item: any) =>
             item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
           ),
-        })));
+        }));
+
+        setReceipts(updateInList);
+        if (selectedReceipt) {
+          setSelectedReceipt((prev: any) => ({
+            ...prev,
+            items: prev.items.map((item: any) =>
+              item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
+            ),
+          }));
+        }
       }
     } catch (err) {
       console.error('カテゴリー更新失敗', err);
@@ -130,27 +110,100 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     return `${BASE_URL}/${imagePath}?v=${cacheKey}`;
   }, [BASE_URL, cacheKey]);
 
-  const renderItem = ({ item }: { item: any }) => (
-    <TouchableOpacity 
-      style={styles.card} 
-      onPress={() => setSelectedReceipt(item)}
-      activeOpacity={0.7}
-    >
-      <View style={styles.cardHeader}>
-        <Text style={styles.date}>{item.date ? new Date(item.date).toLocaleDateString('ja-JP') : '日付不明'}</Text>
-        <Text style={styles.store} numberOfLines={1}>{item.storeName || '店名不明'}</Text>
-      </View>
-      <View style={styles.cardBody}>
-        <View>
-          <Text style={styles.label}>合計</Text>
-          <Text style={styles.amount}>¥{(item.totalAmount || 0).toLocaleString()}</Text>
+  const ReceiptDetailView = ({ receipt }: { receipt: any }) => {
+    if (!receipt) {
+      return (
+        <View style={styles.placeholderContainer}>
+          <Text style={styles.emptyText}>レシートを選択してください</Text>
         </View>
-        <View style={styles.itemCountBadge}>
-          <Text style={styles.itemCountText}>{(item.items?.length || 0)} 点</Text>
+      );
+    }
+
+    return (
+      <ScrollView style={styles.detailScroll} showsVerticalScrollIndicator={false}>
+        <View style={styles.detailHeaderInner}>
+          <Text style={styles.detailTitle} numberOfLines={2}>{receipt.storeName || '店名不明'}</Text>
+          <Text style={styles.detailDate}>
+            {receipt.date ? new Date(receipt.date).toLocaleDateString('ja-JP') : '日付不明'}
+          </Text>
         </View>
-      </View>
-    </TouchableOpacity>
-  );
+
+        {receipt.imagePath && (
+          <View style={styles.imageWrapper}>
+            <Image 
+              source={{ uri: getImageUrl(receipt.imagePath) as string }}
+              style={styles.receiptImage}
+              resizeMode="contain"
+            />
+          </View>
+        )}
+
+        <View style={styles.detailTotalContainer}>
+          <Text style={styles.detailTotalLabel}>合計金額（税込）</Text>
+          <Text style={styles.detailTotalValue}>¥{(receipt.totalAmount || 0).toLocaleString()}</Text>
+        </View>
+
+        <View style={styles.itemsSection}>
+          <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
+          {receipt.items?.map((item: any) => (
+            <View key={item.id} style={styles.detailItemRow}>
+              {/* 情報を縦に積むスタイルに変更し、衝突を回避 */}
+              <View style={styles.detailItemTop}>
+                <Text style={styles.detailItemName}>{item.name}</Text>
+                <View style={styles.detailPriceContainer}>
+                  <Text style={styles.detailItemPrice}>
+                    ¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}
+                  </Text>
+                  <Text style={styles.detailItemSub}>
+                    （¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）
+                  </Text>
+                </View>
+              </View>
+              <View style={styles.detailItemBottom}>
+                <View style={styles.detailPickerWrapper}>
+                  <Picker
+                    selectedValue={item.categoryId}
+                    onValueChange={(val) => handleCategoryChange(item.id, val)}
+                    style={styles.detailPicker}
+                  >
+                    <Picker.Item label="カテゴリーを選択..." value={null} color={theme.colors.text.muted} />
+                    {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
+                  </Picker>
+                </View>
+              </View>
+            </View>
+          ))}
+        </View>
+        <View style={{ height: 50 }} />
+      </ScrollView>
+    );
+  };
+
+  const renderItem = ({ item }: { item: any }) => {
+    const isSelected = selectedReceipt?.id === item.id;
+    return (
+      <TouchableOpacity 
+        style={[styles.card, isSelected && isWide && styles.activeCard]} 
+        onPress={() => setSelectedReceipt(item)}
+        activeOpacity={0.7}
+      >
+        <View style={styles.cardHeader}>
+          <Text style={styles.date}>{item.date ? new Date(item.date).toLocaleDateString('ja-JP') : '日付不明'}</Text>
+          <Text style={[styles.store, isSelected && isWide && { color: theme.colors.primary }]} numberOfLines={1}>
+            {item.storeName || '店名不明'}
+          </Text>
+        </View>
+        <View style={styles.cardBody}>
+          <View>
+            <Text style={styles.amount}>¥{(item.totalAmount || 0).toLocaleString()}</Text>
+          </View>
+          <View style={styles.itemCountBadge}>
+            <Text style={styles.itemCountText}>{(item.items?.length || 0)} 点</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  };
 
   return (
     <View style={styles.container}>
@@ -162,109 +215,59 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
         <View style={{ width: 40 }} />
       </View>
 
-      <View style={styles.filterContainer}>
-        <View style={styles.pickerBox}>
-          <Picker 
-            selectedValue={selectedMonth} 
-            onValueChange={setSelectedMonth} 
-            style={styles.filterPicker}
-            dropdownIconColor={theme.colors.primary}
-          >
+      <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
+        <View style={[styles.pickerBox, isWide && { maxWidth: 250 }]}>
+          <Picker selectedValue={selectedMonth} onValueChange={setSelectedMonth} style={styles.filterPicker}>
             <Picker.Item label="全期間" value="" />
             {months.map(m => (
               <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
             ))}
           </Picker>
         </View>
-        <View style={styles.pickerBox}>
-          <Picker 
-            selectedValue={selectedMember} 
-            onValueChange={setSelectedMember} 
-            style={styles.filterPicker}
-            dropdownIconColor={theme.colors.primary}
-          >
+        <View style={[styles.pickerBox, isWide && { maxWidth: 200 }]}>
+          <Picker selectedValue={selectedMember} onValueChange={setSelectedMember} style={styles.filterPicker}>
             <Picker.Item label="自分" value="1" />
             <Picker.Item label="その他" value="2" />
           </Picker>
         </View>
       </View>
 
-      {loading ? (
-        <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
-      ) : (
-        <FlatList
-          data={receipts}
-          keyExtractor={(item) => item.id.toString()}
-          renderItem={renderItem}
-          contentContainerStyle={styles.list}
-          ListEmptyComponent={<Text style={styles.empty}>該当する履歴がありません</Text>}
-          initialNumToRender={10}
-          removeClippedSubviews={true}
-        />
-      )}
-
-      <Modal
-        visible={!!selectedReceipt}
-        animationType="slide"
-        onRequestClose={() => setSelectedReceipt(null)}
-      >
-        <View style={styles.modalContent}>
-          <View style={styles.detailHeader}>
-            <Text style={styles.detailTitle} numberOfLines={1}>{selectedReceipt?.storeName || '店名不明'}</Text>
-            <TouchableOpacity onPress={() => setSelectedReceipt(null)} hitSlop={{top: 20, bottom: 20, left: 20, right: 20}}>
-              <Text style={styles.detailClose}>✕</Text>
-            </TouchableOpacity>
-          </View>
-
-          <ScrollView style={styles.detailScroll} showsVerticalScrollIndicator={false}>
-            {selectedReceipt?.imagePath && (
-              <View style={styles.imageWrapper}>
-                <Image 
-                  source={{ uri: getImageUrl(selectedReceipt.imagePath) as string }}
-                  style={styles.receiptImage}
-                  resizeMode="contain"
-                />
-              </View>
-            )}
-
-            <View style={styles.detailTotalContainer}>
-              <Text style={styles.detailTotalLabel}>合計金額（税込）</Text>
-              <Text style={styles.detailTotalValue}>¥{(selectedReceipt?.totalAmount || 0).toLocaleString()}</Text>
-            </View>
-
-            <View style={styles.itemsSection}>
-              <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
-              {selectedReceipt?.items?.map((item: any) => (
-                <View key={item.id} style={styles.detailItemRow}>
-                  <View style={styles.detailItemInfo}>
-                    <Text style={styles.detailItemName} numberOfLines={1}>{item.name}</Text>
-                    {/* [Issue #65] 単価・数量・小計の表示 */}
-                    <View style={styles.detailPriceContainer}>
-                      <Text style={styles.detailItemPrice}>
-                        ¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}
-                      </Text>
-                      <Text style={styles.detailItemSub}>
-                        （¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）
-                      </Text>
-                    </View>
-                  </View>
-                  <View style={styles.detailPickerWrapper}>
-                    <Picker
-                      selectedValue={item.categoryId}
-                      onValueChange={(val) => handleCategoryChange(item.id, val)}
-                      style={styles.detailPicker}
-                    >
-                      <Picker.Item label="未分類" value={null} color={theme.colors.text.muted} />
-                      {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
-                    </Picker>
-                  </View>
-                </View>
-              ))}
-            </View>
-            <View style={{ height: 100 }} />
-          </ScrollView>
+      <View style={isWide ? styles.mainContentWide : styles.mainContentMobile}>
+        <View style={isWide ? styles.masterPane : styles.fullPane}>
+          {loading ? (
+            <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
+          ) : (
+            <FlatList
+              data={receipts}
+              keyExtractor={(item) => item.id.toString()}
+              renderItem={renderItem}
+              contentContainerStyle={styles.list}
+              ListEmptyComponent={<Text style={styles.empty}>該当する履歴がありません</Text>}
+              initialNumToRender={15}
+            />
+          )}
         </View>
-      </Modal>
+
+        {isWide && (
+          <View style={styles.detailPane}>
+            <ReceiptDetailView receipt={selectedReceipt} />
+          </View>
+        )}
+      </View>
+
+      {!isWide && (
+        <Modal visible={!!selectedReceipt} animationType="slide" onRequestClose={() => setSelectedReceipt(null)}>
+          <View style={styles.modalContent}>
+            <View style={styles.detailHeader}>
+              <Text style={styles.detailTitleMobile} numberOfLines={1}>{selectedReceipt?.storeName || '店名不明'}</Text>
+              <TouchableOpacity onPress={() => setSelectedReceipt(null)}>
+                <Text style={styles.detailClose}>✕</Text>
+              </TouchableOpacity>
+            </View>
+            <ReceiptDetailView receipt={selectedReceipt} />
+          </View>
+        </Modal>
+      )}
     </View>
   );
 }
@@ -272,42 +275,101 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
-  backButton: { ...theme.typography.body, color: theme.colors.primary, fontWeight: '700' },
+  backButton: { color: theme.colors.primary, fontWeight: '700' },
   title: { ...theme.typography.h2, color: theme.colors.text.main },
   filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, justifyContent: 'space-between' },
-  pickerBox: { flex: 1, height: 48, backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.sm, marginHorizontal: theme.spacing.xs, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, elevation: 1 },
+  wideFilter: { justifyContent: 'flex-start', gap: 10 },
+  pickerBox: { flex: 1, height: 44, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border },
   filterPicker: { width: '100%' },
-  list: { paddingHorizontal: theme.spacing.md, paddingBottom: theme.spacing.xl },
-  card: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.md, marginBottom: theme.spacing.sm, borderWidth: 1, borderColor: theme.colors.border, ...Platform.select({ ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.05, shadowRadius: 4 }, android: { elevation: 2 } }) },
-  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: theme.spacing.sm },
-  date: { ...theme.typography.caption, color: theme.colors.text.muted },
-  store: { ...theme.typography.body, fontWeight: '700', color: theme.colors.text.main, flex: 1, marginLeft: theme.spacing.sm, textAlign: 'right' },
-  cardBody: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end' },
-  label: { ...theme.typography.caption, color: theme.colors.text.muted },
-  amount: { ...theme.typography.h2, color: theme.colors.primary },
-  itemCountBadge: { backgroundColor: theme.colors.background, paddingHorizontal: theme.spacing.sm, paddingVertical: 2, borderRadius: theme.borderRadius.round },
-  itemCountText: { ...theme.typography.caption, color: theme.colors.secondary },
+
+  mainContentMobile: { flex: 1 },
+  mainContentWide: { flex: 1, flexDirection: 'row', borderTopWidth: 1, borderTopColor: theme.colors.border },
+  masterPane: { width: 380, backgroundColor: theme.colors.surface, borderRightWidth: 1, borderRightColor: theme.colors.border },
+  fullPane: { flex: 1 },
+  detailPane: { flex: 1, backgroundColor: theme.colors.background },
+
+  list: { padding: theme.spacing.md },
+  card: { backgroundColor: theme.colors.surface, borderRadius: 12, padding: 15, marginBottom: 10, borderWidth: 1, borderColor: theme.colors.border },
+  activeCard: { borderColor: theme.colors.primary, backgroundColor: '#F0F7FF', elevation: 0, shadowOpacity: 0 },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 },
+  date: { fontSize: 12, color: theme.colors.text.muted },
+  store: { fontWeight: '700', color: theme.colors.text.main, flex: 1, marginLeft: 10, textAlign: 'right' },
+  cardBody: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  amount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary },
+  itemCountBadge: { backgroundColor: theme.colors.background, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
+  itemCountText: { fontSize: 10, color: theme.colors.secondary },
   empty: { textAlign: 'center', marginTop: 50, color: theme.colors.text.muted },
-  modalContent: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 50 : 20, paddingHorizontal: theme.spacing.lg },
-  detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: theme.spacing.lg, paddingBottom: theme.spacing.sm, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  detailTitle: { ...theme.typography.h2, flex: 1, color: theme.colors.text.main },
-  detailClose: { fontSize: 24, color: theme.colors.secondary, fontWeight: '300' },
-  detailScroll: { flex: 1 },
-  imageWrapper: { width: '100%', height: 300, backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, marginBottom: theme.spacing.lg, overflow: 'hidden', borderWidth: 1, borderColor: theme.colors.border },
+
+  placeholderContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  emptyText: { color: theme.colors.text.muted },
+  detailScroll: { flex: 1, padding: 20 },
+  detailHeaderInner: { marginBottom: 20 },
+  detailTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text.main },
+  detailDate: { fontSize: 14, color: theme.colors.text.muted, marginTop: 4 },
+  imageWrapper: { width: '100%', height: 400, backgroundColor: theme.colors.surface, borderRadius: 12, marginBottom: 20, borderWidth: 1, borderColor: theme.colors.border },
   receiptImage: { width: '100%', height: '100%' },
-  detailTotalContainer: { alignItems: 'flex-end', marginBottom: theme.spacing.xl },
-  detailTotalLabel: { ...theme.typography.caption, color: theme.colors.text.muted },
-  detailTotalValue: { ...theme.typography.h1, color: theme.colors.text.main },
-  itemsSection: { marginBottom: theme.spacing.md },
-  itemsSectionTitle: { ...theme.typography.caption, fontWeight: '700', color: theme.colors.secondary, marginBottom: theme.spacing.sm, textTransform: 'uppercase' },
-  detailItemRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: theme.spacing.md, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  detailItemInfo: { flex: 1 },
-  detailItemName: { ...theme.typography.body, fontSize: 14, color: theme.colors.text.main },
-  // 修正箇所：価格表示を横並びにするコンテナ
-  detailPriceContainer: { flexDirection: 'row', alignItems: 'baseline', marginTop: 2 },
-  detailItemPrice: { ...theme.typography.body, fontWeight: '700', color: theme.colors.primary },
-  // 追加箇所：単価・数量の補助テキスト
-  detailItemSub: { ...theme.typography.caption, color: theme.colors.text.muted, marginLeft: 4 },
-  detailPickerWrapper: { width: 140, height: 40, backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.sm, borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
-  detailPicker: { width: '100%' },
+  detailTotalContainer: { alignItems: 'flex-end', marginBottom: 30, paddingBottom: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  detailTotalLabel: { fontSize: 12, color: theme.colors.text.muted },
+  detailTotalValue: { fontSize: 32, fontWeight: 'bold', color: theme.colors.text.main },
+  
+  itemsSection: { marginBottom: 20 },
+  itemsSectionTitle: { fontSize: 12, fontWeight: '700', color: theme.colors.secondary, marginBottom: 10, textTransform: 'uppercase' },
+  
+  // --- ★ レイアウトを「縦積み」に変更：衝突を物理的に排除 ---
+  detailItemRow: { 
+    flexDirection: 'column', // 横並びをやめて縦並びにする
+    justifyContent: 'flex-start', 
+    alignItems: 'stretch', 
+    paddingVertical: 15, 
+    borderBottomWidth: 1, 
+    borderBottomColor: '#F0F0F0' 
+  },
+  detailItemTop: { 
+    marginBottom: 8, // Pickerとの間に余白を作る
+  },
+  detailItemBottom: { 
+    width: '100%',
+  },
+  detailItemName: { 
+    fontSize: 16, 
+    fontWeight: '600',
+    color: theme.colors.text.main,
+    marginBottom: 4,
+  },
+  detailPriceContainer: { 
+    flexDirection: 'row', 
+    alignItems: 'baseline',
+  },
+  detailItemPrice: { 
+    fontSize: 14,
+    fontWeight: '700', 
+    color: theme.colors.primary 
+  },
+  detailItemSub: { 
+    fontSize: 11, 
+    color: theme.colors.text.muted, 
+    marginLeft: 4 
+  },
+  detailPickerWrapper: { 
+    height: 44, // 少し高さを出して押しやすく
+    backgroundColor: theme.colors.surface, 
+    borderRadius: 8, 
+    borderWidth: 1, 
+    borderColor: theme.colors.border, 
+    overflow: 'hidden',
+    justifyContent: 'center'
+  },
+  detailPicker: { 
+    width: '100%',
+    ...Platform.select({
+      web: {
+        outlineStyle: 'none',
+      } as any
+    })
+  },
+
+  modalContent: { flex: 1, backgroundColor: theme.colors.background },
+  detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  detailTitleMobile: { fontSize: 18, fontWeight: 'bold', flex: 1 },
+  detailClose: { fontSize: 24, color: theme.colors.text.muted, marginLeft: 15 }
 });


### PR DESCRIPTION
## 概要
iPadおよびWebブラウザ環境において、履歴一覧画面（HistoryScreen）の利便性を向上させるため、
Master-Detail（2カラム）レイアウトを導入し、レスポンシブなUIへと刷新しました。

## 変更内容
- **Master-Detail レイアウトの導入**:
  - 画面幅800px以上で、左側に履歴リスト、右側に詳細パネルを常時表示する構成に変更。
  - ワイド画面時は、初期ロード時に最新のレシートを自動選択して表示するロジックを追加。
- **明細表示の安定化（衝突回避）**:
  - 商品名とカテゴリー選択（Picker）の重なりを解消するため、明細行を「縦積み」のレイアウトにリフォーム。
  - 商品名が長い場合やフォントサイズが異なる環境でも、絶対に表示が崩れない堅牢な設計に変更。
- **モバイル互換性の維持**:
  - スマホ環境では、従来通りの「リスト表示 ＋ スライドモーダル」の挙動を維持。
- **TypeScript 型定義の修正**:
  - Web環境専用の `outlineStyle` 指定における型エラーを、型キャスト（as any）を用いて解消。

## 確認事項
- [x] Webブラウザのウィンドウ幅を変更した際、1列（モバイル）と2列（ワイド）が正常に切り替わるか。
- [x] ワイド画面で左側のリストを選択した際、右側の詳細パネルが即座に更新されるか。
- [x] 商品名が長い項目において、Pickerと重ならずに正しく表示されるか。