### PR TITLE
Issue #83: 汎用ボタンコンポーネントの実装と表記揺れの統一

### DIFF
--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -13,6 +13,8 @@ import {
   Alert 
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
+import { AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, BREAKPOINTS } from '../theme';
 import apiClient from '../utils/apiClient';
 
@@ -149,24 +151,38 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
         <View style={styles.editControls}>
           {isEditing ? (
             <>
-              <TouchableOpacity onPress={() => setIsEditing(false)} style={styles.cancelButton}>
-                <Text style={styles.cancelButtonText}>キャンセル</Text>
-              </TouchableOpacity>
-              <TouchableOpacity onPress={handleSave} disabled={loading} style={styles.saveButton}>
-                {loading ? <ActivityIndicator color={theme.colors.text.inverse} size="small" /> : <Text style={styles.saveButtonText}>保存</Text>}
-              </TouchableOpacity>
+              <AppButton
+                title={BUTTON_LABELS.cancel}
+                onPress={() => setIsEditing(false)}
+                variant="secondary"
+                size="sm"
+              />
+              <AppButton
+                title={BUTTON_LABELS.save}
+                onPress={handleSave}
+                loading={loading}
+                disabled={loading}
+                size="sm"
+              />
             </>
           ) : (
             <>
               {/* ★ [Issue #81] スマホ非表示化 ＆ 文言変更 */}
               {onGoToSplitEditor && isWide && (
-                <TouchableOpacity onPress={() => onGoToSplitEditor(receipt)} style={styles.splitButton}>
-                  <Text style={styles.splitButtonText}>➗ 割り勘</Text>
-                </TouchableOpacity>
+                <AppButton
+                  title="➗ 割り勘"
+                  onPress={() => onGoToSplitEditor(receipt)}
+                  variant="outline"
+                  size="sm"
+                  style={styles.splitButtonOverride}
+                />
               )}
-              <TouchableOpacity onPress={() => setIsEditing(true)} style={styles.editButton}>
-                <Text style={styles.editButtonText}>✎ 編集</Text>
-              </TouchableOpacity>
+              <AppButton
+                title={`✎ ${BUTTON_LABELS.edit}`}
+                onPress={() => setIsEditing(true)}
+                variant="secondary"
+                size="sm"
+              />
             </>
           )}
         </View>
@@ -334,14 +350,7 @@ const styles = StyleSheet.create({
   detailItemSub: { fontSize: 12, color: theme.colors.text.muted, marginLeft: 6 },
   detailItemBottom: { width: '100%' },
   editControls: { flexDirection: 'row', justifyContent: 'flex-end', marginBottom: 10, gap: 10 },
-  editButton: { backgroundColor: theme.colors.background, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: theme.colors.border },
-  editButtonText: { color: theme.colors.text.main, fontWeight: 'bold' },
-  splitButton: { backgroundColor: sem.info.bg, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: sem.info.border },
-  splitButtonText: { color: sem.info.text, fontWeight: 'bold' },
-  saveButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 16, paddingVertical: 6, borderRadius: 8 },
-  saveButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold' },
-  cancelButton: { backgroundColor: sem.neutral.bg, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
-  cancelButtonText: { color: theme.colors.text.muted },
+  splitButtonOverride: { backgroundColor: sem.info.bg, borderColor: sem.info.border },
   editPriceRow: { flexDirection: 'row', alignItems: 'center', gap: 5 },
   priceInput: { borderBottomWidth: 1, borderBottomColor: theme.colors.primary, width: 80, fontSize: 15, textAlign: 'right', color: theme.colors.primary },
   quantityInput: { borderBottomWidth: 1, borderBottomColor: theme.colors.primary, width: 50, fontSize: 15, textAlign: 'center', color: theme.colors.primary },

--- a/frontend/src/components/ui/AppBackButton.tsx
+++ b/frontend/src/components/ui/AppBackButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, ViewStyle, StyleProp } from 'react-native';
+import { BUTTON_LABELS } from '../../constants/buttonLabels';
+import { theme } from '../../theme';
+
+export interface AppBackButtonProps {
+  onPress: () => void;
+  label?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const AppBackButton: React.FC<AppBackButtonProps> = ({
+  onPress,
+  label = BUTTON_LABELS.back,
+  style,
+}) => (
+  <TouchableOpacity
+    onPress={onPress}
+    style={[styles.wrap, style]}
+    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+  >
+    <Text style={styles.text}>{label}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  wrap: {
+    minWidth: 60,
+    paddingVertical: 8,
+  },
+  text: {
+    color: theme.colors.primary,
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});

--- a/frontend/src/components/ui/AppButton.tsx
+++ b/frontend/src/components/ui/AppButton.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  ViewStyle,
+  StyleProp,
+  TextStyle,
+} from 'react-native';
+import { theme } from '../../theme';
+
+export type AppButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'outline'
+  | 'danger'
+  | 'dangerFilled'
+  | 'ghost'
+  | 'success';
+
+export type AppButtonSize = 'sm' | 'md' | 'lg';
+
+export interface AppButtonProps {
+  title: string;
+  onPress: () => void;
+  variant?: AppButtonVariant;
+  size?: AppButtonSize;
+  disabled?: boolean;
+  loading?: boolean;
+  fullWidth?: boolean;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+}
+
+const SIZE_STYLES: Record<AppButtonSize, ViewStyle> = {
+  sm: { paddingHorizontal: 12, paddingVertical: 6, minHeight: 32 },
+  md: { paddingHorizontal: 16, paddingVertical: 10, minHeight: 40 },
+  lg: { paddingHorizontal: 20, paddingVertical: 14, minHeight: 48 },
+};
+
+const FONT_SIZES: Record<AppButtonSize, number> = {
+  sm: 12,
+  md: 16,
+  lg: 16,
+};
+
+function getVariantStyle(variant: AppButtonVariant): { container: ViewStyle; text: TextStyle } {
+  const c = theme.colors;
+  const adm = c.semantic.admin;
+
+  switch (variant) {
+    case 'primary':
+      return {
+        container: { backgroundColor: c.primary, borderWidth: 0 },
+        text: { color: c.text.inverse },
+      };
+    case 'success':
+      return {
+        container: { backgroundColor: adm.success, borderWidth: 0 },
+        text: { color: c.text.inverse },
+      };
+    case 'secondary':
+      return {
+        container: { backgroundColor: c.semantic.neutral.bg, borderWidth: 1, borderColor: c.border },
+        text: { color: c.text.muted },
+      };
+    case 'outline':
+      return {
+        container: { backgroundColor: 'transparent', borderWidth: 1, borderColor: c.primary },
+        text: { color: c.primary },
+      };
+    case 'danger':
+      return {
+        container: { backgroundColor: 'transparent', borderWidth: 1, borderColor: adm.danger },
+        text: { color: adm.danger },
+      };
+    case 'dangerFilled':
+      return {
+        container: { backgroundColor: c.error, borderWidth: 0 },
+        text: { color: c.text.inverse },
+      };
+    case 'ghost':
+      return {
+        container: { backgroundColor: c.semantic.neutral.bg, borderWidth: 0 },
+        text: { color: c.text.muted, fontWeight: 'bold' },
+      };
+    default:
+      return {
+        container: { backgroundColor: c.primary, borderWidth: 0 },
+        text: { color: c.text.inverse },
+      };
+  }
+}
+
+export const AppButton: React.FC<AppButtonProps> = ({
+  title,
+  onPress,
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  fullWidth = false,
+  style,
+  textStyle,
+}) => {
+  const isDisabled = disabled || loading;
+  const variantStyle = useMemo(() => getVariantStyle(variant), [variant]);
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={isDisabled}
+      activeOpacity={0.7}
+      style={[
+        styles.base,
+        SIZE_STYLES[size],
+        variantStyle.container,
+        fullWidth && styles.fullWidth,
+        isDisabled && styles.disabled,
+        style,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator
+          size="small"
+          color={variantStyle.text.color as string}
+        />
+      ) : (
+        <Text
+          style={[
+            styles.text,
+            { fontSize: FONT_SIZES[size] },
+            variantStyle.text,
+            textStyle,
+          ]}
+        >
+          {title}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  base: {
+    borderRadius: theme.borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  fullWidth: {
+    alignSelf: 'stretch',
+    width: '100%',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  text: {
+    ...theme.typography.button,
+    textAlign: 'center',
+  },
+});

--- a/frontend/src/components/ui/AppModalCloseButton.tsx
+++ b/frontend/src/components/ui/AppModalCloseButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, ViewStyle, StyleProp } from 'react-native';
+import { BUTTON_LABELS } from '../../constants/buttonLabels';
+import { theme } from '../../theme';
+
+export interface AppModalCloseButtonProps {
+  onPress: () => void;
+  /** 読み上げ用（表示は × 固定） */
+  accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * モーダル・オーバーレイを閉じる操作（表示 × / 意味・アクセシビリティは「閉じる」）
+ */
+export const AppModalCloseButton: React.FC<AppModalCloseButtonProps> = ({
+  onPress,
+  accessibilityLabel = BUTTON_LABELS.close,
+  style,
+}) => (
+  <TouchableOpacity
+    onPress={onPress}
+    style={[styles.wrap, style]}
+    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+    accessibilityRole="button"
+    accessibilityLabel={accessibilityLabel}
+  >
+    <Text style={styles.icon} accessible={false}>
+      {BUTTON_LABELS.closeIcon}
+    </Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  wrap: {
+    minWidth: 32,
+    minHeight: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 8,
+  },
+  icon: {
+    color: theme.colors.text.muted,
+    fontWeight: '600',
+    fontSize: 22,
+    lineHeight: 24,
+  },
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+export { AppButton, type AppButtonProps, type AppButtonVariant, type AppButtonSize } from './AppButton';
+export { AppBackButton, type AppBackButtonProps } from './AppBackButton';
+export { AppModalCloseButton, type AppModalCloseButtonProps } from './AppModalCloseButton';

--- a/frontend/src/constants/buttonLabels.ts
+++ b/frontend/src/constants/buttonLabels.ts
@@ -1,0 +1,15 @@
+/** Issue #83: ボタン表記の統一 */
+export const BUTTON_LABELS = {
+  save: '保存',
+  cancel: 'キャンセル',
+  delete: '削除',
+  edit: '編集',
+  back: '← 戻る',
+  close: '閉じる',
+  closeIcon: '×',
+  add: '追加',
+  create: '新規作成',
+  recordTransfer: '送金を記録',
+  setDefault: 'デフォルトに設定',
+  splitEqual: '均等',
+} as const;

--- a/frontend/src/screens/AdminMenuScreen.tsx
+++ b/frontend/src/screens/AdminMenuScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { AppBackButton } from '../components/ui';
 import { theme } from '../theme';
 
 interface AdminMenuScreenProps {
@@ -20,9 +21,7 @@ export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={onBack}>
-          <Text style={styles.backButtonText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>管理者メニュー</Text>
         <View style={{ width: 60 }} />
       </View>
@@ -91,8 +90,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: adm.border,
   },
-  backButton: { width: 60, paddingVertical: 8 },
-  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
   headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   content: { padding: 16 },
   section: { marginBottom: 24 },

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   TouchableOpacity
 } from 'react-native';
+import { AppBackButton } from '../components/ui';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
 
@@ -61,9 +62,7 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={onBack}>
-          <Text style={styles.backButtonText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>AIコスト統計</Text>
         <View style={{ width: 60 }} />
       </View>
@@ -133,8 +132,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: adm.border,
   },
-  backButton: { width: 60, paddingVertical: 8 },
-  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
   headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   content: { padding: 16, paddingBottom: 40 },
   

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
 interface Category {
@@ -115,9 +117,7 @@ export const CategoryManagementScreen = ({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} style={styles.backButton}>
-          <Text style={styles.backText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.title}>カテゴリー設定</Text>
       </View>
 
@@ -129,22 +129,18 @@ export const CategoryManagementScreen = ({
           placeholder="新しいカテゴリー"
           placeholderTextColor={theme.colors.text.muted}
         />
-        <TouchableOpacity style={styles.addButton} onPress={addCategory}>
-          <Text style={styles.addButtonText}>追加</Text>
-        </TouchableOpacity>
+        <AppButton title={BUTTON_LABELS.add} onPress={addCategory} size="md" />
       </View>
 
-      <TouchableOpacity 
-        style={[styles.optimizeButton, optimizing && styles.buttonDisabled]} 
+      <AppButton
+        title="🪄 キーワード自動最適化"
         onPress={handleOptimize}
+        loading={optimizing}
         disabled={optimizing}
-      >
-        {optimizing ? (
-          <ActivityIndicator size="small" color="white" />
-        ) : (
-          <Text style={styles.optimizeButtonText}>🪄 キーワード自動最適化</Text>
-        )}
-      </TouchableOpacity>
+        fullWidth
+        size="md"
+        style={{ backgroundColor: theme.colors.semantic.category.optimize, marginBottom: 20 }}
+      />
 
       {!currentMemberId ? (
         <Text style={styles.emptyText}>メンバーを選択してください</Text>
@@ -159,9 +155,12 @@ export const CategoryManagementScreen = ({
             <View style={styles.itemRow}>
               <View style={[styles.colorBadge, { backgroundColor: item.color }]} />
               <Text style={styles.categoryName}>{item.name}</Text>
-              <TouchableOpacity onPress={() => deleteCategory(item.id)} style={styles.deleteButton}>
-                <Text style={styles.deleteText}>削除</Text>
-              </TouchableOpacity>
+              <AppButton
+                title={BUTTON_LABELS.delete}
+                onPress={() => deleteCategory(item.id)}
+                variant="dangerFilled"
+                size="sm"
+              />
             </View>
           )}
         />
@@ -173,21 +172,12 @@ export const CategoryManagementScreen = ({
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background, padding: 20, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
   header: { flexDirection: 'row', alignItems: 'center', marginBottom: 30 },
-  backButton: { padding: 5 },
-  backText: { color: theme.colors.primary, fontSize: 16, fontWeight: 'bold' },
-  title: { ...theme.typography.h1, marginLeft: 15 },
-  inputSection: { flexDirection: 'row', marginBottom: 15, gap: 10 },
+  title: { ...theme.typography.h1, marginLeft: 8, flex: 1 },
+  inputSection: { flexDirection: 'row', marginBottom: 15, gap: 10, alignItems: 'center' },
   input: { flex: 1, backgroundColor: theme.colors.surface, borderRadius: 10, padding: 14, borderWidth: 1, borderColor: theme.colors.border, color: theme.colors.text.main },
-  addButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 25, justifyContent: 'center', borderRadius: 10 },
-  addButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold' },
-  optimizeButton: { backgroundColor: theme.colors.semantic.category.optimize, padding: 12, borderRadius: 10, marginBottom: 20, alignItems: 'center', justifyContent: 'center' },
-  optimizeButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold' },
-  buttonDisabled: { opacity: 0.6 },
   list: { paddingBottom: 40 },
   itemRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: theme.colors.surface, padding: 16, borderRadius: 12, marginBottom: 12, borderWidth: 1, borderColor: theme.colors.border },
   colorBadge: { width: 14, height: 14, borderRadius: 7, marginRight: 15 },
   categoryName: { flex: 1, ...theme.typography.body, fontWeight: '600' },
-  deleteButton: { padding: 8 },
-  deleteText: { color: theme.colors.error, fontSize: 14, fontWeight: '700' },
   emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted }
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 // Issue #66: BREAKPOINTS 参照
+import { AppBackButton, AppModalCloseButton } from '../components/ui';
 import { theme, BREAKPOINTS } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -247,9 +248,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
     <View style={styles.container}>
       <View style={styles.mainWrapper}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-            <Text style={styles.backButton}>← 戻る</Text>
-          </TouchableOpacity>
+          <AppBackButton onPress={onBack} />
           <Text style={styles.title}>レシート履歴</Text>
           <View style={{ width: 40 }} />
         </View>
@@ -310,9 +309,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
               <Text style={styles.detailTitleMobile} numberOfLines={1}>
                 {selectedReceipt?.storeName || '店名不明'}
               </Text>
-              <TouchableOpacity onPress={() => setSelectedReceipt(null)}>
-                <Text style={styles.detailClose}>✕</Text>
-              </TouchableOpacity>
+              <AppModalCloseButton onPress={() => setSelectedReceipt(null)} />
             </View>
             {selectedReceipt && (
               <ReceiptDetailComponent 
@@ -336,7 +333,6 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   mainWrapper: { flex: 1, width: '100%', alignSelf: 'stretch', paddingTop: Platform.OS === 'ios' ? 60 : 20 },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
-  backButton: { color: theme.colors.primary, fontWeight: '700' },
   title: { ...theme.typography.h2, color: theme.colors.text.main },
   filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 10 },
   wideFilter: { justifyContent: 'flex-start' },
@@ -376,7 +372,6 @@ const styles = StyleSheet.create({
   modalContent: { flex: 1, backgroundColor: theme.colors.background },
   detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   detailTitleMobile: { fontSize: 18, fontWeight: 'bold', flex: 1 },
-  detailClose: { fontSize: 24, color: theme.colors.text.muted, marginLeft: 15 },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center', marginTop: 50 },
   emptyDetailWrapper: { flex: 1, justifyContent: 'center', alignItems: 'center' }
 });

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
 interface ProductMaster {
@@ -150,9 +152,12 @@ export const ProductMasterScreen = ({
         </View>
       </View>
       <View style={styles.actions}>
-        <TouchableOpacity onPress={() => handleDelete(item.id)} style={styles.deleteBtn}>
-          <Text style={styles.btnText}>削除</Text>
-        </TouchableOpacity>
+        <AppButton
+          title={BUTTON_LABELS.delete}
+          onPress={() => handleDelete(item.id)}
+          variant="dangerFilled"
+          size="sm"
+        />
       </View>
     </View>
   );
@@ -160,9 +165,7 @@ export const ProductMasterScreen = ({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} hitSlop={{top:10, bottom:10, left:10, right:10}}>
-          <Text style={styles.backText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.title}>学習マスタ ({currentMemberId === 1 ? '個人' : 'その他'})</Text>
         <TouchableOpacity onPress={handleMergeStores}>
           <Text style={styles.mergeText}>店舗統合</Text>
@@ -217,8 +220,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1, 
     borderBottomColor: theme.colors.border 
   },
-  backText: { color: theme.colors.primary, fontWeight: 'bold', fontSize: 16 },
-  title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1, textAlign: 'center' },
   mergeText: { color: theme.colors.secondary, fontWeight: 'bold' },
   searchBar: { padding: 10, flexDirection: 'row', backgroundColor: theme.colors.surface },
   input: { 
@@ -258,7 +260,5 @@ const styles = StyleSheet.create({
   badge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 3, borderRadius: 12 },
   badgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: 'bold' },
   actions: { justifyContent: 'center', paddingLeft: 10 },
-  deleteBtn: { backgroundColor: theme.colors.error, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 6 },
-  btnText: { color: theme.colors.text.inverse, fontSize: 12, fontWeight: 'bold', textAlign: 'center' },
   empty: { textAlign: 'center', marginTop: 40, color: theme.colors.text.muted }
 });

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -12,6 +12,8 @@ import {
 } from 'react-native';
 
 import apiClient from '../utils/apiClient';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
 interface PromptTemplate {
@@ -192,9 +194,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={onBack}>
-          <Text style={styles.backButtonText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>プロンプト管理</Text>
         <View style={{ width: 60 }} />
       </View>
@@ -213,9 +213,12 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
               <Text style={styles.formTitle}>
                 {isCreatingNew ? '新規プロンプトの作成' : 'プロンプトの編集'}
               </Text>
-              <TouchableOpacity onPress={cancelForm}>
-                <Text style={styles.cancelText}>キャンセル</Text>
-              </TouchableOpacity>
+              <AppButton
+                title={BUTTON_LABELS.cancel}
+                onPress={cancelForm}
+                variant="ghost"
+                size="sm"
+              />
             </View>
 
             <View style={styles.section}>
@@ -242,16 +245,25 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
               />
             </View>
 
-            <TouchableOpacity style={[styles.saveButton, isSaving && styles.disabledButton]} onPress={handleSave} disabled={isSaving}>
-              {isSaving ? <ActivityIndicator size="small" color={theme.colors.text.inverse} /> : <Text style={styles.saveButtonText}>保存</Text>}
-            </TouchableOpacity>
+            <AppButton
+              title={BUTTON_LABELS.save}
+              onPress={handleSave}
+              loading={isSaving}
+              disabled={isSaving}
+              fullWidth
+              size="lg"
+            />
           </View>
         ) : (
           /* 一覧表示画面 */
           <View>
-            <TouchableOpacity style={styles.createButton} onPress={openCreateForm}>
-              <Text style={styles.createButtonText}>＋ 新規プロンプトを作成</Text>
-            </TouchableOpacity>
+            <AppButton
+              title={`＋ ${BUTTON_LABELS.create}`}
+              onPress={openCreateForm}
+              variant="success"
+              fullWidth
+              style={{ marginBottom: 16 }}
+            />
 
             {templates.map((tpl) => (
               <View key={tpl.id} style={[styles.card, tpl.isActive && styles.activeCard]}>
@@ -274,17 +286,25 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
                 
                 <View style={styles.cardActions}>
                   {!tpl.isActive && (
-                    <TouchableOpacity style={styles.actionBtnOutline} onPress={() => handleActivate(tpl.id)}>
-                      <Text style={styles.actionBtnOutlineText}>デフォルトに設定</Text>
-                    </TouchableOpacity>
+                    <AppButton
+                      title={BUTTON_LABELS.setDefault}
+                      onPress={() => handleActivate(tpl.id)}
+                      variant="outline"
+                      size="sm"
+                    />
                   )}
-                  <TouchableOpacity style={styles.actionBtnFill} onPress={() => openEditForm(tpl)}>
-                    <Text style={styles.actionBtnFillText}>編集</Text>
-                  </TouchableOpacity>
+                  <AppButton
+                    title={BUTTON_LABELS.edit}
+                    onPress={() => openEditForm(tpl)}
+                    size="sm"
+                  />
                   {!tpl.isActive && (
-                    <TouchableOpacity style={styles.actionBtnDanger} onPress={() => handleDelete(tpl.id)}>
-                      <Text style={styles.actionBtnDangerText}>削除</Text>
-                    </TouchableOpacity>
+                    <AppButton
+                      title={BUTTON_LABELS.delete}
+                      onPress={() => handleDelete(tpl.id)}
+                      variant="danger"
+                      size="sm"
+                    />
                   )}
                 </View>
               </View>
@@ -301,8 +321,6 @@ const adm = theme.colors.semantic.admin;
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: adm.background },
   header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', backgroundColor: adm.surface, paddingVertical: 16, paddingHorizontal: 16, borderBottomWidth: 1, borderBottomColor: adm.border },
-  backButton: { width: 60, paddingVertical: 8 },
-  backButtonText: { color: theme.colors.primary, fontWeight: 'bold' },
   headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   contentContainer: { padding: 16, paddingBottom: 40 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
@@ -310,8 +328,6 @@ const styles = StyleSheet.create({
   errorContainer: { backgroundColor: adm.errorBg, padding: 12, borderRadius: 6, marginBottom: 16 },
   errorText: { color: adm.errorText },
   
-  createButton: { backgroundColor: adm.success, padding: 14, borderRadius: 8, alignItems: 'center', marginBottom: 16 },
-  createButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold', fontSize: 15 },
   card: { backgroundColor: adm.surface, padding: 16, borderRadius: 8, marginBottom: 12, borderWidth: 2, borderColor: adm.border },
   activeCard: { borderColor: theme.colors.primary },
   cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 },
@@ -324,23 +340,13 @@ const styles = StyleSheet.create({
   
   cardDesc: { fontSize: 13, color: adm.textMuted, marginBottom: 12 },
   cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' },
-  actionBtnOutline: { borderWidth: 1, borderColor: theme.colors.primary, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 4, marginBottom: 4 },
-  actionBtnOutlineText: { color: theme.colors.primary, fontSize: 12 },
-  actionBtnFill: { backgroundColor: theme.colors.primary, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 4, marginBottom: 4 },
-  actionBtnFillText: { color: theme.colors.text.inverse, fontSize: 12 },
-  actionBtnDanger: { borderWidth: 1, borderColor: adm.danger, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 4, marginBottom: 4 },
-  actionBtnDangerText: { color: adm.danger, fontSize: 12 },
 
   formContainer: { backgroundColor: adm.surface, padding: 16, borderRadius: 8, borderWidth: 1, borderColor: adm.border },
   formHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 },
-  formTitle: { fontSize: 18, fontWeight: 'bold' },
-  cancelText: { color: adm.textMuted, fontSize: 14 },
+  formTitle: { fontSize: 18, fontWeight: 'bold', flex: 1 },
   section: { marginBottom: 16 },
   label: { fontSize: 14, fontWeight: 'bold', color: adm.textLabel, marginBottom: 6 },
   input: { backgroundColor: adm.inputBg, borderWidth: 1, borderColor: adm.inputBorder, borderRadius: 6, padding: 12, fontSize: 14 },
   textArea: { height: 200, fontFamily: 'System' },
   jsonArea: { height: 150, fontFamily: 'Courier' },
-  saveButton: { backgroundColor: theme.colors.primary, paddingVertical: 14, borderRadius: 6, alignItems: 'center' },
-  disabledButton: { opacity: 0.5 },
-  saveButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold', fontSize: 16 },
 });

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -15,6 +15,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
 const c = theme.colors;
@@ -153,13 +155,15 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
     <SafeAreaView style={styles.container}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
         <View style={styles.header}>
-          <TouchableOpacity onPress={onCancel} style={styles.headerButton}>
-            <Text style={styles.cancelText}>戻る</Text>
-          </TouchableOpacity>
+          <AppBackButton onPress={onCancel} style={styles.headerBack} />
           <Text style={styles.headerTitle}>解析結果の確認</Text>
-          <TouchableOpacity onPress={handleCommit} disabled={loading} style={[styles.saveButton, loading && { opacity: 0.6 }]}>
-            {loading ? <ActivityIndicator color={c.text.inverse} size="small" /> : <Text style={styles.saveButtonText}>確定保存</Text>}
-          </TouchableOpacity>
+          <AppButton
+            title={BUTTON_LABELS.save}
+            onPress={handleCommit}
+            loading={loading}
+            disabled={loading}
+            size="sm"
+          />
         </View>
 
         <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
@@ -204,9 +208,12 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
 
           <View style={styles.itemsHeader}>
             <Text style={styles.sectionLabel}>商品明細 ({receiptData.items.length})</Text>
-            <TouchableOpacity onPress={addItem} style={styles.addButton}>
-              <Text style={styles.addButtonText}>+ 追加</Text>
-            </TouchableOpacity>
+            <AppButton
+              title={`+ ${BUTTON_LABELS.add}`}
+              onPress={addItem}
+              variant="outline"
+              size="sm"
+            />
           </View>
 
           {receiptData.items.map((item, idx) => (
@@ -286,9 +293,7 @@ const styles = StyleSheet.create({
     borderBottomColor: s.borderLight,
   },
   headerTitle: { fontSize: 17, fontWeight: 'bold', color: s.textTitle },
-  cancelText: { color: s.textSecondary, fontSize: 15 },
-  saveButton: { backgroundColor: c.primary, paddingHorizontal: 16, paddingVertical: 8, borderRadius: theme.borderRadius.lg },
-  saveButtonText: { color: c.text.inverse, fontWeight: 'bold' },
+  headerBack: { minWidth: 50 },
   scrollView: { flex: 1 },
   imageContainer: { width: '100%', height: 260, backgroundColor: s.imageBg, marginBottom: theme.spacing.md, position: 'relative' },
   receiptImage: { width: '100%', height: '100%' },
@@ -304,8 +309,6 @@ const styles = StyleSheet.create({
   totalLabel: { fontSize: 14, color: s.textSecondary },
   totalValue: { fontSize: 24, fontWeight: 'bold', color: c.primary },
   itemsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginHorizontal: theme.spacing.md, marginBottom: 12 },
-  addButton: { backgroundColor: s.primaryLight, paddingHorizontal: 12, paddingVertical: 6, borderRadius: theme.borderRadius.sm },
-  addButtonText: { color: c.primary, fontWeight: 'bold', fontSize: 13 },
   itemCard: { backgroundColor: c.surface, marginHorizontal: theme.spacing.md, marginBottom: 12, borderRadius: theme.spacing.md, padding: theme.spacing.md, borderLeftWidth: 4, borderLeftColor: c.primary, elevation: 1 },
   itemHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
   itemNameInput: { flex: 1, fontSize: 15, fontWeight: 'bold', color: s.textBody },

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -13,6 +13,8 @@ import {
   Alert
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 
@@ -135,17 +137,15 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
     <View style={styles.container}>
       {/* ヘッダー */}
       <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} style={styles.backButton}>
-          <Text style={styles.backButtonText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>家族間精算サマリー</Text>
         <View style={styles.headerRight}>
-          <TouchableOpacity 
-            style={styles.addTransferButton}
+          <AppButton
+            title={`＋ ${BUTTON_LABELS.recordTransfer}`}
             onPress={() => setTransferModalVisible(true)}
-          >
-            <Text style={styles.addTransferButtonText}>＋ 送金・受取を記録</Text>
-          </TouchableOpacity>
+            size="sm"
+            style={styles.addTransferButton}
+          />
           <View style={styles.monthPickerContainer}>
             {renderMonthPicker()}
           </View>
@@ -300,12 +300,20 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
             </View>
 
             <View style={styles.modalActions}>
-              <TouchableOpacity style={styles.modalCancelBtn} onPress={() => setTransferModalVisible(false)}>
-                <Text style={styles.modalCancelText}>キャンセル</Text>
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.modalSubmitBtn} onPress={handleTransferSubmit} disabled={isSubmitting}>
-                {isSubmitting ? <ActivityIndicator color={theme.colors.text.inverse} /> : <Text style={styles.modalSubmitText}>記録する</Text>}
-              </TouchableOpacity>
+              <AppButton
+                title={BUTTON_LABELS.cancel}
+                onPress={() => setTransferModalVisible(false)}
+                variant="secondary"
+                size="md"
+              />
+              <AppButton
+                title={BUTTON_LABELS.save}
+                onPress={handleTransferSubmit}
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                size="md"
+                style={styles.modalSubmitBtn}
+              />
             </View>
           </View>
         </View>
@@ -321,12 +329,9 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, backgroundColor: theme.colors.surface, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  backButton: { paddingRight: 15 },
-  backButtonText: { color: theme.colors.primary, fontWeight: '700', fontSize: 16 },
   headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
   headerRight: { flexDirection: 'row', alignItems: 'center', gap: 15 },
-  addTransferButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 6 },
-  addTransferButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold', fontSize: 13 },
+  addTransferButton: { paddingHorizontal: 4 },
   monthPickerContainer: { width: 140, height: 36, backgroundColor: theme.colors.surface, borderRadius: 6, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
   filterPicker: { width: '100%' },
   webSelect: { width: '100%', height: '100%', borderWidth: 0, backgroundColor: 'transparent', paddingLeft: 10, fontSize: 14, color: theme.colors.text.main, ...Platform.select({ web: { outlineStyle: 'none' } as any }) } as any,
@@ -386,8 +391,5 @@ const styles = StyleSheet.create({
   modalInput: { flex: 1, height: '100%', fontSize: 16, ...Platform.select({ web: { outlineStyle: 'none' } as any }) },
   unitText: { fontSize: 14, color: theme.colors.text.muted, marginLeft: 8 },
   modalActions: { flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10, gap: 10 },
-  modalCancelBtn: { paddingHorizontal: 15, paddingVertical: 10, borderRadius: 6, backgroundColor: sem.neutral.bg },
-  modalCancelText: { color: theme.colors.text.muted, fontWeight: 'bold' },
-  modalSubmitBtn: { paddingHorizontal: 20, paddingVertical: 10, borderRadius: 6, backgroundColor: theme.colors.primary, minWidth: 100, alignItems: 'center' },
-  modalSubmitText: { color: theme.colors.text.inverse, fontWeight: 'bold' }
+  modalSubmitBtn: { minWidth: 100 },
 });

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -13,6 +13,8 @@ import {
   useWindowDimensions
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
+import { AppBackButton, AppButton } from '../components/ui';
+import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 
@@ -315,14 +317,16 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} style={styles.backButton}>
-          <Text style={styles.backButtonText}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>割り勘エディタ</Text>
         <View style={styles.headerRight}>
-          <TouchableOpacity style={styles.saveButton} onPress={handleSave} disabled={saving}>
-            {saving ? <ActivityIndicator color={theme.colors.text.inverse} size="small" /> : <Text style={styles.saveButtonText}>確定して保存</Text>}
-          </TouchableOpacity>
+          <AppButton
+            title={BUTTON_LABELS.save}
+            onPress={handleSave}
+            loading={saving}
+            disabled={saving}
+            size="md"
+          />
         </View>
       </View>
 
@@ -438,9 +442,12 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                     })}
 
                     <View style={[styles.cell, styles.cellAction]}>
-                      <TouchableOpacity style={styles.splitBtnSmall} onPress={() => splitItemEqually(item.id, itemTotal)}>
-                        <Text style={styles.splitBtnSmallText}>均等</Text>
-                      </TouchableOpacity>
+                      <AppButton
+                        title={BUTTON_LABELS.splitEqual}
+                        onPress={() => splitItemEqually(item.id, itemTotal)}
+                        variant="ghost"
+                        size="sm"
+                      />
                     </View>
                   </View>
                 );
@@ -488,9 +495,12 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                 })}
 
                 <View style={[styles.cell, styles.cellAction]}>
-                  <TouchableOpacity style={styles.splitBtnSmall} onPress={splitWholeReceiptEqually}>
-                    <Text style={styles.splitBtnSmallText}>均等</Text>
-                  </TouchableOpacity>
+                  <AppButton
+                    title={BUTTON_LABELS.splitEqual}
+                    onPress={splitWholeReceiptEqually}
+                    variant="ghost"
+                    size="sm"
+                  />
                 </View>
               </View>
 
@@ -508,12 +518,8 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, backgroundColor: theme.colors.surface, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  backButton: { paddingRight: 15 },
-  backButtonText: { color: theme.colors.primary, fontWeight: '700', fontSize: 16 },
   headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main },
   headerRight: { minWidth: 100, alignItems: 'flex-end' },
-  saveButton: { backgroundColor: theme.colors.primary, paddingHorizontal: 20, paddingVertical: 10, borderRadius: 8 },
-  saveButtonText: { color: theme.colors.text.inverse, fontWeight: 'bold', fontSize: 16 },
   
   targetSection: { backgroundColor: theme.colors.surface, borderBottomWidth: 1, borderBottomColor: theme.colors.border, padding: 15, paddingHorizontal: 20 },
   targetHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 },
@@ -565,6 +571,4 @@ const styles = StyleSheet.create({
   unitText: { fontSize: 11, color: theme.colors.text.muted },
   
   cellAction: { width: 70, alignItems: 'center' },
-  splitBtnSmall: { backgroundColor: sem.neutral.bg, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 6 },
-  splitBtnSmallText: { fontSize: 12, color: theme.colors.text.muted, fontWeight: 'bold' },
 });

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -18,6 +18,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
+import { AppBackButton, AppModalCloseButton } from '../components/ui';
 import { theme } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -161,9 +162,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={onBack} hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
-          <Text style={styles.backButton}>← 戻る</Text>
-        </TouchableOpacity>
+        <AppBackButton onPress={onBack} />
         <Text style={styles.headerTitle}>家計分析レポート</Text>
         <View style={{ width: 40 }} />
       </View>
@@ -290,9 +289,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
           <SafeAreaView style={[styles.modalContainer, isWide && styles.wideModal]}>
             <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>解析レシート詳細</Text>
-              <TouchableOpacity onPress={() => setMainModalVisible(false)}>
-                <Text style={styles.modalCloseText}>閉じる</Text>
-              </TouchableOpacity>
+              <AppModalCloseButton onPress={() => setMainModalVisible(false)} />
             </View>
             
             <ReceiptDetailComponent 
@@ -313,7 +310,6 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 20, paddingVertical: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  backButton: { color: theme.colors.primary, fontWeight: '700' },
   headerTitle: { fontSize: 18, fontWeight: 'bold' },
   scrollContent: { padding: 20 },
   topInfo: { marginBottom: 15 },
@@ -357,5 +353,4 @@ const styles = StyleSheet.create({
   wideModal: { width: '95%', maxWidth: 1400, height: '90%', borderRadius: 20, overflow: 'hidden' },
   modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   modalTitle: { fontSize: 18, fontWeight: 'bold' },
-  modalCloseText: { color: theme.colors.error, fontWeight: '600', fontSize: 16 }
 });


### PR DESCRIPTION
## 概要
Issue #82 で整備した theme を前提に、共有ボタンコンポーネントを導入し、主要画面の操作 UI と文言を統一しました。

Closes #243

## 変更内容
### 共有コンポーネント（`frontend/src/components/ui/`）
- **`AppButton`** — `variant`（primary / secondary / outline / danger / dangerFilled / ghost / success）、`size`、`loading`
- **`AppBackButton`** — ヘッダー「← 戻る」
- **`AppModalCloseButton`** — モーダル閉じる（表示 `×`、アクセシビリティ「閉じる」）
- **`buttonLabels.ts`** — 保存・キャンセル・戻る・閉じる 等の文言定数

### 表記の統一
- 「確定して保存」「確定保存」「記録する」→ **保存**
- 「＋ 送金・受取を記録」→ **＋ 送金を記録**
- 「＋ 新規プロンプトを作成」→ **＋ 新規作成**
- モーダル閉じる: History / Statistics の ✕・閉じる表記ゆれ → **`AppModalCloseButton`**

### 置き換えた画面
AdminMenu / AdminStats / PromptEditor / History / Statistics / SplitEditor / SettlementSummary / ReceiptScan / ReceiptDetail / CategoryManagement / ProductMaster

### スコープ外（意図的に未変更）
- **HomeScreen** の撮影カード・グリッドカード（カード UI）
- **SplitEditor** チップ上の ×（メンバー削除）

## 依存
- **#82（テーマ基盤）** マージ済み `develop` をベースにしています

## 確認事項
- [ ] 各画面の戻る・保存・削除・モーダル操作が従来どおり動作する
- [ ] モーダル（履歴・統計）右上が × 表示で、タップ領域が十分
- [ ] 表記が `buttonLabels` に沿っている（特に保存・送金モーダル）
- [ ] `cd frontend && npx tsc --noEmit` が通る