### PR TITLE
Issue #81: 割り勘機能のUI/UX改善（合計行一括調整・スマホ非表示）および送金記録の実装

### DIFF
--- a/backend/prisma/migrations/20260525122437_add_settlement_transfer/migration.sql
+++ b/backend/prisma/migrations/20260525122437_add_settlement_transfer/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "SettlementTransfer" (
+    "id" SERIAL NOT NULL,
+    "month" TEXT NOT NULL,
+    "fromMemberId" INTEGER NOT NULL,
+    "toMemberId" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "settledAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SettlementTransfer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SettlementTransfer_month_idx" ON "SettlementTransfer"("month");
+
+-- CreateIndex
+CREATE INDEX "SettlementTransfer_fromMemberId_idx" ON "SettlementTransfer"("fromMemberId");
+
+-- CreateIndex
+CREATE INDEX "SettlementTransfer_toMemberId_idx" ON "SettlementTransfer"("toMemberId");
+
+-- AddForeignKey
+ALTER TABLE "SettlementTransfer" ADD CONSTRAINT "SettlementTransfer_fromMemberId_fkey" FOREIGN KEY ("fromMemberId") REFERENCES "FamilyMember"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SettlementTransfer" ADD CONSTRAINT "SettlementTransfer_toMemberId_fkey" FOREIGN KEY ("toMemberId") REFERENCES "FamilyMember"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,6 +35,10 @@ model FamilyMember {
   receipts      Receipt[]
   apiUsageLogs  ApiUsageLog[] // [Issue #59] トークンログとのリレーション
   itemSplits    ItemSplit[]   // [Issue #78] 負担明細へのリレーション
+  
+  // ★ [Issue #81] 送金履歴リレーション
+  sentTransfers     SettlementTransfer[] @relation("TransferSender")
+  receivedTransfers SettlementTransfer[] @relation("TransferReceiver")
 
   @@unique([name, familyGroupId]) // 同一世帯内での名前重複を禁止
 }
@@ -104,6 +108,23 @@ model ItemSplit {
 
   @@index([itemId])
   @@index([familyMemberId])
+}
+
+// ★ [Issue #81] 送金履歴（締め処理の実績管理）
+model SettlementTransfer {
+  id           Int          @id @default(autoincrement())
+  month        String       // 例: "2026-05" (精算対象月)
+  fromMemberId Int          // 送金した人
+  toMemberId   Int          // 受け取った人
+  amount       Int          // 送金額
+  settledAt    DateTime     @default(now()) @db.Timestamptz(3)
+
+  sender       FamilyMember @relation("TransferSender", fields: [fromMemberId], references: [id])
+  receiver     FamilyMember @relation("TransferReceiver", fields: [toMemberId], references: [id])
+
+  @@index([month])
+  @@index([fromMemberId])
+  @@index([toMemberId])
 }
 
 // 学習マスタ (世帯ごとに学習結果を分離)

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -3,8 +3,9 @@ import { prisma } from '../utils/prismaClient';
 import { getFamilyGroupId } from '../utils/context';
 
 /**
- * [Issue #78] 月間精算ステータスの取得（暗黙的デフォルト対応）
- * 対象月の「各メンバーの立替額」「各メンバーの負担額」を算出し、その差額（精算額）を返します。
+ * [Issue #78 / #81] 月間精算ステータスの取得（暗黙的デフォルト対応 ＆ 送金実績の反映）
+ * 対象月の「各メンバーの立替額」「各メンバーの負担額」を算出し、
+ * さらに同月の送金実績（SettlementTransfer）を加味した最終的な「精算残額」を返します。
  */
 export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
   const familyGroupId = getFamilyGroupId();
@@ -23,9 +24,18 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
       select: { id: true, name: true },
     });
 
-    const stats: Record<number, { name: string; totalPaid: number; totalOwed: number; balance: number }> = {};
+    const stats: Record<number, { 
+      name: string; 
+      totalPaid: number; 
+      totalOwed: number; 
+      baseBalance: number; // レシートベースの本来の差額
+      transferredOut: number; // 他者へ送金した額
+      transferredIn: number; // 他者から受け取った額
+      balance: number; // 最終的な残額（baseBalance + transferredOut - transferredIn）
+    }> = {};
+    
     members.forEach(m => {
-      stats[m.id] = { name: m.name, totalPaid: 0, totalOwed: 0, balance: 0 };
+      stats[m.id] = { name: m.name, totalPaid: 0, totalOwed: 0, baseBalance: 0, transferredOut: 0, transferredIn: 0, balance: 0 };
     });
 
     // 2. 指定月・世帯のレシートを、明細とSplitを含めて取得
@@ -41,7 +51,7 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
       }
     });
 
-    // 3. 集計ロジック（暗黙的デフォルト処理）
+    // 3. レシートと明細に基づく基本集計（暗黙的デフォルト処理）
     receipts.forEach(receipt => {
       let receiptTotalPaid = 0; // そのレシートで立替えた総額
 
@@ -71,17 +81,48 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
       }
     });
 
