### PR TITLE
feat: 管理者権限(Role)の導入とAIコスト統計・管理メニューの実装 (#73)

### DIFF
--- a/backend/prisma/migrations/20260519225122_add_role_to_family_member/migration.sql
+++ b/backend/prisma/migrations/20260519225122_add_role_to_family_member/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'USER');
+
+-- AlterTable
+ALTER TABLE "FamilyMember" ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,6 +7,12 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// [Issue #73] ユーザーの権限レベルを定義
+enum Role {
+  ADMIN // 管理者 (プロンプト編集・コスト統計の閲覧が可能)
+  USER  // 一般ユーザー (レシートの登録・閲覧のみ)
+}
+
 // [Issue #45] 世帯（テナント）最上位テーブル
 model FamilyGroup {
   id             Int             @id @default(autoincrement())
@@ -20,10 +26,11 @@ model FamilyGroup {
 
 // 家族構成
 model FamilyMember {
-  id            Int            @id @default(autoincrement())
+  id            Int           @id @default(autoincrement())
   name          String
   password_hash String?
   familyGroupId Int            // ★ 所属世帯
+  role          Role          @default(USER) // [Issue #73] デフォルトは一般ユーザー
   familyGroup   FamilyGroup    @relation(fields: [familyGroupId], references: [id])
   receipts      Receipt[]
   apiUsageLogs  ApiUsageLog[]  // [Issue #59] トークンログとのリレーション
@@ -35,7 +42,7 @@ model FamilyMember {
 model Category {
   id             Int             @id @default(autoincrement())
   name           String          @unique
-  color          String?          
+  color          String?         
   keywords       Json            @default("[]") 
   items          Item[]
   productMasters ProductMaster[]

--- a/backend/scripts/test-admin-api.ts
+++ b/backend/scripts/test-admin-api.ts
@@ -1,0 +1,34 @@
+import { generateToken } from '../src/utils/auth';
+
+async function runTest() {
+  try {
+    // 1. テスト用トークンの生成 (anyで型エラーを回避しつつ必須項目を網羅)
+    const token = generateToken({
+      id: 1,              // isAdmin ミドルウェアで参照するID
+      memberId: 1,        // 既存の互換性用
+      name: 'Admin User',
+      familyGroupId: 1    // エラーになっていた必須プロパティ
+    } as any);
+
+    console.log('🔑 トークン生成成功');
+
+    // 2. Node.js標準の fetch を使ってコンテナ内部からAPIを実行
+    const response = await fetch('http://localhost:3000/api/admin/stats', {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+
+    const data = await response.json();
+    
+    console.log(`\n📡 APIステータス: ${response.status}`);
+    console.log('📦 レスポンスデータ:');
+    console.dir(data, { depth: null });
+
+  } catch (error) {
+    console.error('❌ エラー:', error);
+  }
+}
+
+runTest();

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -2,6 +2,12 @@ import { Request, Response } from 'express';
 import prisma from '../utils/prismaClient';
 import logger from '../utils/logger';
 
+// --- [Issue #73] AI Cost Constants ---
+// Gemini 2.0 Flash の単価設定 (100万トークンあたり)
+const RATE_USD_TO_JPY = 150; // 為替レート（仮）
+const PRICE_USD_PER_INPUT = 0.075 / 1000000;
+const PRICE_USD_PER_OUTPUT = 0.30 / 1000000;
+
 /**
  * プロンプトテンプレート一覧の取得
  */
@@ -56,6 +62,48 @@ export const updatePrompt = async (req: Request, res: Response) => {
       success: false, 
       message: 'プロンプトの更新に失敗しました',
       error: 'プロンプトの更新に失敗しました'
+    });
+  }
+};
+
+/**
+ * [Issue #73] AIコスト統計の取得（月別・モデル別）
+ */
+export const getCostStats = async (req: Request, res: Response) => {
+  try {
+    // PostgreSQLの TO_CHAR 関数を使用して月別・モデル別に集計
+    const stats: any[] = await prisma.$queryRaw`
+      SELECT
+        TO_CHAR("createdAt", 'YYYY-MM') AS month,
+        "modelId",
+        SUM("promptTokens")::int AS "totalPromptTokens",
+        SUM("candidatesTokens")::int AS "totalCandidatesTokens"
+      FROM "ApiUsageLog"
+      GROUP BY month, "modelId"
+      ORDER BY month DESC;
+    `;
+
+    // 取得した集計データに対して概算料金(円)を計算して付与
+    const result = stats.map(row => {
+      const costUsd = (row.totalPromptTokens * PRICE_USD_PER_INPUT) + (row.totalCandidatesTokens * PRICE_USD_PER_OUTPUT);
+      const costJpy = costUsd * RATE_USD_TO_JPY;
+      
+      return {
+        month: row.month,
+        modelId: row.modelId,
+        totalPromptTokens: row.totalPromptTokens,
+        totalCandidatesTokens: row.totalCandidatesTokens,
+        estimatedCostJpy: Math.round(costJpy * 100) / 100 // 小数第2位で丸め
+      };
+    });
+
+    res.json({ success: true, data: result });
+  } catch (error) {
+    logger.error(`[AdminAPI] getCostStats Error: ${error}`);
+    res.status(500).json({ 
+      success: false, 
+      message: '統計データの取得に失敗しました',
+      error: '統計データの取得に失敗しました'
     });
   }
 };

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,16 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
-import bcrypt from 'bcrypt'; // ★追加
+import bcrypt from 'bcrypt';
 import { generateToken } from '../utils/auth';
 import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
 
 /**
- * [Issue #54] ログイン処理 (bcrypt照合版)
+ * [Issue #54 / #73] ログイン処理 (bcrypt照合版)
  * メンバーIDとパスワードを受け取り、照合後にJWTを発行します。
  */
 export const login = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { memberId, password } = req.body; // ★ password を受け取る
+    const { memberId, password } = req.body;
 
     if (!memberId || !password) {
       throw new AppError('メンバーIDとパスワードを入力してください。', 400);
@@ -29,7 +29,6 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
     }
 
     // 2. パスワード未設定のチェック
-    // マイグレーション直後は null なので、運用回避用のガードを入れます
     if (!member.password_hash) {
       throw new AppError('パスワードが設定されていません。管理者に連絡してください。', 403);
     }
@@ -37,15 +36,17 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
     // 3. bcryptによるパスワード照合
     const isMatch = await bcrypt.compare(password, member.password_hash);
     if (!isMatch) {
-      // セキュリティ上の定石として、ID間違いかパスワード間違いかは明示しません
       throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
     }
 
     // 4. JWTの発行
+    // [Issue #73] authMiddleware (isAdmin) で検証できるよう id を追加し、roleも含める
     const token = generateToken({
+      id: member.id, // ← req.user.id 用に追加
       memberId: member.id,
       familyGroupId: member.familyGroup.id,
-      name: member.name
+      name: member.name,
+      role: member.role 
     });
 
     res.status(200).json({
@@ -55,7 +56,8 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
         member: {
           id: member.id,
           name: member.name,
-          familyGroupId: member.familyGroupId
+          familyGroupId: member.familyGroupId,
+          role: member.role // ★フロントへ渡すための修正
         }
       }
     });

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,6 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../utils/auth';
 import logger from '../utils/logger';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 /**
  * [Issue #51] JWT認証ミドルウェア
@@ -34,4 +37,38 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   (req as any).user = decoded;
   
   next();
+};
+
+/**
+ * [Issue #73] 管理者権限（Role）検証ミドルウェア
+ * ※必ず authMiddleware の後ろに配置して使用すること。
+ * ログインユーザーのIDからDBを引き、role === 'ADMIN' かどうかを判定します。
+ */
+export const isAdmin = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req as any).user?.id; 
+    
+    if (!userId) {
+      return res.status(401).json({ success: false, message: 'ユーザー情報が取得できません' });
+    }
+
+    const user = await prisma.familyMember.findUnique({
+      where: { id: userId },
+      select: { role: true }
+    });
+
+    if (user?.role !== 'ADMIN') {
+      logger.warn(`[AUTH] Forbidden Admin Access Attempt by User ID: ${userId}`);
+      return res.status(403).json({ 
+        success: false, 
+        code: 'FORBIDDEN', 
+        message: 'この操作を実行する権限がありません（管理者専用）' 
+      });
+    }
+
+    next();
+  } catch (error) {
+    logger.error(`[AUTH] Admin Check Error:`, error);
+    res.status(500).json({ success: false, message: '権限の確認中にエラーが発生しました' });
+  }
 };

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,12 +1,20 @@
 import { Router } from 'express';
 import * as adminController from '../controllers/adminController';
