### PR TITLE
T320上でのNginxホスティング環境構築と開発サーバーの並置対応` (#49-5)

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import dotenv from 'dotenv';
 
-// --- [Issue #43] BullMQ & Redis ---
+// --- [Issue #43] BullMQ & Redis Worker ---
 import './workers/receiptWorker'; 
 
 // --- ユーティリティ & ミドルウェア ---
@@ -31,12 +31,17 @@ const host = process.env.HOST || '0.0.0.0';
 // --- 1. 基本ミドルウェア設定 ---
 
 /**
- * [Web対応] CORS設定を緩和
- * 開発環境においてブラウザ(localhost)からT320のIPへの通信を許可するため、
- * origin: true (リクエスト元をそのまま許可) に設定します。
+ * [Issue #49-5] CORS設定の高度化
+ * 運用環境(8080)と開発環境(8081)の両方のオリジンを許可するため、
+ * 環境変数をカンマ区切りでパースして配列化します。
  */
+const rawOrigins = process.env.CORS_ORIGIN || '';
+const allowedOrigins = rawOrigins.includes(',') 
+  ? rawOrigins.split(',').map(o => o.trim())
+  : rawOrigins || true; // 環境変数が空の場合は全許可(開発時フォールバック)
+
 app.use(cors({
-  origin: true, 
+  origin: allowedOrigins,
   methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'x-member-id'],
   credentials: true
@@ -44,7 +49,7 @@ app.use(cors({
 
 app.use(express.json());
 
-// 静的ファイルの提供
+// 静的ファイルの提供 (レシート画像等)
 const uploadDir = path.join(process.cwd(), 'uploads');
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
@@ -53,20 +58,35 @@ app.use('/uploads', express.static(uploadDir));
 
 // --- 2. ルート登録 ---
 
+// ヘルスチェック (NginxやDockerからの監視用)
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
 // 認証なしルート
 app.use('/api/auth', authRoutes);
 
 /**
- * [重要] 認証・テナント必須ルート
+ * 認証・テナント必須ルート
+ * ミドルウェアの順序: 認証 -> テナントコンテキスト設定
  */
 app.use('/api', receiptRoutes);
 app.use('/api/categories', authMiddleware, tenantMiddleware, categoryRoutes);
 app.use('/api/product-master', authMiddleware, tenantMiddleware, productMasterRoutes);
 
-// 404 & Error Handler
-app.use((req, res, next) => next(new AppError(`Not Found - ${req.originalUrl}`, 404)));
+// --- 3. エラーハンドリング ---
+
+// 404 Handler
+app.use((req, res, next) => {
+  next(new AppError(`Not Found - ${req.originalUrl}`, 404));
+});
+
+// Global Error Handler
 app.use(errorHandler);
+
+// --- 4. サーバー起動 ---
 
 app.listen(Number(port), host, () => {
   logger.info(`🚀 API Server running on http://${host}:${port}`);
+  logger.info(`[CORS] Allowed Origins: ${JSON.stringify(allowedOrigins)}`);
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     user: "${UID}:${GID}"
-    command: npm run dev
+    # 運用時は Dockerfile 内の CMD (node dist/index.js) を優先
+    # 開発時にホットリロードが必要なら command: npm run dev で上書き
     volumes:
       - ./backend:/app
       - /etc/localtime:/etc/localtime:ro
-      # レシート画像の永続化（明示的なバインドマウント）
       - ./backend/uploads:/app/uploads
     ports:
       - "${BACKEND_PORT:-3000}:3000"
@@ -19,26 +19,48 @@ services:
       - ./backend/.env
     environment:
       - TZ=Asia/Tokyo
+      - NODE_ENV=production
+      # [重要] 運用版(8080)と開発版(8081)の両方のオリジンを許可
+      - CORS_ORIGIN=http://${T320_IP:-192.168.1.32}:8080,http://${T320_IP:-192.168.1.32}:8081
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
 
-  # --- Frontend (Expo / React Native) ---
+  # --- Frontend (運用・検証用: Nginx Hosting) ---
+  # 常時稼働・安定動作 (http://IP:8080)
   frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.web
