### PR TITLE
feat: [Issue #80] 月間精算サマリー画面の実装

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -17,15 +17,16 @@ import { ReceiptScanScreen } from './src/screens/ReceiptScanScreen';
 import { PromptEditorScreen } from './src/screens/PromptEditorScreen';
 import { AdminStatsScreen } from './src/screens/AdminStatsScreen';
 import { AdminMenuScreen } from './src/screens/AdminMenuScreen';
-import { SplitEditorScreen } from './src/screens/SplitEditorScreen'; // ★ [Issue #79] 追加
+import { SplitEditorScreen } from './src/screens/SplitEditorScreen'; 
+import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen'; // ★ [Issue #80] 追加
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-// ★ 'split_editor' を追加
-type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor';
+// ★ 'settlement_summary' を追加
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -44,7 +45,6 @@ export default function App() {
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
   
-  // ★ [Issue #79] 按分エディタに渡す対象レシートを保持
   const [targetReceipt, setTargetReceipt] = useState<any>(null);
 
   useEffect(() => {
@@ -198,8 +198,8 @@ export default function App() {
     );
   }
 
-  // ★ isFullWidth に 'split_editor' を追加
-  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor'].includes(currentView);
+  // ★ isFullWidth に 'settlement_summary' を追加
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary'].includes(currentView);
 
   if (!userToken) {
     return (
@@ -239,23 +239,26 @@ export default function App() {
           <HistoryScreen 
             onBack={() => setCurrentView('main')} 
             currentMemberId={memberId}
-            // ★ HistoryScreen側から呼び出せるように、ReceiptDetailComponentに onGoToSplitEditor を渡す準備を HistoryScreen 側で行う必要がありますが、
-            // ここでは App.tsx 側で対象レシートを受け取るハンドラを渡す想定にします。
-            // (HistoryScreen.tsxの修正が不要になるよう、ルーティングの親玉で保持する設計)
             onGoToSplitEditor={(receipt) => {
               setTargetReceipt(receipt);
               setCurrentView('split_editor');
             }}
           />
         );
-      case 'split_editor': // ★ [Issue #79] 按分エディタ画面のルーティング
+      case 'split_editor': 
         return (
           <SplitEditorScreen
             receipt={targetReceipt}
             onBack={() => {
               setTargetReceipt(null);
-              setCurrentView('history'); // 戻る先はHistory
+              setCurrentView('history'); 
             }}
+          />
+        );
+      case 'settlement_summary': // ★ [Issue #80] 精算サマリー画面のルーティング追加
+        return (
+          <SettlementSummaryScreen
+            onBack={() => setCurrentView('main')}
           />
         );
       case 'stats': 
@@ -304,6 +307,8 @@ export default function App() {
               onAnalysisReady={handleAnalysisReady} 
               onGoToHistory={() => setCurrentView('history')}
               onGoToStats={() => setCurrentView('stats')}
+              // ★ [Issue #80] ハンドラを注入
+              onGoToSettlement={() => setCurrentView('settlement_summary')}
               onGoToAdminMenu={() => setCurrentView('admin_menu')} 
               currentMemberId={memberId}
               userRole={currentUserRole}

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -20,7 +20,8 @@ interface HomeScreenProps {
   onAnalysisReady: (data: any) => void; 
   onGoToHistory: () => void;
   onGoToStats: () => void;
-  onGoToAdminMenu?: () => void; // [Issue #73] 個別遷移を廃止し、ハブ画面への遷移へ統合
+  onGoToSettlement?: () => void; // ★ [Issue #80] 精算サマリー画面への遷移ハンドラを追加
+  onGoToAdminMenu?: () => void;
   currentMemberId: number;
   userRole?: string | null;
 }
@@ -32,6 +33,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   onAnalysisReady, 
   onGoToHistory, 
   onGoToStats, 
+  onGoToSettlement, // ★ 追加
   onGoToAdminMenu,
   currentMemberId,
   userRole 
@@ -191,18 +193,26 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           </View>
         </TouchableOpacity>
 
-        <View style={[styles.row, isWide && styles.wideRow]}>
-          <TouchableOpacity style={[styles.menuCard, isWide && styles.wideMenuCard]} onPress={onGoToHistory}>
+        {/* メニューカード群：グリッド表示 */}
+        <View style={styles.gridContainer}>
+          <TouchableOpacity style={styles.gridCard} onPress={onGoToHistory}>
             <Text style={{ fontSize: 28, marginBottom: 8 }}>📋</Text>
             <Text style={styles.menuLabel}>履歴一覧</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={[styles.menuCard, isWide && styles.wideMenuCard]} onPress={onGoToStats}>
+          <TouchableOpacity style={styles.gridCard} onPress={onGoToStats}>
             <Text style={{ fontSize: 28, marginBottom: 8 }}>📊</Text>
             <Text style={styles.menuLabel}>支出統計</Text>
           </TouchableOpacity>
+          {/* ★ [Issue #80] 精算サマリーへの遷移ボタン */}
+          {onGoToSettlement && (
+            <TouchableOpacity style={styles.gridCard} onPress={onGoToSettlement}>
+              <Text style={{ fontSize: 28, marginBottom: 8 }}>🤝</Text>
+              <Text style={styles.menuLabel}>精算サマリー</Text>
+            </TouchableOpacity>
+          )}
         </View>
 
-        {/* [Issue #73] 管理者限定メニューへのハブ導線 */}
+        {/* 管理者限定メニューへのハブ導線 */}
         {isAdmin && (
           <View style={styles.section}>
             <TouchableOpacity style={[styles.settingsCard, { backgroundColor: '#F8F9FA' }]} onPress={onGoToAdminMenu}>
@@ -257,10 +267,11 @@ const styles = StyleSheet.create({
   iconCircle: { width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.primary, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
   captureButtonText: { ...theme.typography.h2, color: theme.colors.primary },
   jobStatusText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 2 },
-  row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: theme.spacing.md },
-  wideRow: { justifyContent: 'flex-start', gap: theme.spacing.md },
-  menuCard: { backgroundColor: theme.colors.surface, width: (windowWidth - theme.spacing.lg * 2 - theme.spacing.md) / 2, maxWidth: 280, borderRadius: theme.borderRadius.md, padding: theme.spacing.lg, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border },
-  wideMenuCard: { width: '48%' },
+  
+  // ★ メニュー部分を Grid (flexWrap) 対応に変更
+  gridContainer: { flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.md, marginBottom: theme.spacing.md },
+  gridCard: { flexGrow: 1, minWidth: 100, flexBasis: '30%', backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.lg, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border },
+  
   menuLabel: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text.main },
   section: { marginTop: theme.spacing.lg },
   sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.sm },

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { 
+  StyleSheet, 
+  Text, 
+  View, 
+  ScrollView, 
+  TouchableOpacity, 
+  ActivityIndicator, 
+  Platform,
+  useWindowDimensions
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { theme, BREAKPOINTS } from '../theme';
+import { api } from '../utils/apiClient';
+
+interface SettlementSummaryScreenProps {
+  onBack: () => void;
+}
+
+export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = ({ onBack }) => {
+  const { width } = useWindowDimensions();
+  const isWide = width >= BREAKPOINTS.TABLET;
+
+  const [loading, setLoading] = useState(true);
+  const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [summaryData, setSummaryData] = useState<any[]>([]);
+
+  // 過去6ヶ月の選択肢を生成
+  const months = useMemo(() => {
+    return Array.from({ length: 6 }).map((_, i) => {
+      const d = new Date();
+      d.setMonth(d.getMonth() - i);
+      return d.toISOString().slice(0, 7);
+    });
+  }, []);
+
+  const loadSettlementData = async () => {
+    try {
+      setLoading(true);
+      const res = await api.getSettlementStatus(selectedMonth);
+      if (res.success) {
+        setSummaryData(res.data.members || []);
+      }
+    } catch (err) {
+      console.error('精算サマリーの取得失敗:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSettlementData();
+  }, [selectedMonth]);
+
+  const renderMonthPicker = () => {
+    if (Platform.OS === 'web') {
+      return (
+        <select
+          value={selectedMonth}
+          onChange={(e) => setSelectedMonth(e.target.value)}
+          style={StyleSheet.flatten(styles.webSelect)}
+        >
+          {months.map(m => (
+            <option key={m} value={m}>{`${m.split('-')[0]}年${m.split('-')[1]}月`}</option>
+          ))}
+        </select>
+      );
+    }
+
+    return (
+      <Picker 
+        selectedValue={selectedMonth} 
+        onValueChange={setSelectedMonth} 
+        style={styles.filterPicker}
+        mode="dropdown"
+      >
+        {months.map(m => (
+          <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
+        ))}
+      </Picker>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* ヘッダー */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backButtonText}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>家族間精算サマリー</Text>
+        <View style={styles.monthPickerContainer}>
+          {renderMonthPicker()}
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={styles.centerLoading}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+        </View>
+      ) : (
+        <ScrollView style={styles.scrollContainer} contentContainerStyle={styles.scrollContent}>
+          
+          {/* キャッシュ・フロー・サマリーカード群 */}
+          <View style={[styles.cardGrid, isWide ? styles.rowLayout : styles.colLayout]}>
+            {summaryData.map(m => {
+              const isSurplus = m.balance >= 0;
+              return (
+                <View key={m.memberId} style={[styles.summaryCard, isSurplus ? styles.cardSurplus : styles.cardDeficit]}>
+                  <Text style={styles.cardMemberName}>{m.name}</Text>
+                  <View style={styles.statRow}>
+                    <Text style={styles.statLabel}>実際の立替支払額:</Text>
+                    <Text style={styles.statValue}>¥{m.totalPaid.toLocaleString()}</Text>
+                  </View>
+                  <View style={styles.statRow}>
+                    <Text style={styles.statLabel}>本来の自己負担額:</Text>
+                    <Text style={styles.statValue}>¥{m.totalOwed.toLocaleString()}</Text>
+                  </View>
+                  <View style={styles.cardDivider} />
+                  <Text style={styles.balanceLabel}>{isSurplus ? "他メンバーから受け取る額" : "他メンバーへ支払う額"}</Text>
+                  <Text style={[styles.balanceValue, isSurplus ? styles.textSurplus : styles.textDeficit]}>
+                    ¥{Math.abs(m.balance).toLocaleString()}
+                  </Text>
+                </View>
+              );
+            })}
+          </View>
+
+          {/* 清算ステータス詳細（スプレッドシート風一覧テーブル） */}
+          <View style={styles.tableContainer}>
+            <Text style={styles.tableTitle}>📋 世帯内精算内訳（一覧）</Text>
+            <View style={styles.tableWrapper}>
+              {/* テーブルヘッダー */}
+              <View style={[styles.tableRow, styles.tableHeader]}>
+                <Text style={[styles.cell, styles.cellName, styles.headerText]}>メンバー名</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>立替金額(A)</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>負担金額(B)</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>精算差額(A - B)</Text>
+              </View>
+
+              {/* テーブルボディ */}
+              {summaryData.map(m => {
+                // ★ 修正箇所: スタイル計算を変数に切り出し、型エラーと可読性の問題を解消
+                const balanceStyle = m.balance >= 0 ? styles.textSurplus : styles.textDeficit;
+                
+                return (
+                  <View key={m.memberId} style={styles.tableRow}>
+                    <Text style={[styles.cell, styles.cellName, styles.bodyText, styles.boldText]}>{m.name}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalPaid.toLocaleString()}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalOwed.toLocaleString()}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, balanceStyle, styles.boldText]}>
+                      {m.balance >= 0 ? "+" : ""}{m.balance.toLocaleString()}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+
+        </ScrollView>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, backgroundColor: '#fff', borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  backButton: { paddingRight: 15 },
+  backButtonText: { color: theme.colors.primary, fontWeight: '700', fontSize: 16 },
+  headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
+  monthPickerContainer: { width: 160, height: 40, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
+  filterPicker: { width: '100%' },
+  webSelect: {
+    width: '100%',
+    height: '100%',
+    borderWidth: 0,
+    backgroundColor: 'transparent',
+    paddingLeft: 10,
+    fontSize: 14,
+    color: theme.colors.text.main,
+    ...Platform.select({ web: { outlineStyle: 'none' } as any }),
+  } as any,
+  scrollContainer: { flex: 1 },
+  scrollContent: { padding: 20, paddingBottom: 40 },
+  rowLayout: { flexDirection: 'row' },
+  colLayout: { flexDirection: 'column' },
+  cardGrid: { gap: 20, marginBottom: 30 },
+  summaryCard: { flex: 1, padding: 20, borderRadius: 12, borderWidth: 1, elevation: 2, backgroundColor: '#fff' },
+  cardSurplus: { borderColor: '#bbf7d0', backgroundColor: '#f0fdf4' },
+  cardDeficit: { borderColor: '#fecaca', backgroundColor: '#fef2f2' },
+  cardMemberName: { fontSize: 18, fontWeight: 'bold', marginBottom: 12, color: theme.colors.text.main },
+  statRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 6 },
+  statLabel: { fontSize: 13, color: theme.colors.text.muted },
+  statValue: { fontSize: 14, fontWeight: '600', color: theme.colors.text.main },
+  cardDivider: { height: 1, backgroundColor: 'rgba(0,0,0,0.05)', marginVertical: 10 },
+  balanceLabel: { fontSize: 11, color: theme.colors.text.muted, fontWeight: 'bold' },
+  balanceValue: { fontSize: 24, fontWeight: 'bold', marginTop: 4 },
+  textSurplus: { color: '#16a34a' },
+  textDeficit: { color: '#dc2626' },
+  
+  tableContainer: { backgroundColor: '#fff', padding: 20, borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border },
+  tableTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, color: theme.colors.text.main },
+  tableWrapper: { borderWidth: 1, borderColor: '#F0F0F0', borderRadius: 8, overflow: 'hidden' },
+  tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#F0F0F0', alignItems: 'center', height: 48 },
+  tableHeader: { backgroundColor: '#F8F9FA' },
+  cell: { paddingHorizontal: 12, justifyContent: 'center' },
+  headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
+  bodyText: { fontSize: 14, color: theme.colors.text.main },
+  boldText: { fontWeight: 'bold' }, // ★ インラインスタイルではなく、StyleSheetに定義
+  cellName: { flex: 1.5, minWidth: 100 },
+  cellAmount: { flex: 1, textAlign: 'right' }
+});

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -4,7 +4,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform, Alert } from 'react-native';
 
 // --- 定数定義 ---
-// [Issue #73] role を保存するためのキー（USER_ROLE）を追加
 const STORAGE_KEYS = {
   TOKEN: 'userToken',
   MEMBER_ID: 'currentMemberId',
@@ -20,7 +19,6 @@ export const setOnUnauthorized = (handler: () => void) => {
   onUnauthorizedHandler = handler;
 };
 
-// 環境変数からベースURLを取得。未設定の場合は警告を出す
 const API_BASE = process.env.EXPO_PUBLIC_API_URL;
 if (!API_BASE) {
   console.warn('[API] Warning: EXPO_PUBLIC_API_URL is not defined. Falling back to localhost.');
@@ -76,20 +74,17 @@ apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
     if (error.response && error.response.data) {
-      // バックエンドの AppError 構造からメッセージを抽出
       const serverMessage = error.response.data.message || error.message;
       const errorCode = error.response.data.code;
       
       error.message = serverMessage;
 
-      // [Issue #51/52/73/75] 認証エラー (401) または 権限エラー (403) のハンドリング
       if (error.response.status === 401) {
         console.warn(`[API] Unauthorized: ${errorCode || 'TOKEN_EXPIRED'}`);
         if (onUnauthorizedHandler) {
           onUnauthorizedHandler();
         }
       } else if (error.response.status === 403) {
-        // [Issue #75] 403 Forbidden: 管理者メニュー等への不正アクセス時のUIフィードバック
         console.warn(`[API] Forbidden: ${serverMessage}`);
         Alert.alert('アクセス権限エラー', 'この操作を行う権限がありません。');
       }
@@ -98,16 +93,19 @@ apiClient.interceptors.response.use(
   }
 );
 
-// ★ [Issue #78/#79] 按分機能等のAPIコール用ラッパー
+// ★ [Issue #78/#79/#80] 各種APIコール用ラッパー
 export const api = {
-  // 家族メンバー一覧の取得
   getFamilyMembers: async () => {
     const res = await apiClient.get('/family-groups/members');
     return res.data;
   },
-  // 明細ごとの按分設定保存
   saveItemSplits: async (itemId: number, splits: { familyMemberId: number; amount?: number; ratio?: number }[]) => {
     const res = await apiClient.post(`/receipts/items/${itemId}/splits`, { splits });
+    return res.data;
+  },
+  // ★ [Issue #80] 月間精算ステータスの取得メソッドを追加
+  getSettlementStatus: async (month: string) => {
+    const res = await apiClient.get('/stats/settlement', { params: { month } });
     return res.data;
   }
 };


### PR DESCRIPTION
Closes #80

## 変更内容
- `SettlementSummaryScreen` の新規作成（立替・負担・精算差額の可視化）
- `apiClient.ts` へ精算データ取得API（`getSettlementStatus`）のラッパー追加
- `App.tsx` へ `settlement_summary` のルーティング追加
- `HomeScreen` へ精算サマリー画面への遷移導線を追加
- インラインスタイルの型エラーを解消

## テスト・確認事項
- ホーム画面から「精算サマリー」画面へ遷移できること
- 過去の月を切り替えた際、その月の精算ステータスが正しく取得・表示されること