### PR TITLE
feat: [Issue #78] 家族間精算のDB定義と集計APIの実装

### DIFF
--- a/backend/prisma/migrations/20260523114921_add_item_split/migration.sql
+++ b/backend/prisma/migrations/20260523114921_add_item_split/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "ItemSplit" (
+    "id" SERIAL NOT NULL,
+    "itemId" INTEGER NOT NULL,
+    "familyMemberId" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ItemSplit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ItemSplit_itemId_idx" ON "ItemSplit"("itemId");
+
+-- CreateIndex
+CREATE INDEX "ItemSplit_familyMemberId_idx" ON "ItemSplit"("familyMemberId");
+
+-- AddForeignKey
+ALTER TABLE "ItemSplit" ADD CONSTRAINT "ItemSplit_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemSplit" ADD CONSTRAINT "ItemSplit_familyMemberId_fkey" FOREIGN KEY ("familyMemberId") REFERENCES "FamilyMember"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,6 +34,7 @@ model FamilyMember {
   familyGroup   FamilyGroup   @relation(fields: [familyGroupId], references: [id])
   receipts      Receipt[]
   apiUsageLogs  ApiUsageLog[] // [Issue #59] トークンログとのリレーション
+  itemSplits    ItemSplit[]   // [Issue #78] 負担明細へのリレーション
 
   @@unique([name, familyGroupId]) // 同一世帯内での名前重複を禁止
 }
@@ -76,14 +77,33 @@ model Receipt {
 }
 
 model Item {
-  id         Int       @id @default(autoincrement())
+  id         Int         @id @default(autoincrement())
   receiptId  Int
-  receipt    Receipt   @relation(fields: [receiptId], references: [id], onDelete: Cascade)
+  receipt    Receipt     @relation(fields: [receiptId], references: [id], onDelete: Cascade)
   categoryId Int?
-  category   Category? @relation(fields: [categoryId], references: [id])
+  category   Category?   @relation(fields: [categoryId], references: [id])
   name       String
   price      Float
-  quantity   Float     @default(1.0)
+  quantity   Float       @default(1.0)
+  
+  // [Issue #78] 負担割合の内訳（1対多）
+  splits     ItemSplit[] 
+}
+
+// [Issue #78] レシート明細ごとの負担内訳
+// レコードが存在しない場合（0件）は「レシート登録者の全額負担」とみなす（暗黙的デフォルト）
+model ItemSplit {
+  id             Int          @id @default(autoincrement())
+  itemId         Int
+  familyMemberId Int
+  amount         Int          // 精算用金額（端数を丸めた日本円のためInt）
+  createdAt      DateTime     @default(now()) @db.Timestamptz(3)
+
+  item           Item         @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  familyMember   FamilyMember @relation(fields: [familyMemberId], references: [id])
+
+  @@index([itemId])
+  @@index([familyMemberId])
 }
 
 // 学習マスタ (世帯ごとに学習結果を分離)

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -285,7 +285,7 @@ export const getReceipts = async (req: Request, res: Response, next: NextFunctio
 
     const receipts = await prisma.receipt.findMany({
       where,
-      include: { items: { include: { category: true } } },
+      include: { items: { include: { category: true, splits: true } } }, // ★ Issue #78: splitsも一緒に取得するよう変更
       orderBy: { date: 'desc' }
     });
     res.json({ success: true, data: receipts });
@@ -300,7 +300,7 @@ export const getLatestReceipt = async (_req: Request, res: Response, next: NextF
     const receipt = await prisma.receipt.findFirst({
       where: { familyGroupId: getFamilyGroupId() },
       orderBy: { createdAt: 'desc' },
-      include: { items: { include: { category: true } } }
+      include: { items: { include: { category: true, splits: true } } } // ★ Issue #78
     });
     res.json({ success: true, data: receipt });
   } catch (error) { next(error); }
@@ -443,5 +443,82 @@ export const getFamilyMembers = async (_req: Request, res: Response, next: NextF
     });
 
     res.json({ success: true, data: members });
+  } catch (error) { next(error); }
+};
+
+/**
+ * ★ [Issue #78] 明細（Item）の負担内訳（ItemSplit）を更新・保存する
+ * 要求されるデータ形式:
+ * { splits: [{ familyMemberId: 1, ratio: 0.5 }, { familyMemberId: 2, amount: 500 }] }
+ * 配列が空の場合は「按分なし」とみなし、既存のSplitを全削除します。
+ */
+export const updateItemSplits = async (req: Request, res: Response, next: NextFunction) => {
+  const { itemId } = req.params;
+  const { splits } = req.body;
+  const familyGroupId = getFamilyGroupId();
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      // 1. 対象明細の存在とテナント権限の確認
+      const item = await tx.item.findUnique({
+        where: { id: Number(itemId) },
+        include: { receipt: true }
+      });
+
+      if (!item || item.receipt.familyGroupId !== familyGroupId) {
+        throw new AppError('ItemNotFound', 404);
+      }
+
+      // 2. 空配列が送られてきた場合は、暗黙的デフォルト（按分なし）とみなして削除のみ行う
+      if (!splits || !Array.isArray(splits) || splits.length === 0) {
+        await tx.itemSplit.deleteMany({ where: { itemId: Number(itemId) } });
+        return { message: 'Splits cleared (Fallback to default payer)' };
+      }
+
+      // 3. 単価×数量を基準とする元金額の算出
+      const totalAmount = Math.round((item.price || 0) * (item.quantity || 1));
+      let allocatedAmount = 0;
+      const finalSplits: { familyMemberId: number; amount: number }[] = [];
+
+      // 4. 各メンバーへの金額割り当て計算
+      splits.forEach((split: any, index: number) => {
+        let amount = 0;
+
+        if (index === splits.length - 1) {
+          // ★ 端数丸め: 配列の最後のメンバーに「残額すべて」を寄せて合計不一致を防ぐ
+          amount = totalAmount - allocatedAmount;
+        } else if (split.amount !== undefined) {
+          amount = Math.round(Number(split.amount));
+        } else if (split.ratio !== undefined) {
+          amount = Math.round(totalAmount * Number(split.ratio));
+        }
+
+        allocatedAmount += amount;
+        finalSplits.push({
+          familyMemberId: Number(split.familyMemberId),
+          amount: amount,
+        });
+      });
+
+      // 5. 先頭要素への端数補正（allocatedAmountが超過・不足した場合のセーフティネット）
+      if (allocatedAmount !== totalAmount && finalSplits.length > 0) {
+        finalSplits[0].amount += (totalAmount - allocatedAmount);
+      }
+
+      // 6. DBの洗い替え（Delete & Insert）
+      await tx.itemSplit.deleteMany({ where: { itemId: Number(itemId) } });
+      await tx.itemSplit.createMany({
+        data: finalSplits.map(fs => ({
+          itemId: Number(itemId),
+          familyMemberId: fs.familyMemberId,
+          amount: fs.amount,
+        }))
+      });
+
+      // 更新後のSplitリストを返す
+      return await tx.itemSplit.findMany({ where: { itemId: Number(itemId) } });
+    });
+
+    res.json({ success: true, data: result });
   } catch (error) { next(error); }
 };

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,0 +1,99 @@
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../utils/prismaClient';
+import { getFamilyGroupId } from '../utils/context';
+
+/**
+ * [Issue #78] 月間精算ステータスの取得（暗黙的デフォルト対応）
+ * 対象月の「各メンバーの立替額」「各メンバーの負担額」を算出し、その差額（精算額）を返します。
+ */
+export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
+  const familyGroupId = getFamilyGroupId();
+  
+  // 対象月 (YYYY-MM形式)。指定がなければ今月。
+  const targetMonth = (req.query.month as string) || new Date().toISOString().slice(0, 7);
+
+  try {
+    const startDate = new Date(`${targetMonth}-01T00:00:00.000Z`);
+    const endDate = new Date(startDate);
+    endDate.setMonth(startDate.getMonth() + 1);
+
+    // 1. 対象グループの全メンバーを取得して初期化
+    const members = await prisma.familyMember.findMany({
+      where: { familyGroupId },
+      select: { id: true, name: true },
+    });
+
+    const stats: Record<number, { name: string; totalPaid: number; totalOwed: number; balance: number }> = {};
+    members.forEach(m => {
+      stats[m.id] = { name: m.name, totalPaid: 0, totalOwed: 0, balance: 0 };
+    });
+
+    // 2. 指定月・世帯のレシートを、明細とSplitを含めて取得
+    const receipts = await prisma.receipt.findMany({
+      where: {
+        familyGroupId,
+        date: { gte: startDate, lt: endDate },
+      },
+      include: {
+        items: {
+          include: { splits: true }
+        }
+      }
+    });
+
+    // 3. 集計ロジック（暗黙的デフォルト処理）
+    receipts.forEach(receipt => {
+      let receiptTotalPaid = 0; // そのレシートで立替えた総額
+
+      receipt.items.forEach(item => {
+        // 金額は整数（Int）丸めで計算
+        const itemPriceInt = Math.round((item.price || 0) * (item.quantity || 1));
+        receiptTotalPaid += itemPriceInt;
+
+        if (item.splits.length > 0) {
+          // パターン1: Splitが明示されている場合
+          item.splits.forEach(split => {
+            if (stats[split.familyMemberId]) {
+              stats[split.familyMemberId].totalOwed += split.amount; // Split側の金額（Int）を足す
+            }
+          });
+        } else {
+          // パターン2: 暗黙的デフォルト (Splitがない＝レシート支払者が全額負担)
+          if (stats[receipt.memberId]) {
+            stats[receipt.memberId].totalOwed += itemPriceInt;
+          }
+        }
+      });
+
+      // 立替額（実際にレジで支払った額）をレシートのmemberIdに加算
+      if (stats[receipt.memberId]) {
+        stats[receipt.memberId].totalPaid += receiptTotalPaid;
+      }
+    });
+
+    // 4. 最終的な精算額（balance）の計算
+    // balance > 0: 払いすぎている（他者から受け取るべき）
+    // balance < 0: 払いが足りない（他者に支払うべき）
+    const result = Object.entries(stats).map(([id, s]) => {
+      const balance = s.totalPaid - s.totalOwed;
+      return {
+        memberId: Number(id),
+        name: s.name,
+        totalPaid: s.totalPaid,
+        totalOwed: s.totalOwed,
+        balance: balance,
+      };
+    });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        month: targetMonth,
+        members: result
+      }
+    });
+
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -22,7 +22,8 @@ import {
   getJobStatus,
   getAdvancedStats,
   commitReceipt,
-  getFamilyMembers // ★ Issue #64: コントローラーから世帯メンバー取得関数をインポート
+  getFamilyMembers,
+  updateItemSplits // ★ Issue #78: 按分保存関数をインポート
 } from '../controllers/receiptController';
 
 const router = express.Router();
