### PR TITLE
Issue #41: バックアップの自動実行と外部ストレージへの隔離

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: receipt-${ENV_NAME}-backend
+    restart: unless-stopped
     user: "${UID}:${GID}"
     command: ${BACKEND_COMMAND}
     volumes:
@@ -36,7 +37,7 @@ services:
     container_name: receipt-${ENV_NAME}-frontend
     ports:
       - "${WEB_PORT}:80"
-    restart: always
+    restart: unless-stopped
     environment:
       - TZ=Asia/Tokyo
     depends_on:
@@ -48,6 +49,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: receipt-${ENV_NAME}-frontend-dev
+    restart: unless-stopped
     user: "${UID}:${GID}"
     command: npx expo start --web --port 8081 --host lan
     volumes:
@@ -73,6 +75,7 @@ services:
   db:
     image: postgres:18
     container_name: receipt-${ENV_NAME}-db
+    restart: unless-stopped
     environment:
       - TZ=Asia/Tokyo
       - POSTGRES_USER=${DB_USER}
@@ -93,6 +96,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: receipt-${ENV_NAME}-redis
+    restart: unless-stopped
     environment:
       - TZ=Asia/Tokyo
     volumes:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# --- 环境判定ロジック ---
+# --- 環境判定ロジック ---
 ENV=$1
 
 if [ "$ENV" != "stable" ] && [ "$ENV" != "dev" ]; then
@@ -9,7 +9,7 @@ if [ "$ENV" != "stable" ] && [ "$ENV" != "dev" ]; then
 fi
 
 # --- 設定項目 ---
-PROJECT_ROOT=$(cd $(dirname "$0")/..; pwd)
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RETENTION_DAYS=7
 
@@ -70,43 +70,60 @@ SOURCE_UPLOADS_DIR="${PROJECT_ROOT}/backend/uploads"
 
 echo "[$(date)] ($ENV_LABEL) Backup started."
 
+# エラーカウント用
+ERROR_COUNT=0
+DETAILS=""
+
 # 3. DBバックアップ
 if [ ! "$(docker ps -q -f name=${CONTAINER_NAME})" ]; then
-    msg="Container ${CONTAINER_NAME} is NOT running. ($ENV_LABEL) DB Backup aborted."
+    msg="Container ${CONTAINER_NAME} is NOT running."
     echo "  -> [ERROR] $msg"
-    send_discord_alert "ERROR" "$msg"
+    DETAILS="${DETAILS}- DB Backup: FAILED (Container down)\n"
+    ((ERROR_COUNT++))
 else
     docker exec -e PGPASSWORD="${DB_PASS}" ${CONTAINER_NAME} pg_dump -U ${DB_USER} ${DB_NAME} | gzip > "${BACKUP_DIR}/db/db_backup_${TIMESTAMP}.sql.gz"
     
     if [ ${PIPESTATUS[0]} -eq 0 ]; then
         echo "  -> ($ENV_LABEL) DB Backup SUCCESS."
+        DETAILS="${DETAILS}- DB Backup: SUCCESS\n"
     else
         msg="PostgreSQL Dump FAILED on ($ENV_LABEL)."
         echo "  -> [ERROR] $msg"
-        send_discord_alert "ERROR" "$msg"
+        DETAILS="${DETAILS}- DB Backup: FAILED (Dump error)\n"
+        ((ERROR_COUNT++))
     fi
 fi
 
 # 4. 画像バックアップ
 if [ -d "${SOURCE_UPLOADS_DIR}" ]; then
-    # ★修正: 圧縮コマンド自体の成否を取得するため 2>/dev/null は外し、終了ステータスをチェック
     tar -czf "${BACKUP_DIR}/uploads/uploads_backup_${TIMESTAMP}.tar.gz" -C "${PROJECT_ROOT}/backend" "uploads"
     
     if [ $? -eq 0 ]; then
         echo "  -> ($ENV_LABEL) Uploads Backup SUCCESS."
+        DETAILS="${DETAILS}- Image Backup: SUCCESS\n"
     else
         msg="Tar archive creation FAILED on ($ENV_LABEL)."
         echo "  -> [ERROR] $msg"
-        send_discord_alert "ERROR" "$msg"
+        DETAILS="${DETAILS}- Image Backup: FAILED (Tar error)\n"
+        ((ERROR_COUNT++))
     fi
 else
     msg="Uploads directory NOT found at ${SOURCE_UPLOADS_DIR}."
     echo "  -> [ERROR] $msg"
-    send_discord_alert "ERROR" "$msg"
+    DETAILS="${DETAILS}- Image Backup: FAILED (Dir not found)\n"
+    ((ERROR_COUNT++))
 fi
 
 # 5. 世代管理
 find "${BACKUP_DIR}/db" -name "*.gz" -mtime +${RETENTION_DAYS} -delete
 find "${BACKUP_DIR}/uploads" -name "*.tar.gz" -mtime +${RETENTION_DAYS} -delete
