### PR TITLE
docs: リストア手順の確立と復旧テストの実施 (#62)

### DIFF
--- a/docs/restore-manual.md
+++ b/docs/restore-manual.md
@@ -1,0 +1,137 @@
+# 復旧手順書（リストアマニュアル）
+
+万が一の障害発生時に、データベースとアップロード画像を15分以内に復旧するためのコマンド手順書。
+作業対象の環境（開発環境 または 本番環境）のセクションを選択し、記載されているコマンドを上から順に実行すること。
+
+---
+
+## 1. 事前準備：最新バックアップのタイムスタンプ確認
+
+リストアを実行する前に、まずは復元に使用するバックアップファイルの「タイムスタンプ（日時情報）」を確認する。
+
+### Step 1: 対象環境のバックアップ一覧を表示
+
+```bash
+# 【開発環境 (dev)】のファイルを確認する場合
+ls -l /mnt/raid_1t/backups/receipt-app-dev/db/
+
+# 【本番環境 (stable)】のファイルを確認する場合
+ls -l /mnt/raid_1t/backups/receipt-app/db/
+```
+
+### Step 2: タイムスタンプの特定
+
+出力されたファイル名から、復元したい日時の文字列（例: `20260519_061210`）を確認し、以降の手順の `TARGET_TS=` の右側に差し替えて使用する。
+
+---
+
+## 2. A. 【開発環境 (dev)】一撃リストア手順
+
+開発環境（dev）のデータを復旧する場合は、以下のコマンドブロックを順に実行する。
+
+### Step 1: 環境変数の定義
+
+```bash
+cd ~/dev/receipt-ai-app
+DB_PASS=$(grep '^DB_PASSWORD=' .env | cut -d '=' -f 2-)
+# ★確認したタイムスタンプ（例: 20260519_061210）を以下に設定
+TARGET_TS="【ここにタイムスタンプを入力】"
+```
+
+### Step 2: データベースの物理削除と再作成（初期化）
+
+```bash
+# 既存の接続を強制切断
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-dev-db psql -U cntadm -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'receipt_db' AND pid <> pg_backend_pid();"
+
+# データベースをクリーンに再作成
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-dev-db dropdb -U cntadm --if-exists receipt_db
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-dev-db createdb -U cntadm receipt_db
+```
+
+### Step 3: DBデータの流し込み
+
+```bash
+zcat /mnt/raid_1t/backups/receipt-app-dev/db/db_backup_${TARGET_TS}.sql.gz | \
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-dev-db psql -U cntadm -d receipt_db
+```
+
+### Step 4: アップロード画像の展開
+
+```bash
+# 既存の物理ディレクトリを退避
+if [ -d "backend/uploads" ]; then
+    mv backend/uploads backend/uploads_bak_$(date +%Y%m%d_%H%M%S)
+fi
+
+# アーカイブを展開
+tar -xzvf /mnt/raid_1t/backups/receipt-app-dev/uploads/uploads_backup_${TARGET_TS}.tar.gz -C backend/
+```
+
+### Step 5: 全コンテナの起動と確認
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+---
+
+## 3. B. 【本番・安定環境 (stable)】一撃リストア手順
+
+本番環境（stable）のデータを復旧する場合は、以下のコマンドブロックを順に実行する。
+
+### Step 1: 環境変数の定義
+
+```bash
+cd ~/dev/receipt-ai-app
+DB_PASS=$(grep '^DB_PASSWORD=' .env | cut -d '=' -f 2-)
+# ★確認したタイムスタンプ（例: 20260519_061210）を以下に設定
+TARGET_TS="【ここにタイムスタンプを入力】"
+```
+
+### Step 2: データベースの物理削除と再作成（初期化）
+
+```bash
+# 既存の接続を強制切断
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-stable-db psql -U cntadm -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'receipt_db' AND pid <> pg_backend_pid();"
+
+# データベースをクリーンに再作成
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-stable-db dropdb -U cntadm --if-exists receipt_db
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-stable-db createdb -U cntadm receipt_db
+```
+
+### Step 3: DBデータの流し込み
+
+```bash
+zcat /mnt/raid_1t/backups/receipt-app/db/db_backup_${TARGET_TS}.sql.gz | \
+docker exec -i -e PGPASSWORD="${DB_PASS}" receipt-stable-db psql -U cntadm -d receipt_db
+```
+
+### Step 4: アップロード画像の展開
+
+```bash
+# 既存の物理ディレクトリを退避
+if [ -d "backend/uploads" ]; then
+    mv backend/uploads backend/uploads_bak_$(date +%Y%m%d_%H%M%S)
+fi
+
+# アーカイブを展開
+tar -xzvf /mnt/raid_1t/backups/receipt-app/uploads/uploads_backup_${TARGET_TS}.tar.gz -C backend/
+```
+
+### Step 5: 全コンテナの起動と確認
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+---
+
+## 4. 復旧後の動作確認チェックリスト
+
+- [ ] アプリケーションへ正常にログインできるか。
+- [ ] レシート履歴画面を開き、明細データが欠損なく表示されているか。
+- [ ] 履歴に紐づくレシート画像（WebP等）が正しく描画されているか。
+- [ ] 統計画面等の集計ロジックが正常に動作しているか。

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
+# --- 环境判定ロジック ---
+ENV=$1
+
+if [ "$ENV" != "stable" ] && [ "$ENV" != "dev" ]; then
+    echo "[ERROR] Usage: $0 {stable|dev}"
+    exit 1
+fi
+
 # --- 設定項目 ---
-# スクリプトの場所からプロジェクトルート（1つ上の階層）を特定
 PROJECT_ROOT=$(cd $(dirname "$0")/..; pwd)
-BACKUP_DIR="/mnt/raid_1t/backups/receipt-app"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RETENTION_DAYS=7
 
-# ★ Discord 設定 (取得したURLをここに貼り付け)
+# ★ Discord 設定
 WEBHOOK_URL="https://discord.com/api/webhooks/1494659784304230442/Hh4scCNNv0hga2AtqMbUufCdaAaZUmmRrltAo4Ke5Pjq7QlS1iO1PIDIz5MAK399sY2Z"
 
-# Docker設定
-CONTAINER_NAME="receipt-stable-db" # 前回の成功時が「-1」付きなら修正してください
+# DB基本設定
 DB_USER="cntadm"
 DB_NAME="receipt_db"
+
+# --- 環境別の動的分岐設定 ---
+if [ "$ENV" = "stable" ]; then
+    BACKUP_DIR="/mnt/raid_1t/backups/receipt-app"
+    CONTAINER_NAME="receipt-stable-db"
+    ENV_LABEL="PROD"
+else
+    BACKUP_DIR="/mnt/raid_1t/backups/receipt-app-dev"
+    CONTAINER_NAME="receipt-dev-db" # ★修正: 実際のコンテナ名に一致
+    ENV_LABEL="DEV"
+fi
 
 # --- 通知関数 ---
 send_discord_alert() {
@@ -26,7 +42,7 @@ send_discord_alert() {
             -X POST \
             -d "{
                 \"embeds\": [{
-                    \"title\": \"[$status] T320 Backup Alert\",
+                    \"title\": \"[$status] T320 ($ENV_LABEL) Backup Alert\",
                     \"description\": \"$message\",
                     \"color\": $color,
                     \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
@@ -52,20 +68,20 @@ fi
 
 SOURCE_UPLOADS_DIR="${PROJECT_ROOT}/backend/uploads"
 
-echo "[$(date)] Backup started."
+echo "[$(date)] ($ENV_LABEL) Backup started."
 
 # 3. DBバックアップ
 if [ ! "$(docker ps -q -f name=${CONTAINER_NAME})" ]; then
-    msg="Container ${CONTAINER_NAME} is NOT running. DB Backup aborted."
+    msg="Container ${CONTAINER_NAME} is NOT running. ($ENV_LABEL) DB Backup aborted."
     echo "  -> [ERROR] $msg"
     send_discord_alert "ERROR" "$msg"
 else
     docker exec -e PGPASSWORD="${DB_PASS}" ${CONTAINER_NAME} pg_dump -U ${DB_USER} ${DB_NAME} | gzip > "${BACKUP_DIR}/db/db_backup_${TIMESTAMP}.sql.gz"
     
     if [ ${PIPESTATUS[0]} -eq 0 ]; then
-        echo "  -> DB Backup SUCCESS."
+        echo "  -> ($ENV_LABEL) DB Backup SUCCESS."
     else
-        msg="PostgreSQL Dump FAILED."
+        msg="PostgreSQL Dump FAILED on ($ENV_LABEL)."
         echo "  -> [ERROR] $msg"
         send_discord_alert "ERROR" "$msg"
     fi
@@ -73,8 +89,16 @@ fi
 
 # 4. 画像バックアップ
 if [ -d "${SOURCE_UPLOADS_DIR}" ]; then
+    # ★修正: 圧縮コマンド自体の成否を取得するため 2>/dev/null は外し、終了ステータスをチェック
     tar -czf "${BACKUP_DIR}/uploads/uploads_backup_${TIMESTAMP}.tar.gz" -C "${PROJECT_ROOT}/backend" "uploads"
-    echo "  -> Uploads Backup SUCCESS."
+    
+    if [ $? -eq 0 ]; then
+        echo "  -> ($ENV_LABEL) Uploads Backup SUCCESS."
+    else
+        msg="Tar archive creation FAILED on ($ENV_LABEL)."
+        echo "  -> [ERROR] $msg"
+        send_discord_alert "ERROR" "$msg"
+    fi
 else
     msg="Uploads directory NOT found at ${SOURCE_UPLOADS_DIR}."
     echo "  -> [ERROR] $msg"
@@ -85,7 +109,4 @@ fi
 find "${BACKUP_DIR}/db" -name "*.gz" -mtime +${RETENTION_DAYS} -delete
 find "${BACKUP_DIR}/uploads" -name "*.tar.gz" -mtime +${RETENTION_DAYS} -delete
 
-# 6. 完了通知 (成功時も通知したい場合はコメントアウトを外してください)
-# send_discord_alert "SUCCESS" "Daily backup completed successfully on T320."
-
-echo "[$(date)] Backup completed."
+echo "[$(date)] ($ENV_LABEL) Backup completed."


### PR DESCRIPTION
#### 概要
バックアップの自動化・Discord通知に伴い、万が一の障害発生時に15分以内にサービスを復旧するための手順書（マニュアル）を整備し、dev環境（T320上のDockerコンテナ）を用いたリストアリハーサルを実施・検証しました。

#### 変更内容
1. **バックアップスクリプトの共通化 (`scripts/backup.sh`)**
   - 引数 (`stable` / `dev`) に応じて出力先ディレクトリ、対象コンテナ名、Discord通知タイトルを動的に切り替えるマルチ環境対応を導入。
   - `tar` コマンドの成否判定（終了ステータスチェック）を厳格化し、失敗時の誤通知を防止。
2. **復旧手順書の新規作成 (`docs/restore-manual.md`)**
   - Dockerのバインドマウント配下に実データが残留する特性に対応するため、PostgreSQL内部コマンドによるデータベース完全初期化（DROP/CREATE）の手順を明文化。
   - `dev` と `stable` の手順を完全に独立したセクションとして分離し、ターミナルへのコピペだけで迷わず復旧できる構造に統一。

#### 検証結果
- `dev` 環境における共通化スクリプトでのバックアップ取得、およびデータベース初期化からのリストア・画像展開の一連のフローが正常に動作し、データが100%復旧することを確認済み。