-    // 4. 最終的な精算額（balance）の計算
-    // balance > 0: 払いすぎている（他者から受け取るべき）
-    // balance < 0: 払いが足りない（他者に支払うべき）
+    // ★ [Issue #81] 4. 送金実績（SettlementTransfer）の取得と集計
+    // 対象月の全送金履歴（familyGroupIdに属するメンバー間の送金）
+    const transfers = await prisma.settlementTransfer.findMany({
+      where: {
+        month: targetMonth,
+        sender: { familyGroupId }, // テナント検証
+      },
+      select: {
+        id: true,
+        fromMemberId: true,
+        toMemberId: true,
+        amount: true,
+        settledAt: true,
+      }
+    });
+
+    transfers.forEach(t => {
+      if (stats[t.fromMemberId]) stats[t.fromMemberId].transferredOut += t.amount;
+      if (stats[t.toMemberId]) stats[t.toMemberId].transferredIn += t.amount;
+    });
+
+    // 5. 最終的な精算額（balance）の計算
     const result = Object.entries(stats).map(([id, s]) => {
-      const balance = s.totalPaid - s.totalOwed;
+      // 本来のレシート差額 (立替額 - 負担額)
+      // > 0: 払いすぎ (受け取る権利)
+      // < 0: 払いが足りない (支払う義務)
+      s.baseBalance = s.totalPaid - s.totalOwed;
+
+      // 最終残額の計算
+      // 支払う義務(<0)がある人は、送金(transferredOut)すると義務が減る(+方向へ)
+      // 受け取る権利(>0)がある人は、受領(transferredIn)すると権利が減る(-方向へ)
+      s.balance = s.baseBalance + s.transferredOut - s.transferredIn;
+
       return {
         memberId: Number(id),
         name: s.name,
         totalPaid: s.totalPaid,
         totalOwed: s.totalOwed,
-        balance: balance,
+        baseBalance: s.baseBalance,
+        transferredOut: s.transferredOut,
+        transferredIn: s.transferredIn,
+        balance: s.balance,
       };
     });
 
@@ -89,8 +130,61 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
       success: true,
       data: {
         month: targetMonth,
-        members: result
+        members: result,
+        transfers // 履歴表示用に生の送金データも返す
       }