@@ -86,7 +87,7 @@ router.post(
 // --- 共通認証・テナントミドルウェア ---
 router.use(authMiddleware, tenantMiddleware);
 
-// ★ Issue #64: 所属世帯のメンバー一覧を取得するエンドポイントを追加
+// 所属世帯のメンバー一覧を取得するエンドポイント
 router.get('/family-groups/members', getFamilyMembers);
 
 router.get('/receipts', getReceipts);
@@ -97,10 +98,13 @@ router.get('/stats/advanced', getAdvancedStats);
 router.post('/receipts', createReceipt);
 router.delete('/receipts/:id', deleteReceipt);
 
-// Issue #67: 単価・数量（小数対応）を含むレシート全体の更新
+// レシート・明細更新系
 router.patch('/receipts/:id', updateReceipt);
-
 router.patch('/receipts/items/:id', updateItemCategory);
+
+// ★ Issue #78: 明細ごとの按分設定（ItemSplit）を保存するエンドポイント
+router.post('/receipts/items/:itemId/splits', updateItemSplits);
+
 router.post('/receipts/commit', commitReceipt);
 
 export default router;

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { getSettlementStatus } from '../controllers/statsController';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { tenantMiddleware } from '../middleware/tenantMiddleware';
+
+const router = express.Router();
+
+// 共通認証・テナントミドルウェア
+router.use(authMiddleware, tenantMiddleware);
+
+// ★ Issue #78: 月間精算ステータスの取得
+router.get('/settlement', getSettlementStatus);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,6 +18,7 @@ import receiptRoutes from './routes/receiptRoutes';
 import productMasterRoutes from './routes/productMasterRoutes'; 
 import categoryRoutes from './routes/categoryRoutes';
 import adminRoutes from './routes/adminRoutes'; // [Issue #72] 追加
+import statsRoutes from './routes/statsRoutes'; // ★ [Issue #78] 追加
 
 // --- エラーハンドリング ---
 import { AppError } from './utils/appError';
@@ -102,6 +103,7 @@ protectedApi.use(tenantMiddleware);
 protectedApi.use('/', receiptRoutes); 
 protectedApi.use('/categories', categoryRoutes);
 protectedApi.use('/product-master', productMasterRoutes);
+protectedApi.use('/stats', statsRoutes); // ★ [Issue #78] 統計・精算系ルートの追加
 
 app.use('/api', protectedApi);
 


### PR DESCRIPTION
Closes #78

## 変更内容
- `ItemSplit` モデルの追加およびマイグレーションの実行
- `POST /api/receipts/items/:itemId/splits` の実装（按分データの保存、端数丸め処理、暗黙的デフォルト対応）
- `GET /api/stats/settlement` の実装（月間精算額の集計、未按分明細の立替者100%負担化）
- `statsRoutes` の新規作成および `app.ts` へのマウント

## テスト・確認事項
- 開発環境でバックエンドコンテナが正常に起動することを確認
- Prismaマイグレーション (`add_item_split`) の適用を確認