+      args:
+        # ビルド時にAPI URLを確定させ、JSバイナリ内に埋め込む
+        - EXPO_PUBLIC_API_URL=http://${T320_IP:-192.168.1.32}:${BACKEND_PORT:-3000}/api
+    container_name: "${COMPOSE_PROJECT_NAME:-receipt}-frontend-web"
+    ports:
+      - "8080:80"
+    restart: always
+    environment:
+      - TZ=Asia/Tokyo
+    depends_on:
+      - backend
+
+  # --- Frontend (開発用: Expo Dev Server) ---
+  # デバッグ・ホットリロード用 (http://IP:8081)
+  frontend-dev:
     build:
       context: ./frontend
       dockerfile: Dockerfile
     user: "${UID}:${GID}"
-    command: npx expo start
+    command: npx expo start --web --port 8081 --host lan
     volumes:
       - ./frontend:/app
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - "${FRONTEND_PORT:-8081}:8081"
-      - "${EXPO_PORT_1:-19000}:19000"
-      - "${EXPO_PORT_2:-19001}:19001"
+      - "8081:8081"
+      - "19000:19000"
+      - "19001:19001"
     stdin_open: true
     tty: true
     env_file:
@@ -47,6 +69,8 @@ services:
       - TZ=Asia/Tokyo
       - EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
       - REACT_NATIVE_PACKAGER_HOSTNAME=${T320_IP:-192.168.1.32}
+    depends_on:
+      - backend
 
   # --- Database (PostgreSQL) ---
   db:
@@ -58,7 +82,6 @@ services:
       - POSTGRES_DB=${DB_NAME:-receipt_db}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
-      # 名前付きボリュームではなく、カレントディレクトリの pgdata に保存
       - ./pgdata:/var/lib/postgresql/data
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -76,7 +99,6 @@ services:
     environment:
       - TZ=Asia/Tokyo
     volumes:
-      # redisdata ディレクトリに永続化
       - ./redisdata:/data
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -86,5 +108,3 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-
-# 名前付きボリューム定義は不要になったため削除

--- a/frontend/Dockerfile.web
+++ b/frontend/Dockerfile.web
@@ -1,0 +1,32 @@
+# --- Stage 1: Build ---
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# 依存関係のインストール (キャッシュ利用)
+COPY package*.json ./
+RUN npm install
+
+# ソースコピー
+COPY . .
+
+# [重要] Expo Webのビルド時にAPI URLを静的に埋め込む
+# 実行時ではなくビルド時に確定させる必要があります
+ARG EXPO_PUBLIC_API_URL
+ENV EXPO_PUBLIC_API_URL=${EXPO_PUBLIC_API_URL}
+
+# 静的書き出し (distフォルダが生成される)
+RUN npx expo export --platform web
+
+# --- Stage 2: Serve ---
+FROM nginx:stable-alpine
+
+# SPA用のNginx設定をコピー
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# ビルド成果物をNginxの公開ディレクトリへコピー
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        # React Navigation等のSPAルーティング対応
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Expo資産のキャッシュ設定
+    location /_expo/ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
**説明:**
```markdown
## 概要
Issue #49-5に基づき、T320上のDocker環境でExpo Web版を常時ホスティングする環境を構築しました。
あわせて、開発効率を落とさないよう従来のExpo Dev Serverも並置可能にし、両オリジンからの通信を許容するインフラ構成にアップデートしています。

## 変更内容
- **運用環境の構築**: `Dockerfile.web` (Nginx) を作成し、ポート 8080 で静的配信を開始。
- **開発環境の維持**: `frontend-dev` サービスを追加し、ポート 8081 でホットリロード可能な環境を確保。
- **CORS対応**: `backend/src/index.ts` を改修し、環境変数 `CORS_ORIGIN` のカンマ区切り指定による複数オリジン許可を実装。
- **Expo CLI修正**: Dockerコンテナ外からのアクセスを許可するため、`--host lan` および `REACT_NATIVE_PACKAGER_HOSTNAME` を導入。

## 動作確認
- http://192.168.1.32:8080 (運用版) でログイン・各画面表示を確認。
- http://192.168.1.32:8081 (開発版) でホットリロード動作を確認。

## 備考
本PRのマージ後、同一ホスト内でのポート競合回避を目的とした「環境分離の最適化（Issue #69）」を別途実施予定です。

今回の対応でT320が「開発サーバー」兼「Webサーバー」として機能するようになりました。マージ後、Issue #69にて更なるインフラの堅牢化を進めましょう。お疲れ様でした。