+    });
+
+  } catch (error) {
+    next(error);
+  }
+};
+
+
+/**
+ * ★ [Issue #81] 送金記録（締め処理の実績）の登録
+ * POST /api/stats/settlement/transfers
+ */
+export const addSettlementTransfer = async (req: Request, res: Response, next: NextFunction) => {
+  const familyGroupId = getFamilyGroupId();
+  
+  const { month, fromMemberId, toMemberId, amount } = req.body;
+
+  if (!month || !fromMemberId || !toMemberId || !amount || amount <= 0) {
+    return res.status(400).json({ success: false, message: '必要なパラメータが不足しているか、金額が不正です。' });
+  }
+
+  if (fromMemberId === toMemberId) {
+    return res.status(400).json({ success: false, message: '自分自身への送金は登録できません。' });
+  }
+
+  try {
+    // 送信者・受信者が同一世帯に属しているか（テナント検証）
+    const validMembers = await prisma.familyMember.findMany({
+      where: {
+        id: { in: [fromMemberId, toMemberId] },
+        familyGroupId
+      }
+    });
+
+    if (validMembers.length !== 2) {
+      return res.status(403).json({ success: false, message: '無効なユーザー指定、または権限がありません。' });
+    }
+
+    // 送金記録の作成
+    const newTransfer = await prisma.settlementTransfer.create({
+      data: {
+        month,
+        fromMemberId,
+        toMemberId,
+        amount,
+        // settledAt は default(now()) で自動採番
+      }
+    });
+
+    res.status(201).json({
+      success: true,
+      data: newTransfer
     });
 
   } catch (error) {

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getSettlementStatus } from '../controllers/statsController';
+import { getSettlementStatus, addSettlementTransfer } from '../controllers/statsController';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { tenantMiddleware } from '../middleware/tenantMiddleware';
 
@@ -8,7 +8,10 @@ const router = express.Router();
 // 共通認証・テナントミドルウェア
 router.use(authMiddleware, tenantMiddleware);
 
-// ★ Issue #78: 月間精算ステータスの取得
+// 月間精算ステータスの取得
 router.get('/settlement', getSettlementStatus);
+
+// ★ [Issue #81] 送金履歴の追加
+router.post('/settlement/transfers', addSettlementTransfer);
 
 export default router;

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -27,7 +27,7 @@ interface ReceiptDetailComponentProps {
 }
 
 /**
- * [Issue #67 / #71 / #79] レシート詳細表示・編集コンポーネント
+ * [Issue #67 / #71 / #79 / #81] レシート詳細表示・編集コンポーネント
  */
 export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   receipt,
@@ -158,10 +158,10 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
             </>
           ) : (
             <>
-              {/* ★ [Issue #79] 按分エディタへの遷移ボタンを追加 */}
-              {onGoToSplitEditor && (
+              {/* ★ [Issue #81] スマホ非表示化 ＆ 文言変更 */}
+              {onGoToSplitEditor && isWide && (
                 <TouchableOpacity onPress={() => onGoToSplitEditor(receipt)} style={styles.splitButton}>
-                  <Text style={styles.splitButtonText}>➗ シェア・按分</Text>
+                  <Text style={styles.splitButtonText}>➗ 割り勘</Text>
                 </TouchableOpacity>
               )}
               <TouchableOpacity onPress={() => setIsEditing(true)} style={styles.editButton}>
@@ -334,8 +334,8 @@ const styles = StyleSheet.create({
   editControls: { flexDirection: 'row', justifyContent: 'flex-end', marginBottom: 10, gap: 10 },
   editButton: { backgroundColor: theme.colors.background, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: theme.colors.border },
   editButtonText: { color: theme.colors.text.main, fontWeight: 'bold' },
-  splitButton: { backgroundColor: '#e0f2fe', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: '#bae6fd' }, // 追加: 按分ボタン
-  splitButtonText: { color: '#0369a1', fontWeight: 'bold' }, // 追加: 按分ボタンテキスト
+  splitButton: { backgroundColor: '#e0f2fe', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: '#bae6fd' },
+  splitButtonText: { color: '#0369a1', fontWeight: 'bold' }, 
   saveButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 16, paddingVertical: 6, borderRadius: 8 },
   saveButtonText: { color: '#fff', fontWeight: 'bold' },
   cancelButton: { backgroundColor: '#f1f5f9', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -203,8 +203,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             <Text style={{ fontSize: 28, marginBottom: 8 }}>📊</Text>
             <Text style={styles.menuLabel}>支出統計</Text>
           </TouchableOpacity>
-          {/* ★ [Issue #80] 精算サマリーへの遷移ボタン */}
-          {onGoToSettlement && (
+          {/* ★ [Issue #80] 精算サマリーへの遷移ボタン（スマホ非表示） */}
+          {onGoToSettlement && isWide && (
             <TouchableOpacity style={styles.gridCard} onPress={onGoToSettlement}>
               <Text style={{ fontSize: 28, marginBottom: 8 }}>🤝</Text>
               <Text style={styles.menuLabel}>精算サマリー</Text>

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -7,7 +7,10 @@ import {
   TouchableOpacity, 
   ActivityIndicator, 
   Platform,
-  useWindowDimensions
+  useWindowDimensions,
+  Modal,
+  TextInput,
+  Alert
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { theme, BREAKPOINTS } from '../theme';
@@ -24,6 +27,13 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
   const [summaryData, setSummaryData] = useState<any[]>([]);
+
+  // 送金モーダル用ステート
+  const [isTransferModalVisible, setTransferModalVisible] = useState(false);
+  const [transferFrom, setTransferFrom] = useState<number | null>(null);
+  const [transferTo, setTransferTo] = useState<number | null>(null);
+  const [transferAmount, setTransferAmount] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 過去6ヶ月の選択肢を生成
   const months = useMemo(() => {
@@ -51,6 +61,46 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   useEffect(() => {
     loadSettlementData();
   }, [selectedMonth]);
+
+  const handleTransferSubmit = async () => {
+    if (!transferFrom || !transferTo || !transferAmount) {
+      Alert.alert('入力エラー', '送金元、送金先、金額をすべて入力してください。');
+      return;
+    }
+    if (transferFrom === transferTo) {
+      Alert.alert('入力エラー', '送金元と送金先は異なるメンバーを選択してください。');
+      return;
+    }
+    
+    const amountNum = parseInt(transferAmount.replace(/[^0-9]/g, ''), 10);
+    if (isNaN(amountNum) || amountNum <= 0) {
+      Alert.alert('入力エラー', '正しい金額を入力してください。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await api.addSettlementTransfer({
+        month: selectedMonth,
+        fromMemberId: transferFrom,
+        toMemberId: transferTo,
+        amount: amountNum
+      });
+      if (res.success) {
+        Alert.alert('成功', '送金記録を登録しました。');
+        setTransferModalVisible(false);
+        setTransferFrom(null);
+        setTransferTo(null);
+        setTransferAmount('');
+        loadSettlementData(); // 再読み込みして残額を更新
+      }
+    } catch (err) {
+      console.error('送金記録エラー', err);
+      Alert.alert('エラー', '送金記録の登録に失敗しました。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const renderMonthPicker = () => {
     if (Platform.OS === 'web') {
@@ -89,8 +139,16 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
           <Text style={styles.backButtonText}>← 戻る</Text>
         </TouchableOpacity>
         <Text style={styles.headerTitle}>家族間精算サマリー</Text>
-        <View style={styles.monthPickerContainer}>
-          {renderMonthPicker()}
+        <View style={styles.headerRight}>
+          <TouchableOpacity 
+            style={styles.addTransferButton}
+            onPress={() => setTransferModalVisible(true)}
+          >
+            <Text style={styles.addTransferButtonText}>＋ 送金・受取を記録</Text>
+          </TouchableOpacity>
+          <View style={styles.monthPickerContainer}>
+            {renderMonthPicker()}
+          </View>
         </View>
       </View>
 
@@ -104,23 +162,50 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
           {/* キャッシュ・フロー・サマリーカード群 */}
           <View style={[styles.cardGrid, isWide ? styles.rowLayout : styles.colLayout]}>
             {summaryData.map(m => {
-              const isSurplus = m.balance >= 0;
+              const isSettled = m.balance === 0 && Math.abs(m.baseBalance) > 0;
+              const isSurplus = m.balance > 0;
+              const isDeficit = m.balance < 0;
+              
+              let cardStyle = styles.cardNeutral;
+              if (isSettled) cardStyle = styles.cardSettled;
+              else if (isSurplus) cardStyle = styles.cardSurplus;
+              else if (isDeficit) cardStyle = styles.cardDeficit;
+
               return (
-                <View key={m.memberId} style={[styles.summaryCard, isSurplus ? styles.cardSurplus : styles.cardDeficit]}>
-                  <Text style={styles.cardMemberName}>{m.name}</Text>
+                <View key={m.memberId} style={[styles.summaryCard, cardStyle]}>
+                  <View style={styles.cardHeaderRow}>
+                    <Text style={styles.cardMemberName}>{m.name}</Text>
+                    {isSettled && <View style={styles.settledBadge}><Text style={styles.settledBadgeText}>精算済</Text></View>}
+                  </View>
+
                   <View style={styles.statRow}>
                     <Text style={styles.statLabel}>実際の立替支払額:</Text>
-                    <Text style={styles.statValue}>¥{m.totalPaid.toLocaleString()}</Text>
+                    <Text style={styles.statValue}>¥{m.totalPaid?.toLocaleString()}</Text>
                   </View>
                   <View style={styles.statRow}>
                     <Text style={styles.statLabel}>本来の自己負担額:</Text>
-                    <Text style={styles.statValue}>¥{m.totalOwed.toLocaleString()}</Text>
+                    <Text style={styles.statValue}>¥{m.totalOwed?.toLocaleString()}</Text>
                   </View>
+                  
+                  {((m.transferredOut || 0) > 0 || (m.transferredIn || 0) > 0) && (
+                    <View style={styles.transferSummaryBox}>
+                      {(m.transferredOut || 0) > 0 && <Text style={styles.transferText}>↑ 送金済: ¥{m.transferredOut.toLocaleString()}</Text>}
+                      {(m.transferredIn || 0) > 0 && <Text style={styles.transferText}>↓ 受取済: ¥{m.transferredIn.toLocaleString()}</Text>}
+                    </View>
+                  )}
+
                   <View style={styles.cardDivider} />
-                  <Text style={styles.balanceLabel}>{isSurplus ? "他メンバーから受け取る額" : "他メンバーへ支払う額"}</Text>
-                  <Text style={[styles.balanceValue, isSurplus ? styles.textSurplus : styles.textDeficit]}>
-                    ¥{Math.abs(m.balance).toLocaleString()}
-                  </Text>
+                  
+                  {isSettled ? (
+                    <Text style={[styles.balanceValue, { color: theme.colors.text.muted }]}>¥0 (精算完了)</Text>
+                  ) : (
+                    <>
+                      <Text style={styles.balanceLabel}>{isSurplus ? "他メンバーから受け取る残額" : (isDeficit ? "他メンバーへ支払う残額" : "精算なし")}</Text>
+                      <Text style={[styles.balanceValue, isSurplus ? styles.textSurplus : (isDeficit ? styles.textDeficit : styles.textNeutral)]}>
+                        ¥{Math.abs(m.balance || 0).toLocaleString()}
+                      </Text>
+                    </>
+                  )}
                 </View>
               );
             })}
@@ -130,26 +215,32 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
           <View style={styles.tableContainer}>
             <Text style={styles.tableTitle}>📋 世帯内精算内訳（一覧）</Text>
             <View style={styles.tableWrapper}>
-              {/* テーブルヘッダー */}
               <View style={[styles.tableRow, styles.tableHeader]}>
                 <Text style={[styles.cell, styles.cellName, styles.headerText]}>メンバー名</Text>
                 <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>立替金額(A)</Text>
                 <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>負担金額(B)</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>精算差額(A - B)</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>差額(A-B)</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>送金/受取相殺</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>最終残額</Text>
               </View>
 
-              {/* テーブルボディ */}
               {summaryData.map(m => {
-                // ★ 修正箇所: スタイル計算を変数に切り出し、型エラーと可読性の問題を解消
-                const balanceStyle = m.balance >= 0 ? styles.textSurplus : styles.textDeficit;
+                const balanceStyle = m.balance > 0 ? styles.textSurplus : (m.balance < 0 ? styles.textDeficit : styles.textNeutral);
+                const offsetAmount = (m.transferredOut || 0) - (m.transferredIn || 0);
                 
                 return (
                   <View key={m.memberId} style={styles.tableRow}>
                     <Text style={[styles.cell, styles.cellName, styles.bodyText, styles.boldText]}>{m.name}</Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalPaid.toLocaleString()}</Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalOwed.toLocaleString()}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalPaid?.toLocaleString()}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalOwed?.toLocaleString()}</Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>
+                      {m.baseBalance >= 0 ? "+" : ""}{m.baseBalance?.toLocaleString()}
+                    </Text>
+                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText, { color: theme.colors.text.muted }]}>
+                      {offsetAmount >= 0 ? "+" : ""}{offsetAmount.toLocaleString()}
+                    </Text>
                     <Text style={[styles.cell, styles.cellAmount, balanceStyle, styles.boldText]}>
-                      {m.balance >= 0 ? "+" : ""}{m.balance.toLocaleString()}
+                      {m.balance > 0 ? "+" : ""}{m.balance?.toLocaleString()}
                     </Text>
                   </View>
                 );
@@ -159,6 +250,64 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
 
         </ScrollView>
       )}
+
+      {/* 送金記録モーダル */}
+      <Modal
+        visible={isTransferModalVisible}
+        transparent={true}
+        animationType="fade"
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>送金・受取の記録</Text>
+            <Text style={styles.modalDesc}>実際に現金やPayPay等で精算した金額を記録します。</Text>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>送金元 (払った人)</Text>
+              <View style={styles.pickerWrapper}>
+                <Picker selectedValue={transferFrom} onValueChange={setTransferFrom} style={styles.modalPicker}>
+                  <Picker.Item label="選択してください" value={null} color={theme.colors.text.muted} />
+                  {summaryData.map(m => <Picker.Item key={`from-${m.memberId}`} label={m.name} value={m.memberId} />)}
+                </Picker>
+              </View>
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>送金先 (受け取った人)</Text>
+              <View style={styles.pickerWrapper}>
+                <Picker selectedValue={transferTo} onValueChange={setTransferTo} style={styles.modalPicker}>
+                  <Picker.Item label="選択してください" value={null} color={theme.colors.text.muted} />
+                  {summaryData.map(m => <Picker.Item key={`to-${m.memberId}`} label={m.name} value={m.memberId} />)}
+                </Picker>
+              </View>
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>送金額</Text>
+              <View style={styles.inputWithUnit}>
+                <TextInput
+                  style={styles.modalInput}
+                  value={transferAmount}
+                  onChangeText={setTransferAmount}
+                  keyboardType="number-pad"
+                  placeholder="例: 5000"
+                />
+                <Text style={styles.unitText}>円</Text>
+              </View>
+            </View>
+
+            <View style={styles.modalActions}>
+              <TouchableOpacity style={styles.modalCancelBtn} onPress={() => setTransferModalVisible(false)}>
+                <Text style={styles.modalCancelText}>キャンセル</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.modalSubmitBtn} onPress={handleTransferSubmit} disabled={isSubmitting}>
+                {isSubmitting ? <ActivityIndicator color="#fff" /> : <Text style={styles.modalSubmitText}>記録する</Text>}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
     </View>
   );
 };
@@ -170,35 +319,43 @@ const styles = StyleSheet.create({
   backButton: { paddingRight: 15 },
   backButtonText: { color: theme.colors.primary, fontWeight: '700', fontSize: 16 },
   headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
-  monthPickerContainer: { width: 160, height: 40, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
+  headerRight: { flexDirection: 'row', alignItems: 'center', gap: 15 },
+  addTransferButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 6 },
+  addTransferButtonText: { color: '#fff', fontWeight: 'bold', fontSize: 13 },
+  monthPickerContainer: { width: 140, height: 36, backgroundColor: theme.colors.surface, borderRadius: 6, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
   filterPicker: { width: '100%' },
-  webSelect: {
-    width: '100%',
-    height: '100%',
-    borderWidth: 0,
-    backgroundColor: 'transparent',
-    paddingLeft: 10,
-    fontSize: 14,
-    color: theme.colors.text.main,
-    ...Platform.select({ web: { outlineStyle: 'none' } as any }),
-  } as any,
+  webSelect: { width: '100%', height: '100%', borderWidth: 0, backgroundColor: 'transparent', paddingLeft: 10, fontSize: 14, color: theme.colors.text.main, ...Platform.select({ web: { outlineStyle: 'none' } as any }) } as any,
   scrollContainer: { flex: 1 },
   scrollContent: { padding: 20, paddingBottom: 40 },
   rowLayout: { flexDirection: 'row' },
   colLayout: { flexDirection: 'column' },
   cardGrid: { gap: 20, marginBottom: 30 },
-  summaryCard: { flex: 1, padding: 20, borderRadius: 12, borderWidth: 1, elevation: 2, backgroundColor: '#fff' },
+  
+  summaryCard: { flex: 1, padding: 20, borderRadius: 12, borderWidth: 1, elevation: 2 },
+  cardNeutral: { borderColor: theme.colors.border, backgroundColor: '#fff' },
   cardSurplus: { borderColor: '#bbf7d0', backgroundColor: '#f0fdf4' },
   cardDeficit: { borderColor: '#fecaca', backgroundColor: '#fef2f2' },
-  cardMemberName: { fontSize: 18, fontWeight: 'bold', marginBottom: 12, color: theme.colors.text.main },
+  cardSettled: { borderColor: '#cbd5e1', backgroundColor: '#f8fafc' },
+  
+  cardHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 },
+  cardMemberName: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  settledBadge: { backgroundColor: '#94a3b8', paddingHorizontal: 8, paddingVertical: 4, borderRadius: 12 },
+  settledBadgeText: { color: '#fff', fontSize: 11, fontWeight: 'bold' },
+  
   statRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 6 },
   statLabel: { fontSize: 13, color: theme.colors.text.muted },
   statValue: { fontSize: 14, fontWeight: '600', color: theme.colors.text.main },
+  
+  transferSummaryBox: { marginTop: 8, padding: 8, backgroundColor: 'rgba(0,0,0,0.03)', borderRadius: 6 },
+  transferText: { fontSize: 12, color: theme.colors.text.muted },
+  
   cardDivider: { height: 1, backgroundColor: 'rgba(0,0,0,0.05)', marginVertical: 10 },
   balanceLabel: { fontSize: 11, color: theme.colors.text.muted, fontWeight: 'bold' },
   balanceValue: { fontSize: 24, fontWeight: 'bold', marginTop: 4 },
+  
   textSurplus: { color: '#16a34a' },
   textDeficit: { color: '#dc2626' },
+  textNeutral: { color: theme.colors.text.main },
   
   tableContainer: { backgroundColor: '#fff', padding: 20, borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border },
   tableTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, color: theme.colors.text.main },
@@ -208,7 +365,24 @@ const styles = StyleSheet.create({
   cell: { paddingHorizontal: 12, justifyContent: 'center' },
   headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
   bodyText: { fontSize: 14, color: theme.colors.text.main },
-  boldText: { fontWeight: 'bold' }, // ★ インラインスタイルではなく、StyleSheetに定義
+  boldText: { fontWeight: 'bold' },
   cellName: { flex: 1.5, minWidth: 100 },
-  cellAmount: { flex: 1, textAlign: 'right' }
+  cellAmount: { flex: 1, textAlign: 'right' },
+
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  modalContent: { backgroundColor: '#fff', width: 400, maxWidth: '90%', padding: 25, borderRadius: 12, elevation: 5 },
+  modalTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, marginBottom: 5 },
+  modalDesc: { fontSize: 13, color: theme.colors.text.muted, marginBottom: 20 },
+  formGroup: { marginBottom: 15 },
+  formLabel: { fontSize: 13, fontWeight: '600', color: theme.colors.text.main, marginBottom: 5 },
+  pickerWrapper: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: 6, backgroundColor: '#fff', height: 40, justifyContent: 'center' },
+  modalPicker: { width: '100%', height: 40, ...Platform.select({ web: { outlineStyle: 'none', border: 'none' } as any }) },
+  inputWithUnit: { flexDirection: 'row', alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border, borderRadius: 6, backgroundColor: '#fff', height: 40, paddingHorizontal: 10 },
+  modalInput: { flex: 1, height: '100%', fontSize: 16, ...Platform.select({ web: { outlineStyle: 'none' } as any }) },
+  unitText: { fontSize: 14, color: theme.colors.text.muted, marginLeft: 8 },
+  modalActions: { flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10, gap: 10 },
+  modalCancelBtn: { paddingHorizontal: 15, paddingVertical: 10, borderRadius: 6, backgroundColor: '#f1f5f9' },
+  modalCancelText: { color: theme.colors.text.muted, fontWeight: 'bold' },
+  modalSubmitBtn: { paddingHorizontal: 20, paddingVertical: 10, borderRadius: 6, backgroundColor: theme.colors.primary, minWidth: 100, alignItems: 'center' },
+  modalSubmitText: { color: '#fff', fontWeight: 'bold' }
 });

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -47,12 +47,9 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
           
           let initialActive: any[] = [];
           
-          // ★ 修正: レシート内に既に按分(Split)データが存在するかチェック
           const hasExistingSplits = receipt.items.some((item: any) => item.splits && item.splits.length > 0);
 
           if (hasExistingSplits) {
-            // 【登録済みパターンの復元】
-            // 全ItemのSplitを走査し、一度でも登場したメンバーのIDを抽出
             const splitMemberIds = new Set<number>();
             receipt.items.forEach((item: any) => {
               if (item.splits) {
@@ -60,8 +57,6 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
               }
             });
             
-            // 抽出したIDに該当するメンバー情報を allMembers(res.data) から拾う
-            // ※先頭を必ず支払者にするため、支払者から先にpushする
             const payer = res.data.find((m: any) => m.id === receipt.memberId);
             if (payer) initialActive.push(payer);
             
@@ -72,14 +67,12 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
             });
 
           } else {
-            // 【新規登録時パターンのデフォルト2名設定】
             const payer = res.data.find((m: any) => m.id === receipt.memberId);
             if (payer) initialActive.push(payer);
             const others = res.data.filter((m: any) => m.id !== receipt.memberId);
             if (others.length > 0) initialActive.push(others[0]);
           }
 
-          // 万が一初期メンバーが空になった場合のフェールセーフ
           if (initialActive.length === 0) {
             initialActive = res.data.slice(0, 2);
           }
@@ -106,13 +99,11 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
       const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
 
       if (item.splits && item.splits.length > 0) {
-        // 既存データがある場合はセット
         targetMembers.forEach(m => {
           const split = item.splits.find((s: any) => s.familyMemberId === m.id);
           initialData[item.id][m.id] = split ? split.amount : 0;
         });
       } else {
-        // 無い場合は支払者が全額（デフォルト）
         targetMembers.forEach(m => {
           initialData[item.id][m.id] = m.id === receipt.memberId ? itemTotal : 0;
         });
@@ -204,7 +195,6 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     setEditSplits(prev => ({ ...prev, [itemId]: newData }));
   };
 
-
   const splitItemEqually = (itemId: number, itemTotal: number) => {
     const newData = { ...editSplits[itemId] };
     const memberCount = activeMembers.length;
@@ -218,6 +208,57 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     setEditSplits(prev => ({ ...prev, [itemId]: newData }));
   };
 
+  // ★ 追加: 合計行の変更を全明細にカスケードするロジック
+  const applyCascadePercent = (memberId: number, percent: number) => {
+    if (activeMembers.length <= 1 || percent < 0 || percent > 100) return;
+
+    const firstMemberId = activeMembers[0].id;
+    if (memberId === firstMemberId) return; // 先頭は常に自動計算のためスキップ
+
+    setEditSplits(prev => {
+      const next = { ...prev };
+      receipt.items.forEach((item: any) => {
+        const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+        const newData = { ...next[item.id] };
+
+        // 入力された％に基づいて金額を算出
+        const calculatedAmount = Math.round(itemTotal * (percent / 100));
+        newData[memberId] = calculatedAmount;
+
+        // 先頭メンバーの端数調整
+        let sumOthers = 0;
+        activeMembers.forEach(m => {
+          if (m.id !== firstMemberId) {
+            sumOthers += newData[m.id] || 0;
+          }
+        });
+        newData[firstMemberId] = Math.max(0, itemTotal - sumOthers);
+
+        next[item.id] = newData;
+      });
+      return next;
+    });
+  };
+
+  // ★ 追加: 合計行の金額変更ハンドラ
+  const handleTotalAmountChange = (memberId: number, value: string, receiptTotal: number) => {
+    const numericValue = value.replace(/[^0-9]/g, '');
+    let valToSet = numericValue === '' ? 0 : parseInt(numericValue, 10);
+    if (valToSet > receiptTotal) valToSet = receiptTotal;
+
+    // 入力された金額から割合（％）を算出し、全明細に適用
+    const percent = receiptTotal > 0 ? (valToSet / receiptTotal) * 100 : 0;
+    applyCascadePercent(memberId, percent);
+  };
+
+  // ★ 追加: 合計行の％変更ハンドラ
+  const handleTotalPercentChange = (memberId: number, value: string) => {
+    const numericValue = value.replace(/[^0-9]/g, '');
+    let percent = numericValue === '' ? 0 : parseInt(numericValue, 10);
+    applyCascadePercent(memberId, percent);
+  };
+
+  // ★ 追加: レシート全体を均等割り
   const splitWholeReceiptEqually = () => {
     receipt.items.forEach((item: any) => {
       const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
@@ -256,6 +297,20 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   }
 
   const getImageUrl = () => receipt.imagePath ? `${BASE_URL}/${receipt.imagePath}` : null;
+
+  // レシート全体の合計額を算出
+  const receiptTotalAmount = receipt.items.reduce((sum: number, item: any) => {
+    return sum + Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+  }, 0);
+
+  // 合計行表示用: メンバーごとの合計額を計算
+  const getMemberTotalAmount = (memberId: number) => {
+    let sum = 0;
+    receipt.items.forEach((item: any) => {
+      sum += editSplits[item.id]?.[memberId] || 0;
+    });
+    return sum;
+  };
 
   return (
     <View style={styles.container}>
@@ -322,9 +377,6 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
         <View style={styles.editorPane}>
           <View style={styles.editorToolbar}>
             <Text style={styles.storeName}>{receipt.storeName || '店名不明'}</Text>
-            <TouchableOpacity style={styles.batchSplitButton} onPress={splitWholeReceiptEqually}>
-              <Text style={styles.batchSplitText}>⚡ レシート全体を均等割り</Text>
-            </TouchableOpacity>
           </View>
 
           <ScrollView style={styles.tableScroll} horizontal={false}>
@@ -393,6 +445,55 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                   </View>
                 );
               })}
+
+              {/* ★ 追加: 合計行 (Total) */}
+              <View style={[styles.tableRow, styles.totalRow]}>
+                <Text style={[styles.cell, styles.cellName, styles.totalText]}>一括調整（全体合計）</Text>
+                <Text style={[styles.cell, styles.cellAmount, styles.totalText]}>¥{receiptTotalAmount.toLocaleString()}</Text>
+                
+                {activeMembers.map((m, idx) => {
+                  const memberTotal = getMemberTotalAmount(m.id);
+                  const percentValue = receiptTotalAmount > 0 ? Math.round((memberTotal / receiptTotalAmount) * 100) : 0;
+                  const isFirst = idx === 0;
+
+                  return (
+                    <View key={m.id} style={[styles.cell, styles.cellInputCol]}>
+                      <View style={styles.dualInputWrapper}>
+                        <View style={[styles.inputGroup, styles.totalInputGroup]}>
+                          <TextInput
+                            style={[styles.inputBox, styles.percentBox, isFirst && styles.disabledInputBox, styles.totalInputBox]}
+                            value={String(percentValue)}
+                            onChangeText={(val) => handleTotalPercentChange(m.id, val)}
+                            keyboardType="number-pad"
+                            editable={!isFirst}
+                            selectTextOnFocus
+                          />
+                          <Text style={[styles.unitText, styles.totalUnitText]}>%</Text>
+                        </View>
+                        
+                        <View style={[styles.inputGroup, styles.totalInputGroup, { marginLeft: 4 }]}>
+                          <TextInput
+                            style={[styles.inputBox, styles.amountBox, isFirst && styles.disabledInputBox, styles.totalInputBox]}
+                            value={String(memberTotal)}
+                            onChangeText={(val) => handleTotalAmountChange(m.id, val, receiptTotalAmount)}
+                            keyboardType="number-pad"
+                            editable={!isFirst}
+                            selectTextOnFocus
+                          />
+                          <Text style={[styles.unitText, styles.totalUnitText]}>円</Text>
+                        </View>
+                      </View>
+                    </View>
+                  );
+                })}
+
+                <View style={[styles.cell, styles.cellAction]}>
+                  <TouchableOpacity style={styles.splitBtnSmall} onPress={splitWholeReceiptEqually}>
+                    <Text style={styles.splitBtnSmallText}>均等</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+
             </ScrollView>
           </ScrollView>
         </View>
@@ -436,12 +537,18 @@ const styles = StyleSheet.create({
   editorPane: { flex: 1, backgroundColor: '#fff', borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
   editorToolbar: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border, backgroundColor: theme.colors.surface },
   storeName: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
-  batchSplitButton: { backgroundColor: '#e0f2fe', paddingHorizontal: 15, paddingVertical: 8, borderRadius: 6, borderWidth: 1, borderColor: '#bae6fd' },
-  batchSplitText: { color: '#0369a1', fontWeight: 'bold' },
   
   tableScroll: { flex: 1 },
   tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#F0F0F0', alignItems: 'center', minWidth: 800 },
   tableHeader: { backgroundColor: '#F8F9FA', borderBottomColor: theme.colors.border },
+  
+  // ★ 追加: 合計行のスタイル
+  totalRow: { backgroundColor: '#FFFBEB', borderTopWidth: 2, borderTopColor: '#FCD34D' },
+  totalText: { fontWeight: 'bold', color: '#B45309' },
+  totalInputGroup: { borderColor: '#FCD34D', backgroundColor: '#FEF3C7' },
+  totalInputBox: { fontWeight: 'bold', color: '#B45309' },
+  totalUnitText: { color: '#B45309', fontWeight: 'bold' },
+
   cell: { padding: 12, justifyContent: 'center' },
   headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
   cellName: { width: 160, fontSize: 14, color: theme.colors.text.main },

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -93,7 +93,7 @@ apiClient.interceptors.response.use(
   }
 );
 
-// ★ [Issue #78/#79/#80] 各種APIコール用ラッパー
+// ★ [Issue #78/#79/#80/#81] 各種APIコール用ラッパー
 export const api = {
   getFamilyMembers: async () => {
     const res = await apiClient.get('/family-groups/members');
@@ -103,9 +103,14 @@ export const api = {
     const res = await apiClient.post(`/receipts/items/${itemId}/splits`, { splits });
     return res.data;
   },
-  // ★ [Issue #80] 月間精算ステータスの取得メソッドを追加
+  // [Issue #80] 月間精算ステータスの取得メソッド
   getSettlementStatus: async (month: string) => {
     const res = await apiClient.get('/stats/settlement', { params: { month } });
+    return res.data;
+  },
+  // ★ [Issue #81] 送金記録の登録メソッドを追加
+  addSettlementTransfer: async (payload: { month: string; fromMemberId: number; toMemberId: number; amount: number }) => {
+    const res = await apiClient.post('/stats/settlement/transfers', payload);
     return res.data;
   }
 };


### PR DESCRIPTION
## 概要
割り勘エディタでの一括調整機能、スマホサイズでの各種ボタン非表示制御、および実送金ベースでの精算完了ステータスを管理するための送金記録（締め処理）機能を追加しました。

## 変更内容
- **DB/API**
  - `SettlementTransfer` モデル（送金履歴）の追加とマイグレーション
  - `POST /api/stats/settlement/transfers` の追加
  - `GET /api/stats/settlement` に送金実績（受取/送金）の相殺ロジックを追加
- **Frontend (Editor)**
  - `SplitEditorScreen` にレシート合計行を追加し、％・金額入力による全明細へのカスケード適用ロジックを実装
- **Frontend (Summary)**
  - `SettlementSummaryScreen` に送金記録登録モーダルを追加
  - 相殺後の「最終残額」計算と、残額0円時の「精算済」バッジ表示を追加
- **Frontend (UI/UX)**

## 確認事項
- [ ] 割り勘エディタの合計行を変更した際、全明細に割合・金額が正しく波及し、先頭メンバーに端数が寄るか
- [ ] スマホサイズで閲覧した際、ホーム画面・レシート詳細・サマリー画面で該当ボタンが非表示になるか
- [ ] サマリー画面から送金記録を登録し、最終残額が正しく相殺（減算）されるか