### PR TITLE
PC/Web大画面におけるレシート詳細レイアウトの最適化と外枠制限の解除(#49-4)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -308,9 +308,12 @@ export default function App() {
     );
   }
 
+  // ★ 追加：現在のビューがフル幅（全幅）表示を許可すべき画面かどうかを判定
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master'].includes(currentView);
+
   if (!userToken) {
     return (
-      <ResponsiveContainer>
+      <ResponsiveContainer fullWidth={false}>
         <View style={styles.loginContainer}>
           <Text style={styles.loginTitle}>家計簿アプリ</Text>
           <Text style={styles.loginSub}>パスワードを入力して開始</Text>
@@ -427,7 +430,8 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <ResponsiveContainer>
+      {/* ★ 変更点: fullWidth プロパティに判定結果を渡す */}
+      <ResponsiveContainer fullWidth={isFullWidth}>
         <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
           {renderMainContent()}
         </View>

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View, Image, ScrollView, useWindowDimensions, Platform } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { theme } from '../theme';
+
+interface ReceiptDetailComponentProps {
+  receipt: any;
+  categories: any[];
+  onCategoryChange: (itemId: number, categoryId: number | null) => void;
+  baseUrl: string;
+  fullWidth?: boolean; // App.tsx 外枠の制限が解除されているかどうか
+}
+
+/**
+ * レシート詳細表示コンポーネント
+ * 画面幅に応じて、1カラム(モバイル)と2カラム(Web/iPad)を自動で切り替えます。
+ */
+export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
+  receipt,
+  categories,
+  onCategoryChange,
+  baseUrl,
+  fullWidth = true
+}) => {
+  const { width: windowWidth } = useWindowDimensions();
+  
+  // 外側の有効幅を計算。
+  // fullWidthがtrue（モーダル）なら画面全体、false（履歴画面）ならリスト分(350px)を差し引く。
+  const effectiveWidth = fullWidth ? windowWidth : windowWidth - 350;
+  
+  // 有効幅が 700px 以上確保できるなら横並び(2カラム)にする
+  const isWide = effectiveWidth > 700;
+
+  const cacheKey = useMemo(() => Date.now(), []);
+
+  if (!receipt) {
+    return (
+      <View style={styles.placeholderContainer}>
+        <Text style={styles.emptyText}>レシートを選択してください</Text>
+      </View>
+    );
+  }
+
+  const getImageUrl = (imagePath: string) => {
+    if (!imagePath) return null;
+    return `${baseUrl}/${imagePath}?v=${cacheKey}`;
+  };
+
+  const DetailContent = (
+    <View style={isWide ? styles.wideContentWrapper : styles.mobileContentWrapper}>
+      
+      {/* --- 左側：画像エリア（幅を 400px に固定。これ以上大きくさせず、右側にスペースを譲る） --- */}
+      <View style={isWide ? styles.wideImageColumn : styles.mobileImageArea}>
+        <View style={[styles.imageWrapper, !isWide && { height: 350 }]}>
+          {receipt.imagePath ? (
+            <Image 
+              source={{ uri: getImageUrl(receipt.imagePath) as string }}
+              style={styles.receiptImage}
+              resizeMode="contain"
+            />
+          ) : (
+            <View style={styles.noImagePlaceholder}>
+              <Text style={styles.emptyText}>画像なし</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* --- 右側：情報エリア（flex: 1 により、広がった分の余白をすべて店名表示に充てる） --- */}
+      <View style={isWide ? styles.wideInfoColumn : styles.mobileInfoArea}>
+        <View style={styles.detailHeaderInner}>
+          <Text style={styles.detailTitle} selectable={true}>
+            {receipt.storeName || '店名不明'}
+          </Text>
+          <Text style={styles.detailDate}>
+            {receipt.date ? new Date(receipt.date).toLocaleDateString('ja-JP') : '日付不明'}
+          </Text>
+        </View>
+
+        <View style={styles.detailTotalContainer}>
+          <Text style={styles.detailTotalLabel}>合計金額（税込）</Text>
+          <Text style={styles.detailTotalValue}>¥{(receipt.totalAmount || 0).toLocaleString()}</Text>
+        </View>
+
+        <View style={styles.itemsSection}>
+          <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
+          {receipt.items?.map((item: any) => (
+            <View key={item.id} style={styles.detailItemRow}>
+              <View style={styles.detailItemTop}>
+                <Text style={styles.detailItemName}>{item.name}</Text>
+                <View style={styles.detailPriceContainer}>
+                  <Text style={styles.detailItemPrice}>
+                    ¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}
+                  </Text>
+                  <Text style={styles.detailItemSub}>
+                    （¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）
+                  </Text>
+                </View>
+              </View>
+              <View style={styles.detailItemBottom}>
+                <View style={styles.detailPickerWrapper}>
+                  <Picker
+                    selectedValue={item.categoryId}
+                    onValueChange={(val) => onCategoryChange(item.id, val)}
+                    style={styles.detailPicker}
+                  >
+                    <Picker.Item label="カテゴリーを選択..." value={null} color={theme.colors.text.muted} />
+                    {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
+                  </Picker>
+                </View>
+              </View>
+            </View>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+
+  return (
+    <ScrollView 
+      style={styles.detailScroll} 
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ flexGrow: 1 }}
+    >
+      {DetailContent}
+      <View style={{ height: 50 }} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  detailScroll: { flex: 1 },
+  placeholderContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40 },
+  emptyText: { color: theme.colors.text.muted },
+
+  wideContentWrapper: { 
+    flexDirection: 'row', 
+    padding: 30, 
+    width: '100%', 
+    alignItems: 'flex-start' 
+  },
+  mobileContentWrapper: { flexDirection: 'column', padding: 20 },
+  
+  // ★ 画像エリアを「幅 400px」に固定することで、広がる器の影響を受けすぎないようにする
+  wideImageColumn: { width: 400, marginRight: 40 }, 
+  wideInfoColumn: { flex: 1 }, // ★ 外側の器が広がるほど、ここが横に長く伸びる
+  
+  mobileImageArea: { width: '100%', marginBottom: 25 },
+  mobileInfoArea: { width: '100%' },
+
+  imageWrapper: { 
+    width: '100%', 
+    height: 600, 
+    backgroundColor: '#fff', 
+    borderRadius: 12, 
+    borderWidth: 1, 
+    borderColor: theme.colors.border,
+    overflow: 'hidden'
+  },
+  noImagePlaceholder: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.surface },
+  receiptImage: { width: '100%', height: '100%' },
+
+  detailHeaderInner: { marginBottom: 20 },
+  detailTitle: { fontSize: 28, fontWeight: 'bold', color: theme.colors.text.main },
+  detailDate: { fontSize: 16, color: theme.colors.text.muted, marginTop: 4 },
+  detailTotalContainer: { 
+    alignItems: 'flex-end', 
+    marginBottom: 30, 
+    paddingBottom: 15, 
+    borderBottomWidth: 1, 
+    borderBottomColor: theme.colors.border 
+  },
+  detailTotalLabel: { fontSize: 13, color: theme.colors.text.muted },
+  detailTotalValue: { fontSize: 38, fontWeight: 'bold', color: theme.colors.text.main },
+  
+  itemsSection: { marginBottom: 20 },
+  itemsSectionTitle: { fontSize: 12, fontWeight: '700', color: theme.colors.secondary, marginBottom: 15, textTransform: 'uppercase' },
+  
+  detailItemRow: { 
+    flexDirection: 'column', 
+    paddingVertical: 15, 
+    borderBottomWidth: 1, 
+    borderBottomColor: '#F0F0F0' 
+  },
+  detailItemTop: { marginBottom: 10 },
+  detailItemBottom: { width: '100%' },
+  detailItemName: { fontSize: 17, fontWeight: '600', color: theme.colors.text.main, marginBottom: 4 },
+  detailPriceContainer: { flexDirection: 'row', alignItems: 'baseline' },
+  detailItemPrice: { fontWeight: '700', color: theme.colors.primary },
+  detailItemSub: { fontSize: 11, color: theme.colors.text.muted, marginLeft: 4 },
+  
+  detailPickerWrapper: { 
+    height: 48, 
+    backgroundColor: theme.colors.surface, 
+    borderRadius: 8, 
+    borderWidth: 1, 
+    borderColor: theme.colors.border, 
+    overflow: 'hidden',
+    justifyContent: 'center'
+  },
+  detailPicker: { 
+    width: '100%',
+    ...Platform.select({
+      web: { outlineStyle: 'none' } as any
+    })
+  },
+});

--- a/frontend/src/components/ResponsiveContainer.tsx
+++ b/frontend/src/components/ResponsiveContainer.tsx
@@ -4,17 +4,18 @@ import { useResponsive } from '../hooks/useResponsive';
 
 interface Props {
   children: React.ReactNode;
+  fullWidth?: boolean; // ★ 追加：制限を解除して100%広げるためのスイッチ
 }
 
 /**
- * Web/iPad表示の時にコンテンツが横に広がりすぎないように制限するコンテナ
+ * Web/iPad表示の時にコンテンツの幅を制御するコンテナ
  */
-export const ResponsiveContainer: React.FC<Props> = ({ children }) => {
+export const ResponsiveContainer: React.FC<Props> = ({ children, fullWidth }) => {
   const { isWideScreen } = useResponsive();
 
-  // Webかつ広い画面の時だけ、最大幅(600px)を適用して中央寄せ
+  // Webかつ広い画面で、かつ fullWidth フラグが立っていない時だけ最大幅(600px)を適用
   const isWebWide = Platform.OS === 'web' && isWideScreen;
-  const containerStyle = isWebWide ? styles.wideContainer : styles.mobileContainer;
+  const containerStyle = (isWebWide && !fullWidth) ? styles.wideContainer : styles.mobileContainer;
 
   return (
     <View style={styles.outer}>
@@ -40,8 +41,7 @@ const styles = StyleSheet.create({
     maxWidth: '100%',
   },
   wideContainer: {
-    maxWidth: 600,             // iPad/PCで見た時のアプリの横幅
-    // 左右に薄い境界線を入れると、Webサイトっぽさが増します
+    maxWidth: 600,             // iPad/PCで見た時の通常のアプリ横幅
     borderLeftWidth: 1,
     borderRightWidth: 1,
     borderColor: '#e9ecef',

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { StyleSheet, Text, View, FlatList, TouchableOpacity, ActivityIndicator, Image, ScrollView, Modal, Platform, Alert, useWindowDimensions } from 'react-native';
+import { StyleSheet, Text, View, FlatList, TouchableOpacity, ActivityIndicator, Modal, Platform, Alert, useWindowDimensions } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
+// 共通コンポーネントをインポート
+import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
 interface HistoryScreenProps {
   onBack: () => void;
@@ -20,8 +22,6 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
   
   const [selectedMonth, setSelectedMonth] = useState('');
   const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
-
-  const cacheKey = useMemo(() => Date.now(), []);
 
   const months = useMemo(() => {
     return Array.from({ length: 6 }).map((_, i) => {
@@ -105,80 +105,6 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
     }
   };
 
-  const getImageUrl = useCallback((imagePath: string) => {
-    if (!imagePath) return null;
-    return `${BASE_URL}/${imagePath}?v=${cacheKey}`;
-  }, [BASE_URL, cacheKey]);
-
-  const ReceiptDetailView = ({ receipt }: { receipt: any }) => {
-    if (!receipt) {
-      return (
-        <View style={styles.placeholderContainer}>
-          <Text style={styles.emptyText}>レシートを選択してください</Text>
-        </View>
-      );
-    }
-
-    return (
-      <ScrollView style={styles.detailScroll} showsVerticalScrollIndicator={false}>
-        <View style={styles.detailHeaderInner}>
-          <Text style={styles.detailTitle} numberOfLines={2}>{receipt.storeName || '店名不明'}</Text>
-          <Text style={styles.detailDate}>
-            {receipt.date ? new Date(receipt.date).toLocaleDateString('ja-JP') : '日付不明'}
-          </Text>
-        </View>
-
-        {receipt.imagePath && (
-          <View style={styles.imageWrapper}>
-            <Image 
-              source={{ uri: getImageUrl(receipt.imagePath) as string }}
-              style={styles.receiptImage}
-              resizeMode="contain"
-            />
-          </View>
-        )}
-
-        <View style={styles.detailTotalContainer}>
-          <Text style={styles.detailTotalLabel}>合計金額（税込）</Text>
-          <Text style={styles.detailTotalValue}>¥{(receipt.totalAmount || 0).toLocaleString()}</Text>
-        </View>
-
-        <View style={styles.itemsSection}>
-          <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
-          {receipt.items?.map((item: any) => (
-            <View key={item.id} style={styles.detailItemRow}>
-              {/* 情報を縦に積むスタイルに変更し、衝突を回避 */}
-              <View style={styles.detailItemTop}>
-                <Text style={styles.detailItemName}>{item.name}</Text>
-                <View style={styles.detailPriceContainer}>
-                  <Text style={styles.detailItemPrice}>
-                    ¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}
-                  </Text>
-                  <Text style={styles.detailItemSub}>
-                    （¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）
-                  </Text>
-                </View>
-              </View>
-              <View style={styles.detailItemBottom}>
-                <View style={styles.detailPickerWrapper}>
-                  <Picker
-                    selectedValue={item.categoryId}
-                    onValueChange={(val) => handleCategoryChange(item.id, val)}
-                    style={styles.detailPicker}
-                  >
-                    <Picker.Item label="カテゴリーを選択..." value={null} color={theme.colors.text.muted} />
-                    {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} />)}
-                  </Picker>
-                </View>
-              </View>
-            </View>
-          ))}
-        </View>
-        <View style={{ height: 50 }} />
-      </ScrollView>
-    );
-  };
-
   const renderItem = ({ item }: { item: any }) => {
     const isSelected = selectedReceipt?.id === item.id;
     return (
@@ -207,52 +133,63 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-          <Text style={styles.backButton}>← 戻る</Text>
-        </TouchableOpacity>
-        <Text style={styles.title}>レシート履歴</Text>
-        <View style={{ width: 40 }} />
-      </View>
-
-      <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
-        <View style={[styles.pickerBox, isWide && { maxWidth: 250 }]}>
-          <Picker selectedValue={selectedMonth} onValueChange={setSelectedMonth} style={styles.filterPicker}>
-            <Picker.Item label="全期間" value="" />
-            {months.map(m => (
-              <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
-            ))}
-          </Picker>
+      {/* 画面幅いっぱいに広がるためのラッパー */}
+      <View style={styles.mainWrapper}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
+            <Text style={styles.backButton}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>レシート履歴</Text>
+          <View style={{ width: 40 }} />
         </View>
-        <View style={[styles.pickerBox, isWide && { maxWidth: 200 }]}>
-          <Picker selectedValue={selectedMember} onValueChange={setSelectedMember} style={styles.filterPicker}>
-            <Picker.Item label="自分" value="1" />
-            <Picker.Item label="その他" value="2" />
-          </Picker>
-        </View>
-      </View>
 
-      <View style={isWide ? styles.mainContentWide : styles.mainContentMobile}>
-        <View style={isWide ? styles.masterPane : styles.fullPane}>
-          {loading ? (
-            <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
-          ) : (
-            <FlatList
-              data={receipts}
-              keyExtractor={(item) => item.id.toString()}
-              renderItem={renderItem}
-              contentContainerStyle={styles.list}
-              ListEmptyComponent={<Text style={styles.empty}>該当する履歴がありません</Text>}
-              initialNumToRender={15}
-            />
+        <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
+          <View style={[styles.pickerBox, isWide && { width: 250, flex: 0 }]}>
+            <Picker selectedValue={selectedMonth} onValueChange={setSelectedMonth} style={styles.filterPicker}>
+              <Picker.Item label="全期間" value="" />
+              {months.map(m => (
+                <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
+              ))}
+            </Picker>
+          </View>
+          <View style={[styles.pickerBox, isWide && { width: 200, flex: 0 }]}>
+            <Picker selectedValue={selectedMember} onValueChange={setSelectedMember} style={styles.filterPicker}>
+              <Picker.Item label="自分" value="1" />
+              <Picker.Item label="その他" value="2" />
+            </Picker>
+          </View>
+        </View>
+
+        <View style={isWide ? styles.mainContentWide : styles.mainContentMobile}>
+          {/* 左側：リスト（幅350px固定） */}
+          <View style={isWide ? styles.masterPane : styles.fullPane}>
+            {loading ? (
+              <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
+            ) : (
+              <FlatList
+                data={receipts}
+                keyExtractor={(item) => item.id.toString()}
+                renderItem={renderItem}
+                contentContainerStyle={styles.list}
+                ListEmptyComponent={<Text style={styles.empty}>該当する履歴がありません</Text>}
+                initialNumToRender={15}
+              />
+            )}
+          </View>
+
+          {/* 右側：詳細表示（flex: 1 で残りのスペース全てを使う） */}
+          {isWide && (
+            <View style={styles.detailPane}>
+              <ReceiptDetailComponent 
+                receipt={selectedReceipt}
+                categories={categories}
+                onCategoryChange={handleCategoryChange}
+                baseUrl={BASE_URL}
+                fullWidth={false} // リスト共有モード
+              />
+            </View>
           )}
         </View>
-
-        {isWide && (
-          <View style={styles.detailPane}>
-            <ReceiptDetailView receipt={selectedReceipt} />
-          </View>
-        )}
       </View>
 
       {!isWide && (
@@ -264,7 +201,13 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
                 <Text style={styles.detailClose}>✕</Text>
               </TouchableOpacity>
             </View>
-            <ReceiptDetailView receipt={selectedReceipt} />
+            <ReceiptDetailComponent 
+              receipt={selectedReceipt}
+              categories={categories}
+              onCategoryChange={handleCategoryChange}
+              baseUrl={BASE_URL}
+              fullWidth={true} // モーダル全幅モード
+            />
           </View>
         </Modal>
       )}
@@ -273,19 +216,23 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  mainWrapper: { flex: 1, width: '100%', alignSelf: 'stretch', paddingTop: Platform.OS === 'ios' ? 60 : 20 },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
   backButton: { color: theme.colors.primary, fontWeight: '700' },
   title: { ...theme.typography.h2, color: theme.colors.text.main },
-  filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, justifyContent: 'space-between' },
-  wideFilter: { justifyContent: 'flex-start', gap: 10 },
+  filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 10 },
+  wideFilter: { justifyContent: 'flex-start' },
   pickerBox: { flex: 1, height: 44, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border },
   filterPicker: { width: '100%' },
 
   mainContentMobile: { flex: 1 },
   mainContentWide: { flex: 1, flexDirection: 'row', borderTopWidth: 1, borderTopColor: theme.colors.border },
-  masterPane: { width: 380, backgroundColor: theme.colors.surface, borderRightWidth: 1, borderRightColor: theme.colors.border },
+  
+  masterPane: { width: 350, backgroundColor: theme.colors.surface, borderRightWidth: 1, borderRightColor: theme.colors.border },
   fullPane: { flex: 1 },
+  
+  // ★ デバッグ用黄色を消し、本来の背景色に修正
   detailPane: { flex: 1, backgroundColor: theme.colors.background },
 
   list: { padding: theme.spacing.md },
@@ -299,74 +246,6 @@ const styles = StyleSheet.create({
   itemCountBadge: { backgroundColor: theme.colors.background, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
   itemCountText: { fontSize: 10, color: theme.colors.secondary },
   empty: { textAlign: 'center', marginTop: 50, color: theme.colors.text.muted },
-
-  placeholderContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  emptyText: { color: theme.colors.text.muted },
-  detailScroll: { flex: 1, padding: 20 },
-  detailHeaderInner: { marginBottom: 20 },
-  detailTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text.main },
-  detailDate: { fontSize: 14, color: theme.colors.text.muted, marginTop: 4 },
-  imageWrapper: { width: '100%', height: 400, backgroundColor: theme.colors.surface, borderRadius: 12, marginBottom: 20, borderWidth: 1, borderColor: theme.colors.border },
-  receiptImage: { width: '100%', height: '100%' },
-  detailTotalContainer: { alignItems: 'flex-end', marginBottom: 30, paddingBottom: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  detailTotalLabel: { fontSize: 12, color: theme.colors.text.muted },
-  detailTotalValue: { fontSize: 32, fontWeight: 'bold', color: theme.colors.text.main },
-  
-  itemsSection: { marginBottom: 20 },
-  itemsSectionTitle: { fontSize: 12, fontWeight: '700', color: theme.colors.secondary, marginBottom: 10, textTransform: 'uppercase' },
-  
-  // --- ★ レイアウトを「縦積み」に変更：衝突を物理的に排除 ---
-  detailItemRow: { 
-    flexDirection: 'column', // 横並びをやめて縦並びにする
-    justifyContent: 'flex-start', 
-    alignItems: 'stretch', 
-    paddingVertical: 15, 
-    borderBottomWidth: 1, 
-    borderBottomColor: '#F0F0F0' 
-  },
-  detailItemTop: { 
-    marginBottom: 8, // Pickerとの間に余白を作る
-  },
-  detailItemBottom: { 
-    width: '100%',
-  },
-  detailItemName: { 
-    fontSize: 16, 
-    fontWeight: '600',
-    color: theme.colors.text.main,
-    marginBottom: 4,
-  },
-  detailPriceContainer: { 
-    flexDirection: 'row', 
-    alignItems: 'baseline',
-  },
-  detailItemPrice: { 
-    fontSize: 14,
-    fontWeight: '700', 
-    color: theme.colors.primary 
-  },
-  detailItemSub: { 
-    fontSize: 11, 
-    color: theme.colors.text.muted, 
-    marginLeft: 4 
-  },
-  detailPickerWrapper: { 
-    height: 44, // 少し高さを出して押しやすく
-    backgroundColor: theme.colors.surface, 
-    borderRadius: 8, 
-    borderWidth: 1, 
-    borderColor: theme.colors.border, 
-    overflow: 'hidden',
-    justifyContent: 'center'
-  },
-  detailPicker: { 
-    width: '100%',
-    ...Platform.select({
-      web: {
-        outlineStyle: 'none',
-      } as any
-    })
-  },
 
   modalContent: { flex: 1, backgroundColor: theme.colors.background },
   detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -5,12 +5,14 @@ import { PieChart } from 'react-native-chart-kit';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 import { theme } from '../theme';
+// ★ 共通コンポーネントをインポート
+import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
 // --- interface 定義 ---
 interface Category { id: number; name: string; color: string; }
 interface StatItem { categoryId: number | null; categoryName: string; totalAmount: number | string; color: string; }
 interface ReceiptItem { id: number; name: string; price: number; quantity: number; categoryId: number; category?: { name: string; color: string }; }
-interface ReceiptInfo { id: number; imagePath: string | null; storeName: string; totalAmount: number; items: ReceiptItem[]; }
+interface ReceiptInfo { id: number; imagePath: string | null; storeName: string; totalAmount: number; items: ReceiptItem[]; date?: string; }
 interface MonthlyData { month: string; totalAmount: number; prevTotal: number; diffAmount: number; diffPercentage: number; stats: StatItem[]; latestReceipt: ReceiptInfo | null; }
 
 interface TrendData { period: string; total: number; prev_total: number | null; }
@@ -24,7 +26,7 @@ interface StatisticsScreenProps {
 
 export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId, onBack }) => {
   const { width: windowWidth } = useWindowDimensions();
-  const isWide = windowWidth > 768; // iPad/Web 判定
+  const isWide = windowWidth > 768;
 
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
@@ -33,8 +35,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const [allCategories, setAllCategories] = useState<Category[]>([]);
   
   const [isMainModalVisible, setMainModalVisible] = useState(false);
-  const [isPickerVisible, setPickerVisible] = useState(false);
-  const [selectedItemId, setSelectedItemId] = useState<number | null>(null);
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
@@ -85,14 +85,18 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const handleUpdateCategory = async (categoryId: number) => {
-    if (!selectedItemId) return;
+  // ★ 共通コンポーネント用のカテゴリー更新関数
+  const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
+    if (!categoryId) return;
     try {
-      await apiClient.patch(`/receipt-items/${selectedItemId}`, { categoryId }, { headers: { 'x-member-id': currentMemberId.toString() } });
-      setPickerVisible(false);
-      await fetchData();
-      Alert.alert("完了", "カテゴリーを更新しました");
-    } catch (error) { Alert.alert("エラー", "更新に失敗しました"); }
+      await apiClient.patch(`/receipt-items/${itemId}`, 
+        { categoryId: Number(categoryId) }, 
+        { headers: { 'x-member-id': currentMemberId.toString() } }
+      );
+      await fetchData(); // レポートの数値を再読込
+    } catch (error) {
+      Alert.alert("エラー", "カテゴリーの更新に失敗しました");
+    }
   };
 
   const chartData = useMemo(() => {
@@ -111,7 +115,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       .filter(s => s.population > 0);
   }, [data?.stats]);
 
-  // チャートの幅を計算（ワイド時は固定、モバイル時は画面幅）
   const chartWidth = isWide ? 400 : windowWidth - 60;
 
   return (
@@ -141,7 +144,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         ) : (
           <View style={isWide ? styles.dashboardGrid : null}>
             
-            {/* --- 左カラム (サマリー & チャート) --- */}
+            {/* 左カラム */}
             <View style={isWide ? styles.leftColumn : null}>
               <View style={styles.summaryCard}>
                 <Text style={styles.summaryLabel}>当月合計支出</Text>
@@ -178,7 +181,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                   <TouchableOpacity style={styles.receiptPreviewCard} onPress={() => setMainModalVisible(true)}>
                     <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.receiptImage} resizeMode="cover" />
                     <View style={styles.receiptInfoOverlay}>
-                      {/* ★店名を flex: 1 で包んで金額を保護 */}
                       <View style={{ flex: 1, marginRight: 10 }}>
                         <Text style={styles.receiptStoreName} numberOfLines={1}>
                           {data.latestReceipt.storeName || '店名不明'}
@@ -193,7 +195,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
               </View>
             </View>
 
-            {/* --- 右カラム (トレンド & パレート) --- */}
+            {/* 右カラム */}
             <View style={isWide ? styles.rightColumn : null}>
               <View style={styles.section}>
                 <Text style={styles.sectionTitle}>月次推移 (MoM Trend)</Text>
@@ -239,8 +241,8 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         )}
       </ScrollView>
 
-      {/* 詳細 Modal */}
-      <Modal visible={isMainModalVisible} animationType="slide" transparent={isWide}>
+      {/* --- ★ 修正: 解析レシート詳細 Modal --- */}
+      <Modal visible={isMainModalVisible} animationType="slide" transparent={isWide} onRequestClose={() => setMainModalVisible(false)}>
         <View style={isWide ? styles.modalOverlay : styles.modalContainer}>
           <SafeAreaView style={[styles.modalContainer, isWide && styles.wideModal]}>
             <View style={styles.modalHeader}>
@@ -249,53 +251,16 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                 <Text style={styles.modalCloseText}>閉じる</Text>
               </TouchableOpacity>
             </View>
-            <ScrollView style={styles.modalScroll}>
-              {data?.latestReceipt?.imagePath && (
-                <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.modalImage} resizeMode="contain" />
-              )}
-              <View style={styles.itemListContainer}>
-                {data?.latestReceipt?.items.map((item) => (
-                  <View key={item.id} style={styles.itemRow}>
-                    <View style={{ flex: 1 }}>
-                      <Text style={styles.itemName}>{item.name}</Text>
-                      <View style={styles.itemPriceDetailRow}>
-                        <Text style={styles.itemPrice}>¥{((item.price || 0) * (item.quantity || 1)).toLocaleString()}</Text>
-                        <Text style={styles.itemSubText}>（¥{(item.price || 0).toLocaleString()} × {item.quantity || 1}）</Text>
-                      </View>
-                    </View>
-                    <TouchableOpacity 
-                      style={[styles.categoryBadge, { backgroundColor: item.category?.color || theme.colors.secondary }]}
-                      onPress={() => { setSelectedItemId(item.id); setPickerVisible(true); }}
-                    >
-                      <Text style={styles.categoryBadgeText}>{item.category?.name || '未分類'}</Text>
-                    </TouchableOpacity>
-                  </View>
-                ))}
-              </View>
-            </ScrollView>
-          </SafeAreaView>
-        </View>
-      </Modal>
-
-      {/* カテゴリ変更 Modal */}
-      <Modal visible={isPickerVisible} transparent={true} animationType="fade">
-        <View style={styles.pickerOverlay}>
-          <View style={[styles.pickerWindow, isWide && { width: 400 }]}>
-            <Text style={styles.pickerHeader}>カテゴリー変更</Text>
-            <FlatList
-              data={allCategories}
-              keyExtractor={(item) => item.id.toString()}
-              renderItem={({ item }) => (
-                <TouchableOpacity style={styles.pickerItem} onPress={() => handleUpdateCategory(item.id)}>
-                  <View style={[styles.colorDot, { backgroundColor: item.color }]} />
-                  <Text style={styles.pickerItemText}>{item.name}</Text>
-                </TouchableOpacity>
-              )}
+            
+            {/* ★ 共通コンポーネントに差し替え */}
+            <ReceiptDetailComponent 
+              receipt={data?.latestReceipt}
+              categories={allCategories}
+              onCategoryChange={handleCategoryChange}
+              baseUrl={BASE_URL}
+              fullWidth={true} // モーダルなので広々と使う
             />
-            <TouchableOpacity style={styles.pickerCancel} onPress={() => setPickerVisible(false)}>
-              <Text style={styles.pickerCancelText}>キャンセル</Text>
-            </TouchableOpacity>
-          </View>
+          </SafeAreaView>
         </View>
       </Modal>
     </SafeAreaView>
@@ -313,7 +278,6 @@ const styles = StyleSheet.create({
   monthPickerContainer: { backgroundColor: theme.colors.surface, borderRadius: 10, marginTop: 8, borderWidth: 1, borderColor: theme.colors.border, height: 50, justifyContent: 'center' },
   monthPicker: { width: '100%' },
 
-  // --- Dashboard Grid (iPad/Web用) ---
   dashboardGrid: { flexDirection: 'row', justifyContent: 'space-between' },
   leftColumn: { flex: 1.2, marginRight: 20 },
   rightColumn: { flex: 1 },
@@ -342,37 +306,17 @@ const styles = StyleSheet.create({
   noDataText: { fontSize: 12, color: theme.colors.text.muted },
   receiptPreviewCard: { backgroundColor: theme.colors.surface, borderRadius: 12, overflow: 'hidden', borderWidth: 1, borderColor: theme.colors.border },
   receiptImage: { width: '100%', height: 160, backgroundColor: theme.colors.border },
-  
-  // --- 修正: レシート情報のオーバーレイ ---
   receiptInfoOverlay: { padding: 15, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', minHeight: 60 },
   receiptStoreName: { fontWeight: '700', color: theme.colors.text.main },
   receiptAmount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary, minWidth: 80, textAlign: 'right' },
-
   noImageBox: { height: 100, backgroundColor: theme.colors.border, borderRadius: 12, justifyContent: 'center', alignItems: 'center' },
 
-  // --- Modal Adjustments ---
-  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  // --- Modal (壁の撤去) ---
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'center', alignItems: 'center' },
   modalContainer: { flex: 1, backgroundColor: theme.colors.background },
-  wideModal: { width: 600, maxHeight: '80%', borderRadius: 20, overflow: 'hidden' },
+  // ★ 修正：maxWidth を 1400px に拡張し、画面いっぱいに広がるように変更
+  wideModal: { width: '95%', maxWidth: 1400, height: '90%', borderRadius: 20, overflow: 'hidden' },
   modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   modalTitle: { fontSize: 18, fontWeight: 'bold' },
-  modalCloseText: { color: theme.colors.error, fontWeight: '600' },
-  modalScroll: { flex: 1 },
-  modalImage: { width: '100%', height: 300, marginVertical: 15 },
-  itemListContainer: { paddingHorizontal: 20, paddingBottom: 30 },
-  itemRow: { flexDirection: 'row', paddingVertical: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border, alignItems: 'center' },
-  itemName: { flex: 1, fontSize: 14 },
-  itemPriceDetailRow: { flexDirection: 'row', alignItems: 'baseline', marginTop: 2 },
-  itemPrice: { fontWeight: '700', color: theme.colors.primary },
-  itemSubText: { fontSize: 10, color: theme.colors.text.muted, marginLeft: 4 },
-  categoryBadge: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 20, marginLeft: 10 },
-  categoryBadgeText: { color: 'white', fontWeight: '700', fontSize: 10 },
-  pickerOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center' },
-  pickerWindow: { width: '85%', maxHeight: '70%', backgroundColor: theme.colors.surface, borderRadius: 15, padding: 20 },
-  pickerHeader: { fontSize: 18, fontWeight: 'bold', marginBottom: 15, textAlign: 'center' },
-  pickerItem: { flexDirection: 'row', alignItems: 'center', paddingVertical: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  colorDot: { width: 14, height: 14, borderRadius: 7, marginRight: 15 },
-  pickerItemText: { fontSize: 16 },
-  pickerCancel: { marginTop: 15, alignItems: 'center' },
-  pickerCancelText: { color: theme.colors.error, fontWeight: '700' }
+  modalCloseText: { color: theme.colors.error, fontWeight: '600', fontSize: 16 }
 });


### PR DESCRIPTION
概要

PCおよびWebブラウザの大画面環境において、レシート詳細表示が狭い領域（600px）に制限されていた問題を解消しました。アプリ全体の外枠制限を動的に解除できる仕組みを導入し、広大な画面幅を活かした2カラムレイアウトを実現しています。
主な変更点

    外枠制限の解除 (ResponsiveContainer.tsx / App.tsx)

        Web表示時に一律でかかっていた maxWidth: 600 の制限を、プロパティで制御可能に変更。

        履歴画面、分析画面などの情報量が多い画面では画面幅100%を使い切る設定を適用。

    詳細表示の共通コンポーネント化 (ReceiptDetailComponent.tsx)

        履歴画面と統計画面でバラバラだった詳細表示を一本化。

        画像エリアを固定幅（400px）に抑え、店名や金額が表示されるテキストエリアに flex: 1 を割り当てることで、大画面でも文字が縦に潰れない「1列表示」を保証。

    各画面への適用

        HistoryScreen.tsx: 右側の詳細パネル（黄色枠だった箇所）を全幅に拡張し、背景色をテーマカラーに統一。

        StatisticsScreen.tsx: レシート詳細モーダルの幅制限を撤廃し、大画面でも見やすいワイドモーダルに変更。

修正後の挙動

    ブラウザの幅を広げると、詳細エリアが追従して右側に広がり、店名が改行されずに表示される。

    画像と情報が適切な比率（画像固定：情報可変）で横並びになる。