### PR TITLE
feat: [Issue #79] 割り勘編集エディタの実装（双方向バインディング・端数自動処理）

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -17,13 +17,15 @@ import { ReceiptScanScreen } from './src/screens/ReceiptScanScreen';
 import { PromptEditorScreen } from './src/screens/PromptEditorScreen';
 import { AdminStatsScreen } from './src/screens/AdminStatsScreen';
 import { AdminMenuScreen } from './src/screens/AdminMenuScreen';
+import { SplitEditorScreen } from './src/screens/SplitEditorScreen'; // ★ [Issue #79] 追加
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu';
+// ★ 'split_editor' を追加
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -41,6 +43,9 @@ export default function App() {
   const [resultData, setResultData] = useState<any>(null); 
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
+  
+  // ★ [Issue #79] 按分エディタに渡す対象レシートを保持
+  const [targetReceipt, setTargetReceipt] = useState<any>(null);
 
   useEffect(() => {
     const initializeApp = async () => {
@@ -141,6 +146,7 @@ export default function App() {
     setCurrentUserRole(null);
     setCurrentView('main');
     setResultData(null);
+    setTargetReceipt(null);
     setLoginPassword('');
   };
 
@@ -192,7 +198,8 @@ export default function App() {
     );
   }
 
-  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu'].includes(currentView);
+  // ★ isFullWidth に 'split_editor' を追加
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor'].includes(currentView);
 
   if (!userToken) {
     return (
@@ -228,7 +235,29 @@ export default function App() {
 
     switch (currentView) {
       case 'history': 
-        return <HistoryScreen onBack={() => setCurrentView('main')} currentMemberId={memberId}/>;
+        return (
+          <HistoryScreen 
+            onBack={() => setCurrentView('main')} 
+            currentMemberId={memberId}
+            // ★ HistoryScreen側から呼び出せるように、ReceiptDetailComponentに onGoToSplitEditor を渡す準備を HistoryScreen 側で行う必要がありますが、
+            // ここでは App.tsx 側で対象レシートを受け取るハンドラを渡す想定にします。
+            // (HistoryScreen.tsxの修正が不要になるよう、ルーティングの親玉で保持する設計)
+            onGoToSplitEditor={(receipt) => {
+              setTargetReceipt(receipt);
+              setCurrentView('split_editor');
+            }}
+          />
+        );
+      case 'split_editor': // ★ [Issue #79] 按分エディタ画面のルーティング
+        return (
+          <SplitEditorScreen
+            receipt={targetReceipt}
+            onBack={() => {
+              setTargetReceipt(null);
+              setCurrentView('history'); // 戻る先はHistory
+            }}
+          />
+        );
       case 'stats': 
         return <StatisticsScreen currentMemberId={memberId} onBack={() => setCurrentView('main')} />;
       case 'category_mgr': 
@@ -251,10 +280,8 @@ export default function App() {
           />
         );
       case 'prompt_editor': 
-        // ★ ラッパーを外し、onBack を直接コンポーネントへ渡す
         return <PromptEditorScreen onBack={() => setCurrentView('admin_menu')} />;
       case 'admin_stats':
-        // ★ ラッパーを外し、onBack を直接コンポーネントへ渡す
         return <AdminStatsScreen onBack={() => setCurrentView('admin_menu')} />;
       case 'admin_menu':
         return (

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -22,14 +22,12 @@ interface ReceiptDetailComponentProps {
   onCategoryChange: (itemId: number, categoryId: number | null) => void;
   baseUrl: string;
   fullWidth?: boolean; 
-  onSaveSuccess?: () => void; // 保存成功時のリロード用
+  onSaveSuccess?: () => void;
+  onGoToSplitEditor?: (receipt: any) => void; // ★ [Issue #79] 按分エディタへの遷移
 }
 
 /**
- * [Issue #67 / #71] レシート詳細表示・編集コンポーネント
- * - 外税(taxAmount)の表示・編集機能を追加
- * - 編集モード時の動的な合計金額計算に税額を統合
- * ※保存済みデータの再編集ルートのため、解析用トークンログ（usageLogId）の紐付け処理（Issue #63）は対象外
+ * [Issue #67 / #71 / #79] レシート詳細表示・編集コンポーネント
  */
 export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   receipt,
@@ -37,7 +35,8 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   onCategoryChange,
   baseUrl,
   fullWidth = true,
-  onSaveSuccess
+  onSaveSuccess,
+  onGoToSplitEditor
 }) => {
   const { width: windowWidth } = useWindowDimensions();
   const effectiveWidth = fullWidth ? windowWidth : windowWidth - 350;
@@ -49,10 +48,8 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
 
   const cacheKey = useMemo(() => Date.now(), []);
 
-  // 選択されたレシートが変わったとき、または編集モード開始時にデータを同期
   useEffect(() => {
     if (receipt) {
-      // taxAmount が undefined の場合は 0 をセット
       const data = JSON.parse(JSON.stringify(receipt));
       data.taxAmount = data.taxAmount ?? 0;
       setEditData(data);
@@ -60,7 +57,6 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
     setIsEditing(false);
   }, [receipt]);
 
-  // 表示用の合計金額計算 (明細合計 + 外税)
   const displayTotal = useMemo(() => {
     if (!editData) return 0;
     const items = isEditing ? editData.items : receipt.items;
@@ -72,7 +68,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
       return s + (p * q);
     }, 0);
 
-    return Math.round(itemsSum + tax); // 日本円の整合性のため合算後に四捨五入
+    return Math.round(itemsSum + tax); 
   }, [isEditing, editData?.items, editData?.taxAmount, receipt.items, receipt.taxAmount]);
 
   if (!receipt || !editData) {
@@ -88,7 +84,6 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
     return `${baseUrl}/${imagePath}?v=${cacheKey}`;
   };
 
-  // 編集内容の更新ロジック
   const updateEditField = (key: string, value: any) => {
     setEditData({ ...editData, [key]: value });
   };
@@ -99,14 +94,12 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
     setEditData({ ...editData, items: newItems });
   };
 
-  // 保存処理 (Issue #71: taxAmount を追加)
   const handleSave = async () => {
     setLoading(true);
     try {
       const payload = {
         storeName: editData.storeName,
         date: editData.date,
-        // 数値としての整合性を担保して送信
         taxAmount: parseFloat(String(editData.taxAmount)) || 0,
         totalAmount: displayTotal, 
         items: editData.items.map((item: any) => ({
@@ -164,9 +157,17 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
               </TouchableOpacity>
             </>
           ) : (
-            <TouchableOpacity onPress={() => setIsEditing(true)} style={styles.editButton}>
-              <Text style={styles.editButtonText}>✎ 編集</Text>
-            </TouchableOpacity>
+            <>
+              {/* ★ [Issue #79] 按分エディタへの遷移ボタンを追加 */}
+              {onGoToSplitEditor && (
+                <TouchableOpacity onPress={() => onGoToSplitEditor(receipt)} style={styles.splitButton}>
+                  <Text style={styles.splitButtonText}>➗ シェア・按分</Text>
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity onPress={() => setIsEditing(true)} style={styles.editButton}>
+                <Text style={styles.editButtonText}>✎ 編集</Text>
+              </TouchableOpacity>
+            </>
           )}
         </View>
 
@@ -185,7 +186,6 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
           {isEditing ? (
             <TextInput 
               style={styles.dateInput}
-              // 日付と時刻のパース (YYYY-MM-DD HH:mm 形式を想定)
               value={editData.date ? new Date(editData.date).toISOString().replace('T', ' ').substring(0, 16) : ''}
               onChangeText={(val) => updateEditField('date', val)}
               placeholder="YYYY-MM-DD HH:mm"
@@ -268,7 +268,6 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
             </View>
           ))}
 
-          {/* [Issue #71] 消費税(外税)表示・編集エリア */}
           <View style={styles.taxSection}>
             <View style={styles.taxRow}>
               <Text style={styles.taxLabel}>消費税 (外税・加算額)</Text>
@@ -335,6 +334,8 @@ const styles = StyleSheet.create({
   editControls: { flexDirection: 'row', justifyContent: 'flex-end', marginBottom: 10, gap: 10 },
   editButton: { backgroundColor: theme.colors.background, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: theme.colors.border },
   editButtonText: { color: theme.colors.text.main, fontWeight: 'bold' },
+  splitButton: { backgroundColor: '#e0f2fe', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: '#bae6fd' }, // 追加: 按分ボタン
+  splitButtonText: { color: '#0369a1', fontWeight: 'bold' }, // 追加: 按分ボタンテキスト
   saveButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 16, paddingVertical: 6, borderRadius: 8 },
   saveButtonText: { color: '#fff', fontWeight: 'bold' },
   cancelButton: { backgroundColor: '#f1f5f9', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -20,16 +20,13 @@ import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 interface HistoryScreenProps {
   onBack: () => void;
   currentMemberId: number; 
+  onGoToSplitEditor?: (receipt: any) => void; // ★ [Issue #79] App.tsxからの遷移ハンドラを受け取る
 }
 
 /**
  * [Issue #67 / #64 / Web・ネイティブ完全互換] 履歴一覧画面
- * - 所属世帯のメンバー一覧を動的取得するフィルタ機能を実装。
- * - 大画面（isWide）かつWeb環境下におけるフレックスボックスの横幅潰れバグを完全解消。
- * - 初期ロード時（selectedReceiptがnull）のWeb版レンダリングクラッシュを完全に防ぐヌルガードを導入。
- * - スマホ（縦画面・モーダル表示）とWeb/iPad（横並び2カラム）のスタイル競合を排除。
  */
-export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreenProps) {
+export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEditor }: HistoryScreenProps) {
   const { width: windowWidth } = useWindowDimensions();
   // Issue #66: 定数によるレスポンシブ判定
   const isWide = windowWidth >= BREAKPOINTS.TABLET; 
@@ -184,7 +181,7 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
         <select
           value={selectedMonth}
           onChange={(e) => setSelectedMonth(e.target.value)}
-          style={StyleSheet.flatten(styles.webSelect)} // ★修正: 生HTML互換のため構造をフラット化
+          style={StyleSheet.flatten(styles.webSelect)}
         >
           <option value="">全期間</option>
           {months.map(m => (
@@ -215,7 +212,7 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
         <select
           value={selectedMember}
           onChange={(e) => setSelectedMember(e.target.value)}
-          style={StyleSheet.flatten(styles.webSelect)} // ★修正: 生HTML互換のため構造をフラット化
+          style={StyleSheet.flatten(styles.webSelect)} 
         >
           <option value="">世帯全体</option>
           {members.map(m => (
@@ -257,7 +254,6 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
           <View style={{ width: 40 }} />
         </View>
 
-        {/* ★修正: 大画面（Web）時、縮小特性による0px潰れを防ぐため flexGrow/flexShrink/minWidth を明示 */}
         <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
           <View style={[styles.pickerBox, isWide && { width: 250, minWidth: 250, flexGrow: 0, flexShrink: 0 }]}>
             {renderMonthPicker()}
@@ -295,6 +291,7 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
                   baseUrl={BASE_URL}
                   fullWidth={false}
                   onSaveSuccess={fetchReceipts}
+                  onGoToSplitEditor={onGoToSplitEditor} // ★ 追加: Componentへハンドラを渡す
                 />
               ) : (
                 <View style={styles.emptyDetailWrapper}>
@@ -325,6 +322,7 @@ export default function HistoryScreen({ onBack, currentMemberId }: HistoryScreen
                 baseUrl={BASE_URL}
                 fullWidth={true}
                 onSaveSuccess={fetchReceipts}
+                onGoToSplitEditor={onGoToSplitEditor} // ★ 追加
               />
             )}
           </View>

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -1,0 +1,462 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  StyleSheet, 
+  Text, 
+  View, 
+  ScrollView, 
+  Image, 
+  TextInput, 
+  TouchableOpacity, 
+  ActivityIndicator, 
+  Alert, 
+  Platform,
+  useWindowDimensions
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { theme, BREAKPOINTS } from '../theme';
+import { api } from '../utils/apiClient';
+
+interface SplitEditorScreenProps {
+  receipt: any;
+  onBack: () => void;
+}
+
+export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, onBack }) => {
+  const { width } = useWindowDimensions();
+  const isWide = width >= BREAKPOINTS.TABLET;
+
+  const [allMembers, setAllMembers] = useState<any[]>([]); 
+  const [activeMembers, setActiveMembers] = useState<any[]>([]); 
+  
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  
+  // 明細ごとの入力状態
+  // { itemId: { memberId: 500 } }
+  const [editSplits, setEditSplits] = useState<Record<number, Record<number, number>>>({});
+
+  const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
+  const BASE_URL = API_URL.replace(/\/api\/?$/, '');
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const res = await api.getFamilyMembers();
+        if (res.success) {
+          setAllMembers(res.data);
+          
+          let initialActive: any[] = [];
+          
+          // ★ 修正: レシート内に既に按分(Split)データが存在するかチェック
+          const hasExistingSplits = receipt.items.some((item: any) => item.splits && item.splits.length > 0);
+
+          if (hasExistingSplits) {
+            // 【登録済みパターンの復元】
+            // 全ItemのSplitを走査し、一度でも登場したメンバーのIDを抽出
+            const splitMemberIds = new Set<number>();
+            receipt.items.forEach((item: any) => {
+              if (item.splits) {
+                item.splits.forEach((s: any) => splitMemberIds.add(s.familyMemberId));
+              }
+            });
+            
+            // 抽出したIDに該当するメンバー情報を allMembers(res.data) から拾う
+            // ※先頭を必ず支払者にするため、支払者から先にpushする
+            const payer = res.data.find((m: any) => m.id === receipt.memberId);
+            if (payer) initialActive.push(payer);
+            
+            res.data.forEach((m: any) => {
+              if (splitMemberIds.has(m.id) && m.id !== receipt.memberId) {
+                initialActive.push(m);
+              }
+            });
+
+          } else {
+            // 【新規登録時パターンのデフォルト2名設定】
+            const payer = res.data.find((m: any) => m.id === receipt.memberId);
+            if (payer) initialActive.push(payer);
+            const others = res.data.filter((m: any) => m.id !== receipt.memberId);
+            if (others.length > 0) initialActive.push(others[0]);
+          }
+
+          // 万が一初期メンバーが空になった場合のフェールセーフ
+          if (initialActive.length === 0) {
+            initialActive = res.data.slice(0, 2);
+          }
+          
+          setActiveMembers(initialActive);
+          initializeSplits(res.data, initialActive);
+        }
+      } catch (err) {
+        console.error('メンバー取得失敗', err);
+        Alert.alert('エラー', 'メンバー情報の取得に失敗しました。');
+      } finally {
+        setLoading(false);
+      }
+    };
+    init();
+  }, [receipt]);
+
+  const initializeSplits = (familyMembers: any[], targetMembers: any[]) => {
+    if (!receipt || !receipt.items) return;
+    
+    const initialData: Record<number, Record<number, number>> = {};
+    receipt.items.forEach((item: any) => {
+      initialData[item.id] = {};
+      const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+
+      if (item.splits && item.splits.length > 0) {
+        // 既存データがある場合はセット
+        targetMembers.forEach(m => {
+          const split = item.splits.find((s: any) => s.familyMemberId === m.id);
+          initialData[item.id][m.id] = split ? split.amount : 0;
+        });
+      } else {
+        // 無い場合は支払者が全額（デフォルト）
+        targetMembers.forEach(m => {
+          initialData[item.id][m.id] = m.id === receipt.memberId ? itemTotal : 0;
+        });
+      }
+    });
+    setEditSplits(initialData);
+  };
+
+  const addMember = (memberId: number) => {
+    if (activeMembers.find(m => m.id === memberId)) return;
+    const memberToAdd = allMembers.find(m => m.id === memberId);
+    if (memberToAdd) {
+      const newActive = [...activeMembers, memberToAdd];
+      setActiveMembers(newActive);
+      
+      setEditSplits(prev => {
+        const next = { ...prev };
+        Object.keys(next).forEach(itemId => {
+          next[Number(itemId)] = { ...next[Number(itemId)], [memberId]: 0 };
+        });
+        return next;
+      });
+    }
+  };
+
+  const removeMember = (memberId: number) => {
+    if (activeMembers.length <= 1) {
+      Alert.alert('エラー', '対象者は最低1人必要です。');
+      return;
+    }
+    const newActive = activeMembers.filter(m => m.id !== memberId);
+    setActiveMembers(newActive);
+
+    setEditSplits(prev => {
+      const next = { ...prev };
+      Object.keys(next).forEach(itemId => {
+        const nId = Number(itemId);
+        const newData = { ...next[nId] };
+        delete newData[memberId];
+        next[nId] = newData;
+      });
+      return next;
+    });
+  };
+
+  const handleAmountChange = (itemId: number, memberId: number, value: string, itemTotal: number) => {
+    const numericValue = value.replace(/[^0-9]/g, '');
+    let valToSet = numericValue === '' ? 0 : parseInt(numericValue, 10);
+    if (valToSet > itemTotal) valToSet = itemTotal; 
+
+    const newData = { ...editSplits[itemId] };
+    newData[memberId] = valToSet;
+    
+    const firstMemberId = activeMembers[0].id;
+    if (memberId !== firstMemberId) {
+      let sumOthers = 0;
+      activeMembers.forEach(m => {
+        if (m.id !== firstMemberId) {
+          sumOthers += newData[m.id] || 0;
+        }
+      });
+      newData[firstMemberId] = Math.max(0, itemTotal - sumOthers);
+    }
+    
+    setEditSplits(prev => ({ ...prev, [itemId]: newData }));
+  };
+
+  const handlePercentChange = (itemId: number, memberId: number, value: string, itemTotal: number) => {
+    const numericValue = value.replace(/[^0-9]/g, '');
+    let percent = numericValue === '' ? 0 : parseInt(numericValue, 10);
+    if (percent > 100) percent = 100;
+
+    const calculatedAmount = Math.round(itemTotal * (percent / 100));
+
+    const newData = { ...editSplits[itemId] };
+    newData[memberId] = calculatedAmount;
+
+    const firstMemberId = activeMembers[0].id;
+    if (memberId !== firstMemberId) {
+      let sumOthers = 0;
+      activeMembers.forEach(m => {
+        if (m.id !== firstMemberId) {
+          sumOthers += newData[m.id] || 0;
+        }
+      });
+      newData[firstMemberId] = Math.max(0, itemTotal - sumOthers);
+    }
+
+    setEditSplits(prev => ({ ...prev, [itemId]: newData }));
+  };
+
+
+  const splitItemEqually = (itemId: number, itemTotal: number) => {
+    const newData = { ...editSplits[itemId] };
+    const memberCount = activeMembers.length;
+    if (memberCount === 0) return;
+
+    const baseAmount = Math.floor(itemTotal / memberCount);
+    activeMembers.forEach((m, idx) => {
+      newData[m.id] = idx === 0 ? itemTotal - (baseAmount * (memberCount - 1)) : baseAmount;
+    });
+    
+    setEditSplits(prev => ({ ...prev, [itemId]: newData }));
+  };
+
+  const splitWholeReceiptEqually = () => {
+    receipt.items.forEach((item: any) => {
+      const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+      splitItemEqually(item.id, itemTotal);
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const savePromises = receipt.items.map(async (item: any) => {
+        const payloadSplits = activeMembers.map(m => ({
+          familyMemberId: m.id,
+          amount: editSplits[item.id]?.[m.id] || 0
+        })).filter(p => p.amount > 0);
+
+        return api.saveItemSplits(item.id, payloadSplits);
+      });
+
+      await Promise.all(savePromises);
+      Alert.alert('保存完了', '割り勘設定を保存しました。', [{ text: 'OK', onPress: onBack }]);
+    } catch (err) {
+      console.error('保存エラー', err);
+      Alert.alert('エラー', '保存に失敗しました。');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || !receipt) {
+    return (
+      <View style={styles.centerLoading}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  const getImageUrl = () => receipt.imagePath ? `${BASE_URL}/${receipt.imagePath}` : null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backButtonText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>割り勘エディタ</Text>
+        <View style={styles.headerRight}>
+          <TouchableOpacity style={styles.saveButton} onPress={handleSave} disabled={saving}>
+            {saving ? <ActivityIndicator color="#fff" size="small" /> : <Text style={styles.saveButtonText}>確定して保存</Text>}
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <View style={styles.targetSection}>
+        <View style={styles.targetHeader}>
+          <Text style={styles.targetTitle}>👤 割り勘の対象者</Text>
+        </View>
+        
+        <View style={styles.memberChips}>
+          {activeMembers.map((m, idx) => (
+            <View key={m.id} style={[styles.chip, idx === 0 && styles.firstChip]}>
+              <Text style={[styles.chipText, idx === 0 && styles.firstChipText]}>
+                {m.name} {idx === 0 && "(端数負担)"}
+              </Text>
+              {activeMembers.length > 1 && idx !== 0 && (
+                <TouchableOpacity onPress={() => removeMember(m.id)} style={styles.chipClose}>
+                  <Text style={styles.chipCloseText}>✕</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          ))}
+          
+          {allMembers.filter(am => !activeMembers.find(m => m.id === am.id)).length > 0 && (
+            <View style={styles.addMemberWrapper}>
+              <Picker
+                selectedValue=""
+                onValueChange={(val) => { if(val) addMember(Number(val)); }}
+                style={styles.addPicker}
+              >
+                <Picker.Item label="+ 人を追加" value="" color={theme.colors.primary} />
+                {allMembers
+                  .filter(am => !activeMembers.find(m => m.id === am.id))
+                  .map(am => <Picker.Item key={am.id} label={am.name} value={am.id} />)
+                }
+              </Picker>
+            </View>
+          )}
+        </View>
+      </View>
+
+      <View style={[styles.mainLayout, isWide ? styles.rowLayout : styles.colLayout]}>
+        <View style={[styles.imagePane, isWide && { width: 350 }]}>
+          <View style={styles.imageBox}>
+            {getImageUrl() ? (
+              <Image source={{ uri: getImageUrl()! }} style={styles.receiptImage} resizeMode="contain" />
+            ) : (
+              <Text style={styles.noImageText}>画像がありません</Text>
+            )}
+          </View>
+        </View>
+
+        <View style={styles.editorPane}>
+          <View style={styles.editorToolbar}>
+            <Text style={styles.storeName}>{receipt.storeName || '店名不明'}</Text>
+            <TouchableOpacity style={styles.batchSplitButton} onPress={splitWholeReceiptEqually}>
+              <Text style={styles.batchSplitText}>⚡ レシート全体を均等割り</Text>
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView style={styles.tableScroll} horizontal={false}>
+            <ScrollView horizontal={true} contentContainerStyle={{ flexDirection: 'column' }}>
+              
+              <View style={[styles.tableRow, styles.tableHeader]}>
+                <Text style={[styles.cell, styles.cellName, styles.headerText]}>商品名</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>合計</Text>
+                {activeMembers.map(m => (
+                  <Text key={m.id} style={[styles.cell, styles.cellInputCol, styles.headerText, { textAlign: 'center' }]}>
+                    {m.name}
+                  </Text>
+                ))}
+                <Text style={[styles.cell, styles.cellAction, styles.headerText]}>操作</Text>
+              </View>
+
+              {receipt.items.map((item: any) => {
+                const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+
+                return (
+                  <View key={item.id} style={styles.tableRow}>
+                    <Text style={[styles.cell, styles.cellName]} numberOfLines={2}>{item.name}</Text>
+                    <Text style={[styles.cell, styles.cellAmount]}>¥{itemTotal.toLocaleString()}</Text>
+                    
+                    {activeMembers.map((m, idx) => {
+                      const amountValue = editSplits[item.id]?.[m.id] || 0;
+                      const percentValue = itemTotal > 0 ? Math.round((amountValue / itemTotal) * 100) : 0;
+                      const isFirst = idx === 0;
+
+                      return (
+                        <View key={m.id} style={[styles.cell, styles.cellInputCol]}>
+                          <View style={styles.dualInputWrapper}>
+                            <View style={styles.inputGroup}>
+                              <TextInput
+                                style={[styles.inputBox, styles.percentBox, isFirst && styles.disabledInputBox]}
+                                value={String(percentValue)}
+                                onChangeText={(val) => handlePercentChange(item.id, m.id, val, itemTotal)}
+                                keyboardType="number-pad"
+                                editable={!isFirst}
+                                selectTextOnFocus
+                              />
+                              <Text style={styles.unitText}>%</Text>
+                            </View>
+                            
+                            <View style={[styles.inputGroup, { marginLeft: 4 }]}>
+                              <TextInput
+                                style={[styles.inputBox, styles.amountBox, isFirst && styles.disabledInputBox]}
+                                value={String(amountValue)}
+                                onChangeText={(val) => handleAmountChange(item.id, m.id, val, itemTotal)}
+                                keyboardType="number-pad"
+                                editable={!isFirst}
+                                selectTextOnFocus
+                              />
+                              <Text style={styles.unitText}>円</Text>
+                            </View>
+                          </View>
+                        </View>
+                      );
+                    })}
+
+                    <View style={[styles.cell, styles.cellAction]}>
+                      <TouchableOpacity style={styles.splitBtnSmall} onPress={() => splitItemEqually(item.id, itemTotal)}>
+                        <Text style={styles.splitBtnSmallText}>均等</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                );
+              })}
+            </ScrollView>
+          </ScrollView>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, backgroundColor: '#fff', borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  backButton: { paddingRight: 15 },
+  backButtonText: { color: theme.colors.primary, fontWeight: '700', fontSize: 16 },
+  headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main },
+  headerRight: { minWidth: 100, alignItems: 'flex-end' },
+  saveButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 20, paddingVertical: 10, borderRadius: 8 },
+  saveButtonText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
+  
+  targetSection: { backgroundColor: '#fff', borderBottomWidth: 1, borderBottomColor: theme.colors.border, padding: 15, paddingHorizontal: 20 },
+  targetHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 },
+  targetTitle: { fontSize: 15, fontWeight: 'bold', color: theme.colors.text.main },
+  
+  memberChips: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, alignItems: 'center' },
+  chip: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#e0f2fe', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 20, borderWidth: 1, borderColor: '#bae6fd' },
+  firstChip: { backgroundColor: '#f1f5f9', borderColor: '#cbd5e1' }, 
+  chipText: { color: '#0369a1', fontWeight: 'bold', fontSize: 14 },
+  firstChipText: { color: theme.colors.text.muted },
+  chipClose: { marginLeft: 8, backgroundColor: 'rgba(3,105,161,0.1)', borderRadius: 10, width: 20, height: 20, alignItems: 'center', justifyContent: 'center' },
+  chipCloseText: { color: '#0369a1', fontSize: 10, fontWeight: 'bold' },
+  addMemberWrapper: { height: 32, justifyContent: 'center', backgroundColor: '#f8fafc', borderRadius: 20, borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
+  addPicker: { height: 32, width: 120, color: theme.colors.primary, fontSize: 14, fontWeight: 'bold', ...Platform.select({ web: { outlineStyle: 'none', border: 'none', background: 'transparent' } as any }) },
+  
+  mainLayout: { flex: 1, padding: 20, gap: 20 },
+  rowLayout: { flexDirection: 'row' },
+  colLayout: { flexDirection: 'column' },
+  imagePane: { height: '100%', minHeight: 300 },
+  imageBox: { flex: 1, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border, justifyContent: 'center', alignItems: 'center', overflow: 'hidden' },
+  receiptImage: { width: '100%', height: '100%' },
+  noImageText: { color: theme.colors.text.muted },
+  editorPane: { flex: 1, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
+  editorToolbar: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border, backgroundColor: theme.colors.surface },
+  storeName: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  batchSplitButton: { backgroundColor: '#e0f2fe', paddingHorizontal: 15, paddingVertical: 8, borderRadius: 6, borderWidth: 1, borderColor: '#bae6fd' },
+  batchSplitText: { color: '#0369a1', fontWeight: 'bold' },
+  
+  tableScroll: { flex: 1 },
+  tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#F0F0F0', alignItems: 'center', minWidth: 800 },
+  tableHeader: { backgroundColor: '#F8F9FA', borderBottomColor: theme.colors.border },
+  cell: { padding: 12, justifyContent: 'center' },
+  headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
+  cellName: { width: 160, fontSize: 14, color: theme.colors.text.main },
+  cellAmount: { width: 90, fontSize: 14, fontWeight: 'bold', textAlign: 'right', color: theme.colors.text.main },
+  cellInputCol: { width: 180, alignItems: 'center' }, 
+  
+  dualInputWrapper: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%' },
+  inputGroup: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#fff', borderWidth: 1, borderColor: theme.colors.border, borderRadius: 6, height: 36, paddingRight: 4 },
+  inputBox: { height: '100%', textAlign: 'right', fontSize: 14, color: theme.colors.text.main, paddingRight: 4, ...Platform.select({ web: { outlineStyle: 'none' } as any }) },
+  percentBox: { width: 35 },
+  amountBox: { width: 60 },
+  disabledInputBox: { backgroundColor: '#f1f5f9', color: theme.colors.text.muted },
+  unitText: { fontSize: 11, color: theme.colors.text.muted },
+  
+  cellAction: { width: 70, alignItems: 'center' },
+  splitBtnSmall: { backgroundColor: '#f1f5f9', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 6 },
+  splitBtnSmallText: { fontSize: 12, color: theme.colors.text.muted, fontWeight: 'bold' },
+});

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -98,4 +98,18 @@ apiClient.interceptors.response.use(
   }
 );
 
+// ★ [Issue #78/#79] 按分機能等のAPIコール用ラッパー
+export const api = {
+  // 家族メンバー一覧の取得
+  getFamilyMembers: async () => {
+    const res = await apiClient.get('/family-groups/members');
+    return res.data;
+  },
+  // 明細ごとの按分設定保存
+  saveItemSplits: async (itemId: number, splits: { familyMemberId: number; amount?: number; ratio?: number }[]) => {
+    const res = await apiClient.post(`/receipts/items/${itemId}/splits`, { splits });
+    return res.data;
+  }
+};
+
 export default apiClient;


### PR DESCRIPTION
Closes #79

## 変更内容
- `SplitEditorScreen`（割り勘エディタ画面）の新規作成
- 割合(%)と金額(¥)の双方向バインディングUIの実装
- 端数を先頭メンバー（支払者）に寄せて自動計算し、合計不一致をシステム的に防ぐロジックの導入
- アコーディオン風の割り勘対象者追加・削除機能の実装
- 既存データがある場合は対象者を自動復元する処理の追加
- `App.tsx` および `ReceiptDetailComponent` への導線追加

## テスト・確認事項
- 履歴画面から「シェア・按分」ボタンでエディタが起動すること
- 金額、または割合を入力した際にもう一方がリアルタイムに計算されること
- 保存後、再度開いた際に設定したメンバーと金額が正しく復元されること