+import { isAdmin } from '../middleware/authMiddleware';
 
 const router = Router();
 
-// プロンプト管理
+// ★ [Issue #73] 全ての管理者ルートを isAdmin ミドルウェアで保護する
+// これにより、このルーター配下の全エンドポイントは「ログイン済 かつ role === 'ADMIN'」でないとアクセスできなくなります
+router.use(isAdmin);
+
+// --- [Issue #73] AIコスト統計管理 ---
+router.get('/stats', adminController.getCostStats);
+
+// --- [Issue #72] プロンプト管理 ---
 router.get('/prompts', adminController.getPrompts);
 
-// ★修正: フロントエンドの apiClient.patch('/admin/prompts', { key: ... }) と一致させるため :key を削除
+// フロントエンドの apiClient.patch('/admin/prompts', { key: ... }) と一致させるため :key なし
 router.patch('/prompts', adminController.updatePrompt);
 
 export default router;

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -13,13 +13,16 @@ if (!JWT_SECRET) {
 }
 
 /**
- * [Issue #52] トークンのペイロード定義
+ * [Issue #52 / #73] トークンのペイロード定義
  * familyGroupId を含み、マルチテナント対応の基盤となります。
+ * 権限管理(isAdmin)のために id と role を追加しました。
  */
 export interface JWTPayload {
-  memberId: number;
+  id: number;           // [Issue #73] authMiddleware (req.user.id) 用
+  memberId: number;     // 互換性維持
   familyGroupId: number;
   name: string;
+  role?: string;        // [Issue #73] 権限 (例: 'ADMIN')
 }
 
 /**

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, Alert, ActivityIndicator, Platform, TextInput, Text, 
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
-import * as SplashScreen from 'expo-splash-screen'; // ★ Issue #74: スプラッシュ画面制御の導入
+import * as SplashScreen from 'expo-splash-screen'; 
 
 import apiClient, { setOnUnauthorized } from './src/utils/apiClient';
 import { authService } from './src/services/authService'; 
@@ -14,14 +14,16 @@ import { StatisticsScreen } from './src/screens/StatisticsScreen';
 import { CategoryManagementScreen } from './src/screens/CategoryManagementScreen'; 
 import { ProductMasterScreen } from './src/screens/ProductMasterScreen'; 
 import { ReceiptScanScreen } from './src/screens/ReceiptScanScreen'; 
-import { PromptEditorScreen } from './src/screens/PromptEditorScreen'; 
+import { PromptEditorScreen } from './src/screens/PromptEditorScreen';
+import { AdminStatsScreen } from './src/screens/AdminStatsScreen';
+import { AdminMenuScreen } from './src/screens/AdminMenuScreen';
+
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
 
-// ★ Issue #74: アプリ起動時にスプラッシュ画面を自動非表示にするのを防止（初期ロードの隠蔽）
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor';
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -33,25 +35,22 @@ export default function App() {
   const [isReady, setIsReady] = useState(false);
   const [userToken, setUserToken] = useState<string | null>(null);
   const [currentMemberId, setCurrentMemberId] = useState<number | null>(null);
+  const [currentUserRole, setCurrentUserRole] = useState<string | null>(null);
   const [loginPassword, setLoginPassword] = useState('');
 
-  // メインステート
   const [resultData, setResultData] = useState<any>(null); 
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
 
-  /**
-   * 1. 初期化・ローカル永続化データの完全並列ロード & 先行APIフェッチ
-   */
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        // ★ 変更点: トークン、メンバID、前回のView、解析一時データをすべて並列で一括取得（RTTの削減）
-        const [token, midStr, v, res] = await Promise.all([
+        const [token, midStr, role, v, res] = await Promise.all([
           authService.getToken(),
           Platform.OS === 'web'
             ? AsyncStorage.getItem(STORAGE_KEYS.MEMBER_ID)
             : SecureStore.getItemAsync(STORAGE_KEYS.MEMBER_ID),
+          authService.getRole(),
           AsyncStorage.getItem(STORAGE_KEYS.VIEW),
           AsyncStorage.getItem(STORAGE_KEYS.RESULT),
         ]);
@@ -59,8 +58,8 @@ export default function App() {
         if (token) {
           setUserToken(token);
           setCurrentMemberId(midStr ? parseInt(midStr, 10) : 1);
+          setCurrentUserRole(role);
 
-          // ★ 変更点: ログイン済みの場合は、カテゴリマスタもスプラッシュの裏で先行フェッチして完了させておく
           try {
             const catRes = await apiClient.get('/categories');
             if (catRes.data?.success) {
@@ -78,16 +77,12 @@ export default function App() {
         console.error('初期化失敗', e);
       } finally {
         setIsReady(true);
-        // ★ 変更点: すべてのデータ準備が整った段階でスプラッシュを非表示にし、メイン画面へパッと切り替える
         await SplashScreen.hideAsync().catch(() => {});
       }
     };
     initializeApp();
   }, []);
 
-  /**
-   * 2. 認証エラーハンドリング
-   */
   useEffect(() => {
     setOnUnauthorized(() => {
       handleLogout();
@@ -95,9 +90,6 @@ export default function App() {
     });
   }, []);
 
-  /**
-   * 3. ログイン処理
-   */
   const handleLogin = async (memberId: number) => {
     if (!loginPassword) {
       Alert.alert("入力エラー", "パスワードを入力してください。");
@@ -112,7 +104,12 @@ export default function App() {
       
       if (response.data && response.data.success) {
         const { token, member } = response.data.data;
+        
         await authService.saveToken(token);
+        if (member.role) {
+          await authService.saveRole(member.role);
+          setCurrentUserRole(member.role);
+        }
 
         if (Platform.OS === 'web') {
           await AsyncStorage.setItem(STORAGE_KEYS.MEMBER_ID, member.id.toString());
@@ -131,9 +128,6 @@ export default function App() {
     }
   };
 
-  /**
-   * 4. ログアウト処理
-   */
   const handleLogout = async () => {
     await authService.logout();
     if (Platform.OS === 'web') {
@@ -144,14 +138,12 @@ export default function App() {
 
     setUserToken(null);
     setCurrentMemberId(null);
+    setCurrentUserRole(null);
     setCurrentView('main');
     setResultData(null);
     setLoginPassword('');
   };
 
-  /**
-   * 5. カテゴリマスタの取得（手動更新・既存画面からのコール用）
-   */
   const fetchCategories = useCallback(async () => {
     if (!userToken) return;
     try {
@@ -164,16 +156,12 @@ export default function App() {
     }
   }, [userToken]);
 
-  // ★ 変更点: 起動時に未取得の場合のみ補正用として発火させるガードを追加（重複通信抑止）
   useEffect(() => {
     if (isReady && userToken && categories.length === 0) {
       fetchCategories();
     }
   }, [fetchCategories, isReady, userToken, categories.length]);
 
-  /**
-   * 6. 永続化（現在の表示ビューと未保存の解析結果）
-   */
   useEffect(() => {
     if (!isReady || !userToken) return;
     const saveState = async () => {
@@ -191,15 +179,11 @@ export default function App() {
     saveState();
   }, [currentView, resultData, isReady, userToken]);
 
-  /**
-   * 7. 解析完了時のハンドラ
-   */
   const handleAnalysisReady = (data: any) => {
     setResultData(data);
     setCurrentView('receipt_scan');
   };
 
-  // ★ 変更点: 準備中のActivityIndicator表示は基本通らなくなり、ネイティブのスプラッシュ画面が直接維持される
   if (!isReady) {
     return (
       <View style={styles.loadingContainer}>
@@ -208,7 +192,7 @@ export default function App() {
     );
   }
 
-  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor'].includes(currentView);
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu'].includes(currentView);
 
   if (!userToken) {
     return (
@@ -248,9 +232,9 @@ export default function App() {
       case 'stats': 
         return <StatisticsScreen currentMemberId={memberId} onBack={() => setCurrentView('main')} />;
       case 'category_mgr': 
-        return <CategoryManagementScreen onBack={() => { fetchCategories(); setCurrentView('main'); }} currentMemberId={memberId} />;
+        return <CategoryManagementScreen onBack={() => { fetchCategories(); setCurrentView('admin_menu'); }} currentMemberId={memberId} />;
       case 'product_master': 
-        return <ProductMasterScreen onBack={() => setCurrentView('main')} currentMemberId={memberId} />;
+        return <ProductMasterScreen onBack={() => setCurrentView('admin_menu')} currentMemberId={memberId} />;
       case 'receipt_scan': 
         return (
           <ReceiptScanScreen 
@@ -267,13 +251,20 @@ export default function App() {
           />
         );
       case 'prompt_editor': 
+        // ★ ラッパーを外し、onBack を直接コンポーネントへ渡す
+        return <PromptEditorScreen onBack={() => setCurrentView('admin_menu')} />;
+      case 'admin_stats':
+        // ★ ラッパーを外し、onBack を直接コンポーネントへ渡す
+        return <AdminStatsScreen onBack={() => setCurrentView('admin_menu')} />;
+      case 'admin_menu':
         return (
-          <View style={{ flex: 1, backgroundColor: '#F8F9FA' }}>
-            <TouchableOpacity style={styles.adminBackButton} onPress={() => setCurrentView('main')}>
-              <Text style={styles.adminBackButtonText}>← メイン画面に戻る</Text>
-            </TouchableOpacity>
-            <PromptEditorScreen />
-          </View>
+          <AdminMenuScreen 
+            onBack={() => setCurrentView('main')}
+            onGoToCategories={() => setCurrentView('category_mgr')}
+            onGoToProductMaster={() => setCurrentView('product_master')}
+            onGoToPromptEditor={() => setCurrentView('prompt_editor')}
+            onGoToAdminStats={() => setCurrentView('admin_stats')}
+          />
         );
       default:
         return (
@@ -286,10 +277,9 @@ export default function App() {
               onAnalysisReady={handleAnalysisReady} 
               onGoToHistory={() => setCurrentView('history')}
               onGoToStats={() => setCurrentView('stats')}
-              onGoToCategories={() => setCurrentView('category_mgr')}
-              onGoToProductMaster={() => setCurrentView('product_master')}
-              onGoToPromptEditor={() => setCurrentView('prompt_editor')}
+              onGoToAdminMenu={() => setCurrentView('admin_menu')} 
               currentMemberId={memberId}
+              userRole={currentUserRole}
             />
           </View>
         );
@@ -326,19 +316,4 @@ const styles = StyleSheet.create({
   loginButtonText: { color: theme.colors.primary, fontWeight: 'bold', fontSize: 16 },
   logoutTrigger: { position: 'absolute', top: 60, right: 20, zIndex: 10, backgroundColor: 'rgba(0,0,0,0.05)', padding: 8, borderRadius: 10 },
   logoutText: { color: theme.colors.text.muted, fontSize: 12, fontWeight: 'bold' },
-  adminBackButton: {
-    backgroundColor: '#E9ECEF',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    margin: 16,
-    borderRadius: 6,
-    alignSelf: 'flex-start',
-    borderWidth: 1,
-    borderColor: '#CED4DA',
-  },
-  adminBackButtonText: {
-    color: '#495057',
-    fontWeight: 'bold',
-    fontSize: 14,
-  },
 });

--- a/frontend/src/screens/AdminMenuScreen.tsx
+++ b/frontend/src/screens/AdminMenuScreen.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { theme } from '../theme';
+
+interface AdminMenuScreenProps {
+  onBack: () => void;
+  onGoToCategories: () => void;
+  onGoToProductMaster: () => void;
+  onGoToPromptEditor: () => void;
+  onGoToAdminStats: () => void;
+}
+
+export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
+  onBack,
+  onGoToCategories,
+  onGoToProductMaster,
+  onGoToPromptEditor,
+  onGoToAdminStats
+}) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={onBack}>
+          <Text style={styles.backButtonText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>管理者メニュー</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>マスタデータ管理</Text>
+          
+          <TouchableOpacity style={styles.settingsCard} onPress={onGoToCategories}>
+            <View style={[styles.iconWrapper, { backgroundColor: '#F0F4F8' }]}><Text>⚙️</Text></View>
+            <View style={styles.textWrapper}>
+              <Text style={styles.cardTitle}>カテゴリー設定</Text>
+              <Text style={styles.cardDesc}>支出カテゴリの追加・編集・色変更</Text>
+            </View>
+            <Text style={styles.arrow}>›</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity style={styles.settingsCard} onPress={onGoToProductMaster}>
+            <View style={[styles.iconWrapper, { backgroundColor: '#E3F2FD' }]}><Text>🧠</Text></View>
+            <View style={styles.textWrapper}>
+              <Text style={styles.cardTitle}>学習マスタ管理</Text>
+              <Text style={styles.cardDesc}>商品名からの自動カテゴリ分類の修正</Text>
+            </View>
+            <Text style={styles.arrow}>›</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>システム・AI設定</Text>
+          
+          <TouchableOpacity style={styles.settingsCard} onPress={onGoToPromptEditor}>
+            <View style={[styles.iconWrapper, { backgroundColor: '#EDE7F6' }]}><Text>📝</Text></View>
+            <View style={styles.textWrapper}>
+              <Text style={styles.cardTitle}>プロンプト・外税ヒント編集</Text>
+              <Text style={styles.cardDesc}>Geminiへの指示と店舗特有の計算ルール</Text>
+            </View>
+            <Text style={styles.arrow}>›</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity style={styles.settingsCard} onPress={onGoToAdminStats}>
+            <View style={[styles.iconWrapper, { backgroundColor: '#FFF3E0' }]}><Text>📈</Text></View>
+            <View style={styles.textWrapper}>
+              <Text style={styles.cardTitle}>AIコスト統計</Text>
+              <Text style={styles.cardDesc}>API利用量と概算コストの確認</Text>
+            </View>
+            <Text style={styles.arrow}>›</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F8F9FA' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'white',
+    paddingTop: 16,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E9ECEF',
+  },
+  backButton: { width: 60, paddingVertical: 8 },
+  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  content: { padding: 16 },
+  section: { marginBottom: 24 },
+  sectionTitle: { fontSize: 14, fontWeight: 'bold', color: theme.colors.text.muted, marginBottom: 12, marginLeft: 4 },
+  settingsCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#E9ECEF',
+  },
+  iconWrapper: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  textWrapper: { flex: 1 },
+  cardTitle: { fontSize: 16, fontWeight: 'bold', color: theme.colors.text.main, marginBottom: 4 },
+  cardDesc: { fontSize: 12, color: theme.colors.text.muted },
+  arrow: { fontSize: 24, color: '#CED4DA' }
+});

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  View, 
+  Text, 
+  StyleSheet, 
+  ActivityIndicator, 
+  ScrollView,
+  Alert,
+  TouchableOpacity
+} from 'react-native';
+import { theme } from '../theme';
+import apiClient from '../utils/apiClient';
+
+interface StatData {
+  month: string;
+  modelId: string;
+  totalPromptTokens: number;
+  totalCandidatesTokens: number;
+  estimatedCostJpy: number;
+}
+
+interface AdminStatsScreenProps {
+  onBack: () => void;
+}
+
+export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) => {
+  const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState<StatData[]>([]);
+  const [totalCost, setTotalCost] = useState(0);
+
+  useEffect(() => {
+    fetchStats();
+  }, []);
+
+  const fetchStats = async () => {
+    try {
+      const res = await apiClient.get('/admin/stats');
+      if (res.data && res.data.success) {
+        setStats(res.data.data);
+        const total = res.data.data.reduce((sum: number, item: StatData) => sum + item.estimatedCostJpy, 0);
+        setTotalCost(total);
+      }
+    } catch (error: any) {
+      console.error('Stats Fetch Error:', error);
+      Alert.alert('取得エラー', 'コスト統計の取得に失敗しました。管理者権限があるか確認してください。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={onBack}>
+          <Text style={styles.backButtonText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>AIコスト統計</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>累計利用コスト (概算)</Text>
+          <Text style={styles.summaryAmount}>¥{totalCost.toFixed(2)}</Text>
+          <Text style={styles.summaryNote}>※為替レート150円/$、Gemini 2.0 Flashでの算出</Text>
+        </View>
+
+        <View style={styles.tableHeader}>
+          <Text style={[styles.tableCell, { flex: 1.5 }]}>年月</Text>
+          <Text style={[styles.tableCell, { flex: 2 }]}>In / Out (Tokens)</Text>
+          <Text style={[styles.tableCell, { flex: 1.5, textAlign: 'right' }]}>概算(円)</Text>
+        </View>
+
+        {stats.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>データがありません</Text>
+          </View>
+        ) : (
+          stats.map((item, index) => (
+            <View key={`${item.month}-${item.modelId}-${index}`} style={styles.tableRow}>
+              <View style={{ flex: 1.5 }}>
+                <Text style={styles.cellMainText}>{item.month}</Text>
+                <Text style={styles.cellSubText} numberOfLines={1}>{item.modelId}</Text>
+              </View>
+              <View style={{ flex: 2 }}>
+                <Text style={styles.cellMainText}>{item.totalPromptTokens.toLocaleString()}</Text>
+                <Text style={styles.cellSubText}>{item.totalCandidatesTokens.toLocaleString()}</Text>
+              </View>
+              <Text style={[styles.cellMainText, { flex: 1.5, textAlign: 'right', fontWeight: 'bold' }]}>
+                ¥{item.estimatedCostJpy.toFixed(2)}
+              </Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F8F9FA' },
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'white',
+    paddingTop: 16,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E9ECEF',
+  },
+  backButton: { width: 60, paddingVertical: 8 },
+  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  content: { padding: 16, paddingBottom: 40 },
+  summaryCard: { 
+    backgroundColor: theme.colors.primary, 
+    padding: 20, 
+    borderRadius: 12, 
+    marginBottom: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3
+  },
+  summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, marginBottom: 8 },
+  summaryAmount: { color: 'white', fontSize: 36, fontWeight: 'bold' },
+  summaryNote: { color: 'rgba(255,255,255,0.6)', fontSize: 12, marginTop: 8 },
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#E9ECEF',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  tableCell: { fontSize: 13, fontWeight: 'bold', color: theme.colors.text.muted },
+  tableRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#E9ECEF'
+  },
+  cellMainText: { fontSize: 15, color: theme.colors.text.main },
+  cellSubText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 4 },
+  emptyContainer: { padding: 32, alignItems: 'center' },
+  emptyText: { color: theme.colors.text.muted, fontSize: 16 }
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -20,25 +20,21 @@ interface HomeScreenProps {
   onAnalysisReady: (data: any) => void; 
   onGoToHistory: () => void;
   onGoToStats: () => void;
-  onGoToCategories: () => void; 
-  onGoToProductMaster: () => void; 
-  onGoToPromptEditor: () => void;
+  onGoToAdminMenu?: () => void; // [Issue #73] 個別遷移を廃止し、ハブ画面への遷移へ統合
   currentMemberId: number;
+  userRole?: string | null;
 }
 
 /**
- * [Issue #67 / #72 / #63] ホーム画面（ダッシュボード）
- * - 合計金額の表示時に四捨五入を適用し、小数の端数表示を抑制。
- * - 非同期ジョブの完了時に、解析データに含まれる usageLogId を欠落させずに親コンポーネントへ送出。
+ * ホーム画面（ダッシュボード）
  */
 export const HomeScreen: React.FC<HomeScreenProps> = ({ 
   onAnalysisReady, 
   onGoToHistory, 
   onGoToStats, 
-  onGoToCategories,
-  onGoToProductMaster,
-  onGoToPromptEditor,
-  currentMemberId 
+  onGoToAdminMenu,
+  currentMemberId,
+  userRole 
 }) => {
   const [latestReceipt, setLatestReceipt] = useState<any>(null);
   const [monthlyTotal, setMonthlyTotal] = useState<number>(0);
@@ -60,7 +56,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
       }
       
       if (statsRes.data && statsRes.data.success) {
-        // [Issue #67] 小数点誤差や計算結果の端数を丸めてセット
         const total = statsRes.data.data.totalAmount || 0;
         setMonthlyTotal(Math.round(total));
       }
@@ -87,7 +82,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           clearInterval(interval);
           setIsAnalyzing(false);
           setJobStatus('');
-          // ★ [Issue #63]: result に含まれる { parsedData: { usageLogId, ... }, imagePath, validation } をそのまま親に渡す
           if (result) onAnalysisReady(result);
         } else if (state === 'failed') {
           clearInterval(interval);
@@ -156,6 +150,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const isWide = windowWidth > 600;
+  const isAdmin = userRole === 'ADMIN';
 
   return (
     <SafeAreaView style={styles.container}>
@@ -207,26 +202,19 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           </TouchableOpacity>
         </View>
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>マスタ管理</Text>
-          <TouchableOpacity style={styles.settingsCard} onPress={onGoToCategories}>
-            <View style={styles.settingsIconWrapper}><Text>⚙️</Text></View>
-            <View style={styles.settingsTextWrapper}><Text style={styles.settingsLabel}>カテゴリー設定</Text></View>
-            <Text style={styles.arrowIcon}>›</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity style={[styles.settingsCard, { marginTop: -10 }]} onPress={onGoToProductMaster}>
-            <View style={[styles.settingsIconWrapper, { backgroundColor: '#E3F2FD' }]}><Text>🧠</Text></View>
-            <View style={styles.settingsTextWrapper}><Text style={styles.settingsLabel}>学習マスタ管理</Text></View>
-            <Text style={styles.arrowIcon}>›</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity style={[styles.settingsCard, { marginTop: -10 }]} onPress={onGoToPromptEditor}>
-            <View style={[styles.settingsIconWrapper, { backgroundColor: '#EDE7F6' }]}><Text>📝</Text></View>
-            <View style={styles.settingsTextWrapper}><Text style={styles.settingsLabel}>プロンプト・外税ヒント編集</Text></View>
-            <Text style={styles.arrowIcon}>›</Text>
-          </TouchableOpacity>
-        </View>
+        {/* [Issue #73] 管理者限定メニューへのハブ導線 */}
+        {isAdmin && (
+          <View style={styles.section}>
+            <TouchableOpacity style={[styles.settingsCard, { backgroundColor: '#F8F9FA' }]} onPress={onGoToAdminMenu}>
+              <View style={[styles.settingsIconWrapper, { backgroundColor: '#E9ECEF' }]}><Text>🛡️</Text></View>
+              <View style={styles.settingsTextWrapper}>
+                <Text style={styles.settingsLabel}>管理者メニュー</Text>
+                <Text style={{ fontSize: 12, color: theme.colors.text.muted, marginTop: 2 }}>マスタ管理・システム設定</Text>
+              </View>
+              <Text style={styles.arrowIcon}>›</Text>
+            </TouchableOpacity>
+          </View>
+        )}
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>最近の登録</Text>

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -10,9 +10,8 @@ import {
   Alert,
 } from 'react-native';
 
-// 共通APIクライアント（環境に合わせて適宜インポートパスを調整してください）
-// 認証ヘッダー等は共通クライアント側で設定されている前提です
 import apiClient from '../utils/apiClient';
+import { theme } from '../theme';
 
 interface PromptTemplate {
   key: string;
@@ -22,7 +21,11 @@ interface PromptTemplate {
   version: number;
 }
 
-export const PromptEditorScreen: React.FC = () => {
+interface PromptEditorScreenProps {
+  onBack: () => void;
+}
+
+export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }) => {
   const [template, setTemplate] = useState<PromptTemplate | null>(null);
   const [systemPrompt, setSystemPrompt] = useState('');
   const [domainHintsStr, setDomainHintsStr] = useState('');
@@ -32,16 +35,13 @@ export const PromptEditorScreen: React.FC = () => {
 
   const PROMPT_KEY = 'RECEIPT_ANALYSIS';
 
-  // 1. プロンプトテンプレートの取得
   const fetchPromptTemplate = async () => {
     setIsLoading(true);
     setError(null);
     try {
-      // adminRoutes: /api/admin/prompts (GET)
       const response = await apiClient.get<{ success: boolean; data: PromptTemplate[] }>('/admin/prompts');
       
       if (response.data.success && response.data.data) {
-        // キーが RECEIPT_ANALYSIS のものを抽出
         const target = response.data.data.find((p) => p.key === PROMPT_KEY);
         if (target) {
           setTemplate(target);
@@ -64,14 +64,12 @@ export const PromptEditorScreen: React.FC = () => {
     fetchPromptTemplate();
   }, []);
 
-  // 2. 編集内容の保存
   const handleSave = async () => {
     if (!template) return;
 
     setError(null);
     let parsedHints: Record<string, any>;
 
-    // domainHints (JSON) のパースバリデーション
     try {
       parsedHints = JSON.parse(domainHintsStr);
     } catch (e) {
@@ -81,8 +79,6 @@ export const PromptEditorScreen: React.FC = () => {
 
     setIsSaving(true);
     try {
-      // adminRoutes: /api/admin/prompts (PATCH)
-      // tenantMiddleware を通さないため、全世帯共通のシステム設定として更新
       const response = await apiClient.patch(`/admin/prompts`, {
         key: PROMPT_KEY,
         systemPrompt,
@@ -91,7 +87,7 @@ export const PromptEditorScreen: React.FC = () => {
 
       if (response.status === 200) {
         Alert.alert('保存完了', `プロンプトをバージョン ${template.version + 1} に更新しました。`);
-        fetchPromptTemplate(); // 最新状態（バージョン等）を再取得
+        fetchPromptTemplate();
       }
     } catch (err: any) {
       const errMsg = err?.response?.data?.error || err.message || '保存に失敗しました。';
@@ -112,62 +108,70 @@ export const PromptEditorScreen: React.FC = () => {
   }
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
-      <Text style={styles.title}>プロンプト・チューニング (Admin UI)</Text>
-      
-      {template && (
-        <View style={styles.infoBadge}>
-          <Text style={styles.infoText}>Target Key: {template.key}</Text>
-          <Text style={styles.infoText}>Current Version: v{template.version}</Text>
-        </View>
-      )}
-
-      {error && (
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorText}>{error}</Text>
-        </View>
-      )}
-
-      <View style={styles.section}>
-        <Text style={styles.label}>System Prompt (ベース指示 / Chain of Thought規則)</Text>
-        <TextInput
-          style={[styles.input, styles.textArea]}
-          multiline
-          numberOfLines={12}
-          textAlignVertical="top"
-          value={systemPrompt}
-          onChangeText={setSystemPrompt}
-          placeholder="Geminiへのシステムプロンプトを入力してください"
-        />
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={onBack}>
+          <Text style={styles.backButtonText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>プロンプト・チューニング</Text>
+        <View style={{ width: 60 }} />
       </View>
 
-      <View style={styles.section}>
-        <Text style={styles.label}>Domain Hints (業態別レジストリ - JSON形式)</Text>
-        <TextInput
-          style={[styles.input, styles.jsonArea]}
-          multiline
-          numberOfLines={10}
-          textAlignVertical="top"
-          value={domainHintsStr}
-          onChangeText={setDomainHintsStr}
-          placeholder={`{\n  "gas_station": "ガソリンスタンドのヒント...",\n  "pharmacy": "薬局のヒント..."\n}`}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <TouchableOpacity
-        style={[styles.saveButton, isSaving && styles.disabledButton]}
-        onPress={handleSave}
-        disabled={isSaving}
-      >
-        {isSaving ? (
-          <ActivityIndicator size="small" color="#FFF" />
-        ) : (
-          <Text style={styles.saveButtonText}>更新を保存 (反映)</Text>
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        {template && (
+          <View style={styles.infoBadge}>
+            <Text style={styles.infoText}>Target Key: {template.key}</Text>
+            <Text style={styles.infoText}>Current Version: v{template.version}</Text>
+          </View>
         )}
-      </TouchableOpacity>
-    </ScrollView>
+
+        {error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        )}
+
+        <View style={styles.section}>
+          <Text style={styles.label}>System Prompt (ベース指示 / Chain of Thought規則)</Text>
+          <TextInput
+            style={[styles.input, styles.textArea]}
+            multiline
+            numberOfLines={12}
+            textAlignVertical="top"
+            value={systemPrompt}
+            onChangeText={setSystemPrompt}
+            placeholder="Geminiへのシステムプロンプトを入力してください"
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.label}>Domain Hints (業態別レジストリ - JSON形式)</Text>
+          <TextInput
+            style={[styles.input, styles.jsonArea]}
+            multiline
+            numberOfLines={10}
+            textAlignVertical="top"
+            value={domainHintsStr}
+            onChangeText={setDomainHintsStr}
+            placeholder={`{\n  "gas_station": "ガソリンスタンドのヒント...",\n  "pharmacy": "薬局のヒント..."\n}`}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <TouchableOpacity
+          style={[styles.saveButton, isSaving && styles.disabledButton]}
+          onPress={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? (
+            <ActivityIndicator size="small" color="#FFF" />
+          ) : (
+            <Text style={styles.saveButtonText}>更新を保存 (反映)</Text>
+          )}
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
   );
 };
 
@@ -176,6 +180,20 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#F8F9FA',
   },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'white',
+    paddingTop: 16,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E9ECEF',
+  },
+  backButton: { width: 60, paddingVertical: 8 },
+  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   contentContainer: {
     padding: 16,
     paddingBottom: 40,
@@ -185,12 +203,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#F8F9FA',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: '#212529',
-    marginBottom: 12,
   },
   infoBadge: {
     backgroundColor: '#E9ECEF',
@@ -244,7 +256,7 @@ const styles = StyleSheet.create({
   },
   jsonArea: {
     height: 200,
-    fontFamily: 'Courier', // 固定ピッチフォント（Web/iOS環境を考慮、Androidはフォールバック）
+    fontFamily: 'Courier', 
   },
   saveButton: {
     backgroundColor: '#007AFF',

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -3,6 +3,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
 const TOKEN_KEY = 'userToken';
+// [Issue #73] Role保存用のキー
+const ROLE_KEY = 'currentUserRole';
 
 export const authService = {
   // トークンを保存する
@@ -21,12 +23,30 @@ export const authService = {
       return await SecureStore.getItemAsync(TOKEN_KEY);
     }
   },
-  // ログアウト時にトークンを消去する
+  // [Issue #73] Roleを保存する
+  async saveRole(role: string) {
+    if (Platform.OS === 'web') {
+      await AsyncStorage.setItem(ROLE_KEY, role);
+    } else {
+      await SecureStore.setItemAsync(ROLE_KEY, role);
+    }
+  },
+  // [Issue #73] 保存されているRoleを読み出す
+  async getRole() {
+    if (Platform.OS === 'web') {
+      return await AsyncStorage.getItem(ROLE_KEY);
+    } else {
+      return await SecureStore.getItemAsync(ROLE_KEY);
+    }
+  },
+  // ログアウト時にトークンとRoleを消去する
   async logout() {
     if (Platform.OS === 'web') {
       await AsyncStorage.removeItem(TOKEN_KEY);
+      await AsyncStorage.removeItem(ROLE_KEY);
     } else {
       await SecureStore.deleteItemAsync(TOKEN_KEY);
+      await SecureStore.deleteItemAsync(ROLE_KEY);
     }
   }
 };

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -4,9 +4,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 
 // --- 定数定義 ---
+// [Issue #73] role を保存するためのキー（USER_ROLE）を追加
 const STORAGE_KEYS = {
   TOKEN: 'userToken',
   MEMBER_ID: 'currentMemberId',
+  USER_ROLE: 'currentUserRole', 
 } as const;
 
 /**
@@ -45,6 +47,13 @@ const getStorageItem = async (key: string): Promise<string | null> => {
   }
 };
 
+/**
+ * [Issue #73] 現在ログイン中のユーザーの Role を取得するユーティリティ
+ */
+export const getUserRole = async (): Promise<string | null> => {
+  return await getStorageItem(STORAGE_KEYS.USER_ROLE);
+};
+
 // --- リクエストインターセプター：送信前に認証情報を自動注入 ---
 apiClient.interceptors.request.use(async (config) => {
   const token = await getStorageItem(STORAGE_KEYS.TOKEN);
@@ -73,14 +82,16 @@ apiClient.interceptors.response.use(
       
       error.message = serverMessage;
 
-      // [Issue #51/52] 認証エラー (401) のハンドリング
+      // [Issue #51/52/73] 認証エラー (401) または 権限エラー (403) のハンドリング
       if (error.response.status === 401) {
         console.warn(`[API] Unauthorized: ${errorCode || 'TOKEN_EXPIRED'}`);
-        
-        // App.tsx で登録されたログアウト関数を実行
         if (onUnauthorizedHandler) {
           onUnauthorizedHandler();
         }
+      } else if (error.response.status === 403) {
+        // 403 Forbidden: 管理者メニュー等への不正アクセス
+        console.warn(`[API] Forbidden: ${serverMessage}`);
+        // 403はログアウトさせず、エラーメッセージのみを投げる（画面側でToast等を出す想定）
       }
     }
     return Promise.reject(error);


### PR DESCRIPTION
## 概要
Issue #73 の対応。ユーザーに管理者権限(Role)を導入し、AI利用コストの集計機能と管理者専用画面を実装しました。

## 変更内容
- **バックエンド**
  - `FamilyMember` テーブルに `role` カラムを追加し、ID:1 を `ADMIN` に設定。
  - JWTペイロードに `id` と `role` を追加。
  - `isAdmin` ミドルウェアを実装し、管理者専用ルートを保護。
  - `/api/admin/stats` エンドポイントを追加（月別・モデル別のトークン集計と概算コスト算出）。
- **フロントエンド**
  - ログイン時に `role` を取得・永続化する処理を追加。
  - 一般ユーザーのホーム画面からマスタ管理を隠蔽し、管理者(ADMIN)にのみ「管理者メニュー」を表示する制御を追加。
  - `AdminMenuScreen` (管理ハブ画面) と `AdminStatsScreen` (AIコスト統計画面) を新規作成。
  - 各設定画面のヘッダーデザインを統一し、JSXコメント起因のレンダリングエラーを修正。

## 動作確認
- ID:1（ADMIN）でログインし、管理者メニューおよびAIコスト統計画面が正常に表示されることを確認。
- 各設定画面間の遷移（戻るボタン）がエラーなく動作することを確認。
- ID:2（一般）でログイン時、ホーム画面に管理者メニューが表示されないことを確認。