+DETAILS="${DETAILS}- Retention Policy: Applied (Kept $RETENTION_DAYS days)"
 
 echo "[$(date)] ($ENV_LABEL) Backup completed."
+
+# 6. 最終結果通知
+if [ $ERROR_COUNT -eq 0 ]; then
+    send_discord_alert "SUCCESS" "Backup completed successfully.\n\n**Details:**\n$DETAILS"
+else
+    send_discord_alert "ERROR" "Backup finished with $ERROR_COUNT error(s).\n\n**Details:**\n$DETAILS"
+fi

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -25,6 +25,8 @@ DB_NAME="receipt_db"
 # [Issue #69] Redis内部ポートの固定
 REDIS_PORT_INTERNAL=6379
 
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # 3. 環境ごとの切り替え設定
 if [ "$ENV" == "dev" ]; then
     ENV_NAME="dev"
@@ -40,6 +42,7 @@ if [ "$ENV" == "dev" ]; then
     BACKEND_COMMAND="npm run dev"
     CORS_ORIGIN="http://localhost:$DEV_PORT,http://$HOST_IP:$DEV_PORT,exp://$HOST_IP:$DEV_PORT,http://$HOST_IP:$WEB_PORT"
     GEMINI_MODEL="gemini-flash-latest"
+    CRON_SCHEDULE="0 3 * * *" # dev環境は毎日午前3時に実行
 else
     ENV_NAME="stable"
     NODE_ENV="production"
@@ -54,6 +57,7 @@ else
     BACKEND_COMMAND="npm run start"
     CORS_ORIGIN="http://$HOST_IP:$WEB_PORT"
     GEMINI_MODEL="gemini-flash-latest"
+    CRON_SCHEDULE="0 4 * * *" # stable環境は毎日午前4時に実行
 fi
 
 # 4. ルート .env (docker-compose.yml 用)
@@ -103,4 +107,31 @@ REDIS_HOST=redis
 REDIS_PORT_INTERNAL=$REDIS_PORT_INTERNAL
 EOF
 
+echo "✅ Environment variables created."
+
+# ★ [Issue #41] Cronジョブの自動登録（定期実行 ＆ 起動時実行の多重登録）
+CRON_CMD="${PROJECT_ROOT}/scripts/backup.sh $ENV >> ${PROJECT_ROOT}/logs/backup_${ENV}.log 2>&1"
+
+# 現在のcronを一時ファイルに出力 (存在しない場合は空ファイル作成)
+crontab -l > /tmp/current_cron 2>/dev/null || touch /tmp/current_cron
+
+# 既に同じ環境のバックアップジョブ（定期・reboot双方）があれば削除
+grep -v "scripts/backup.sh $ENV" /tmp/current_cron > /tmp/new_cron
+
+# 1. 定期時間実行の追加
+echo "$CRON_SCHEDULE $CRON_CMD" >> /tmp/new_cron
+
+# 2. サーバー起動時実行（@reboot）の追加（コンテナ安定のため120秒スリープを噛ませる）
+echo "@reboot sleep 120 && $CRON_CMD" >> /tmp/new_cron
+
+# crontabの更新
+crontab /tmp/new_cron
+rm /tmp/current_cron /tmp/new_cron
+
+# ログディレクトリの作成
+mkdir -p "${PROJECT_ROOT}/logs"
+
+echo "✅ Cron jobs registered for $ENV:"
+echo "   - Scheduled: $CRON_SCHEDULE"
+echo "   - On Boot:   @reboot (with 120s delay)"
 echo "✅ Setup complete for $ENV_NAME. Project name: receipt-$ENV_NAME"


### PR DESCRIPTION
## 概要
DBおよびアップロード画像の自動バックアップ処理、外部ストレージ（RAID）への保存、およびサーバー再起動時のコンテナ自動起動・バックアップ復旧ロジックを実装しました。

## 変更内容
- **バックアップスクリプト (`scripts/backup.sh`)**
  - 成功・失敗に応じたDiscord通知ロジックの強化と、7日間の世代管理（ローテーション）を実装
- **環境構築スクリプト (`setup-env.sh`)**
  - `cron` への自動登録処理を追加（dev: 深夜3時 / stable: 深夜4時）
  - サーバー起動時 (`@reboot`) に、コンテナの立ち上がりを考慮した120秒ディレイでの自動バックアップ登録を追加
- **Docker Compose (`docker-compose.yml`)**
  - 各コンテナの `restart` ポリシーを `unless-stopped` に変更し、サーバー起動と連動して立ち上がるよう修正

## 確認事項
- [x] 手動実行でバックアップファイルが指定マウントポイントに作成され、DiscordにSUCCESS通知が飛ぶこと
- [x] `crontab -l` に定期実行および `@reboot` のスケジュールが登録されること
- [x] OS再起動後、Dockerコンテナ群が自動起動すること