### PR TITLE
feat(ui): [Issue #84] リスト・テーブルUIの共通化

### DIFF
--- a/frontend/src/components/ui/AppListItem.tsx
+++ b/frontend/src/components/ui/AppListItem.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  StyleProp,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { listItemStyles } from '../../theme/tableStyles';
+
+export type AppListItemVariant = 'default' | 'nav';
+
+export interface AppListItemProps {
+  title: string;
+  subtitle?: string;
+  onPress?: () => void;
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+  children?: React.ReactNode;
+  variant?: AppListItemVariant;
+  style?: StyleProp<ViewStyle>;
+}
+
+/** カテゴリー色などリスト左端のドット */
+export const AppListColorDot: React.FC<{ color: string }> = ({ color }) => (
+  <View style={[listItemStyles.colorDot, { backgroundColor: color }]} />
+);
+
+export const AppListItem: React.FC<AppListItemProps> = ({
+  title,
+  subtitle,
+  onPress,
+  left,
+  right,
+  children,
+  variant = 'default',
+  style,
+}) => {
+  const trailing =
+    right ?? (variant === 'nav' ? <Text style={listItemStyles.chevron}>›</Text> : null);
+
+  const content = (
+    <>
+      {left}
+      <View style={listItemStyles.main}>
+        <Text style={listItemStyles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={listItemStyles.subtitle} numberOfLines={2}>
+            {subtitle}
+          </Text>
+        ) : null}
+        {children}
+      </View>
+      {trailing}
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity
+        style={[listItemStyles.row, style]}
+        onPress={onPress}
+        activeOpacity={0.7}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return <View style={[listItemStyles.row, style]}>{content}</View>;
+};

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,3 +1,10 @@
 export { AppButton, type AppButtonProps, type AppButtonVariant, type AppButtonSize } from './AppButton';
 export { AppBackButton, type AppBackButtonProps } from './AppBackButton';
 export { AppModalCloseButton, type AppModalCloseButtonProps } from './AppModalCloseButton';
+export {
+  AppListItem,
+  AppListColorDot,
+  type AppListItemProps,
+  type AppListItemVariant,
+} from './AppListItem';
+export { tableStyles, listItemStyles } from '../../theme/tableStyles';

--- a/frontend/src/screens/AdminMenuScreen.tsx
+++ b/frontend/src/screens/AdminMenuScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
-import { AppBackButton } from '../components/ui';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { AppBackButton, AppListItem } from '../components/ui';
 import { theme } from '../theme';
 
 interface AdminMenuScreenProps {
@@ -30,45 +30,57 @@ export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>マスタデータ管理</Text>
           
-          <TouchableOpacity style={styles.settingsCard} onPress={onGoToCategories}>
-            <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.settings }]}><Text>⚙️</Text></View>
-            <View style={styles.textWrapper}>
-              <Text style={styles.cardTitle}>カテゴリー設定</Text>
-              <Text style={styles.cardDesc}>支出カテゴリの追加・編集・色変更</Text>
-            </View>
-            <Text style={styles.arrow}>›</Text>
-          </TouchableOpacity>
+          <AppListItem
+            variant="nav"
+            onPress={onGoToCategories}
+            title="カテゴリー設定"
+            subtitle="支出カテゴリの追加・編集・色変更"
+            left={
+              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.settings }]}>
+                <Text>⚙️</Text>
+              </View>
+            }
+          />
 
-          <TouchableOpacity style={styles.settingsCard} onPress={onGoToProductMaster}>
-            <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.product }]}><Text>🧠</Text></View>
-            <View style={styles.textWrapper}>
-              <Text style={styles.cardTitle}>学習マスタ管理</Text>
-              <Text style={styles.cardDesc}>商品名からの自動カテゴリ分類の修正</Text>
-            </View>
-            <Text style={styles.arrow}>›</Text>
-          </TouchableOpacity>
+          <AppListItem
+            variant="nav"
+            onPress={onGoToProductMaster}
+            title="学習マスタ管理"
+            subtitle="商品名からの自動カテゴリ分類の修正"
+            left={
+              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.product }]}>
+                <Text>🧠</Text>
+              </View>
+            }
+          />
         </View>
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>システム・AI設定</Text>
           
-          <TouchableOpacity style={styles.settingsCard} onPress={onGoToPromptEditor}>
-            <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.prompt }]}><Text>📝</Text></View>
-            <View style={styles.textWrapper}>
-              <Text style={styles.cardTitle}>プロンプト・外税ヒント編集</Text>
-              <Text style={styles.cardDesc}>Geminiへの指示と店舗特有の計算ルール</Text>
-            </View>
-            <Text style={styles.arrow}>›</Text>
-          </TouchableOpacity>
+          <AppListItem
+            variant="nav"
+            onPress={onGoToPromptEditor}
+            title="プロンプト・外税ヒント編集"
+            subtitle="Geminiへの指示と店舗特有の計算ルール"
+            left={
+              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.prompt }]}>
+                <Text>📝</Text>
+              </View>
+            }
+          />
 
-          <TouchableOpacity style={styles.settingsCard} onPress={onGoToAdminStats}>
-            <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.stats }]}><Text>📈</Text></View>
-            <View style={styles.textWrapper}>
-              <Text style={styles.cardTitle}>AIコスト統計</Text>
-              <Text style={styles.cardDesc}>API利用量と概算コストの確認</Text>
-            </View>
-            <Text style={styles.arrow}>›</Text>
-          </TouchableOpacity>
+          <AppListItem
+            variant="nav"
+            onPress={onGoToAdminStats}
+            title="AIコスト統計"
+            subtitle="API利用量と概算コストの確認"
+            left={
+              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.stats }]}>
+                <Text>📈</Text>
+              </View>
+            }
+          />
         </View>
       </ScrollView>
     </View>
@@ -94,26 +106,12 @@ const styles = StyleSheet.create({
   content: { padding: 16 },
   section: { marginBottom: 24 },
   sectionTitle: { fontSize: 14, fontWeight: 'bold', color: theme.colors.text.muted, marginBottom: 12, marginLeft: 4 },
-  settingsCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: adm.surface,
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: adm.border,
-  },
   iconWrapper: {
     width: 44,
     height: 44,
     borderRadius: 22,
     justifyContent: 'center',
     alignItems: 'center',
-    marginRight: 16,
+    marginRight: 0,
   },
-  textWrapper: { flex: 1 },
-  cardTitle: { fontSize: 16, fontWeight: 'bold', color: theme.colors.text.main, marginBottom: 4 },
-  cardDesc: { fontSize: 12, color: theme.colors.text.muted },
-  arrow: { fontSize: 24, color: adm.arrow },
 });

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, Text, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
+import { StyleSheet, View, Text, FlatList, TextInput, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton } from '../components/ui';
+import { AppBackButton, AppButton, AppListColorDot, AppListItem } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -152,16 +152,18 @@ export const CategoryManagementScreen = ({
           keyExtractor={(item) => item.id.toString()}
           contentContainerStyle={styles.list}
           renderItem={({ item }) => (
-            <View style={styles.itemRow}>
-              <View style={[styles.colorBadge, { backgroundColor: item.color }]} />
-              <Text style={styles.categoryName}>{item.name}</Text>
-              <AppButton
-                title={BUTTON_LABELS.delete}
-                onPress={() => deleteCategory(item.id)}
-                variant="dangerFilled"
-                size="sm"
-              />
-            </View>
+            <AppListItem
+              title={item.name}
+              left={<AppListColorDot color={item.color} />}
+              right={
+                <AppButton
+                  title={BUTTON_LABELS.delete}
+                  onPress={() => deleteCategory(item.id)}
+                  variant="dangerFilled"
+                  size="sm"
+                />
+              }
+            />
           )}
         />
       )}
@@ -176,8 +178,5 @@ const styles = StyleSheet.create({
   inputSection: { flexDirection: 'row', marginBottom: 15, gap: 10, alignItems: 'center' },
   input: { flex: 1, backgroundColor: theme.colors.surface, borderRadius: 10, padding: 14, borderWidth: 1, borderColor: theme.colors.border, color: theme.colors.text.main },
   list: { paddingBottom: 40 },
-  itemRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: theme.colors.surface, padding: 16, borderRadius: 12, marginBottom: 12, borderWidth: 1, borderColor: theme.colors.border },
-  colorBadge: { width: 14, height: 14, borderRadius: 7, marginRight: 15 },
-  categoryName: { flex: 1, ...theme.typography.body, fontWeight: '600' },
-  emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted }
+  emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted },
 });

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton } from '../components/ui';
+import { AppBackButton, AppButton, AppListItem } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -143,23 +143,27 @@ export const ProductMasterScreen = ({
   };
 
   const renderItem = ({ item }: { item: ProductMaster }) => (
-    <View style={styles.card}>
-      <View style={styles.cardInfo}>
-        <Text style={styles.itemName}>{item.name}</Text>
-        <Text style={styles.storeName}>店舗: {item.storeName || '共通'}</Text>
-        <View style={[styles.badge, { backgroundColor: item.category?.color || theme.colors.semantic.placeholder.badge }]}>
-          <Text style={styles.badgeText}>{item.category?.name || '未分類'}</Text>
-        </View>
-      </View>
-      <View style={styles.actions}>
+    <AppListItem
+      title={item.name}
+      subtitle={`店舗: ${item.storeName || '共通'}`}
+      right={
         <AppButton
           title={BUTTON_LABELS.delete}
           onPress={() => handleDelete(item.id)}
           variant="dangerFilled"
           size="sm"
         />
+      }
+    >
+      <View
+        style={[
+          styles.badge,
+          { backgroundColor: item.category?.color || theme.colors.semantic.placeholder.badge },
+        ]}
+      >
+        <Text style={styles.badgeText}>{item.category?.name || '未分類'}</Text>
       </View>
-    </View>
+    </AppListItem>
   );
 
   return (
@@ -233,32 +237,8 @@ const styles = StyleSheet.create({
     borderColor: theme.colors.border,
     color: theme.colors.text.main 
   },
-  listContent: { paddingBottom: 40 },
-  card: { 
-    backgroundColor: theme.colors.surface, 
-    marginHorizontal: 15, 
-    marginTop: 10, 
-    padding: 15, 
-    borderRadius: 10, 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    borderWidth: 1, 
-    borderColor: theme.colors.border,
-    ...Platform.select({
-      ios: {
-        shadowColor: theme.shadows.sm.shadowColor,
-        shadowOffset: theme.shadows.sm.shadowOffset,
-        shadowOpacity: theme.shadows.sm.shadowOpacity,
-        shadowRadius: theme.shadows.sm.shadowRadius,
-      },
-      android: { elevation: theme.shadows.sm.elevation },
-    }),
-  },
-  cardInfo: { flex: 1 },
-  itemName: { fontWeight: 'bold', fontSize: 16, color: theme.colors.text.main },
-  storeName: { color: theme.colors.text.muted, fontSize: 13, marginVertical: 4 },
-  badge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 3, borderRadius: 12 },
+  listContent: { paddingHorizontal: 15, paddingBottom: 40 },
+  badge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 3, borderRadius: 12, marginTop: 4 },
   badgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: 'bold' },
-  actions: { justifyContent: 'center', paddingLeft: 10 },
   empty: { textAlign: 'center', marginTop: 40, color: theme.colors.text.muted }
 });

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -15,7 +15,7 @@ import {
 import { Picker } from '@react-native-picker/picker';
 import { AppBackButton, AppButton } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme, BREAKPOINTS } from '../theme';
+import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 
 interface SettlementSummaryScreenProps {
@@ -217,14 +217,14 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
           {/* 清算ステータス詳細（スプレッドシート風一覧テーブル） */}
           <View style={styles.tableContainer}>
             <Text style={styles.tableTitle}>📋 世帯内精算内訳（一覧）</Text>
-            <View style={styles.tableWrapper}>
-              <View style={[styles.tableRow, styles.tableHeader]}>
-                <Text style={[styles.cell, styles.cellName, styles.headerText]}>メンバー名</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>立替金額(A)</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>負担金額(B)</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>差額(A-B)</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>送金/受取相殺</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>最終残額</Text>
+            <View style={tableStyles.wrapper}>
+              <View style={[tableStyles.row, tableStyles.headerRow]}>
+                <Text style={[tableStyles.cell, styles.cellName, tableStyles.headerText]}>メンバー名</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>立替金額(A)</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>負担金額(B)</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>差額(A-B)</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>送金/受取相殺</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>最終残額</Text>
               </View>
 
               {summaryData.map(m => {
@@ -232,17 +232,17 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
                 const offsetAmount = (m.transferredOut || 0) - (m.transferredIn || 0);
                 
                 return (
-                  <View key={m.memberId} style={styles.tableRow}>
-                    <Text style={[styles.cell, styles.cellName, styles.bodyText, styles.boldText]}>{m.name}</Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalPaid?.toLocaleString()}</Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>¥{m.totalOwed?.toLocaleString()}</Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText]}>
+                  <View key={m.memberId} style={tableStyles.row}>
+                    <Text style={[tableStyles.cell, styles.cellName, tableStyles.bodyText, tableStyles.boldText]}>{m.name}</Text>
+                    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.bodyText]}>¥{m.totalPaid?.toLocaleString()}</Text>
+                    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.bodyText]}>¥{m.totalOwed?.toLocaleString()}</Text>
+                    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.bodyText]}>
                       {m.baseBalance >= 0 ? "+" : ""}{m.baseBalance?.toLocaleString()}
                     </Text>
-                    <Text style={[styles.cell, styles.cellAmount, styles.bodyText, { color: theme.colors.text.muted }]}>
+                    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.bodyText, { color: theme.colors.text.muted }]}>
                       {offsetAmount >= 0 ? "+" : ""}{offsetAmount.toLocaleString()}
                     </Text>
-                    <Text style={[styles.cell, styles.cellAmount, balanceStyle, styles.boldText]}>
+                    <Text style={[tableStyles.cell, styles.cellAmount, balanceStyle, tableStyles.boldText]}>
                       {m.balance > 0 ? "+" : ""}{m.balance?.toLocaleString()}
                     </Text>
                   </View>
@@ -369,13 +369,6 @@ const styles = StyleSheet.create({
   
   tableContainer: { backgroundColor: theme.colors.surface, padding: 20, borderRadius: 12, borderWidth: 1, borderColor: theme.colors.border },
   tableTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, color: theme.colors.text.main },
-  tableWrapper: { borderWidth: 1, borderColor: sem.table.rowBorder, borderRadius: 8, overflow: 'hidden' },
-  tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: sem.table.rowBorder, alignItems: 'center', height: 48 },
-  tableHeader: { backgroundColor: sem.table.headerBg },
-  cell: { paddingHorizontal: 12, justifyContent: 'center' },
-  headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
-  bodyText: { fontSize: 14, color: theme.colors.text.main },
-  boldText: { fontWeight: 'bold' },
   cellName: { flex: 1.5, minWidth: 100 },
   cellAmount: { flex: 1, textAlign: 'right' },
 

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -15,7 +15,7 @@ import {
 import { Picker } from '@react-native-picker/picker';
 import { AppBackButton, AppButton } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme, BREAKPOINTS } from '../theme';
+import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 
 interface SplitEditorScreenProps {
@@ -385,25 +385,25 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
 
           <ScrollView style={styles.tableScroll} horizontal={false}>
             <ScrollView horizontal={true} contentContainerStyle={{ flexDirection: 'column' }}>
-              
-              <View style={[styles.tableRow, styles.tableHeader]}>
-                <Text style={[styles.cell, styles.cellName, styles.headerText]}>商品名</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.headerText]}>合計</Text>
+              <View style={tableStyles.wrapper}>
+              <View style={[tableStyles.row, tableStyles.headerRow, styles.tableRowWide]}>
+                <Text style={[tableStyles.cell, styles.cellName, tableStyles.headerText]}>商品名</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>合計</Text>
                 {activeMembers.map(m => (
-                  <Text key={m.id} style={[styles.cell, styles.cellInputCol, styles.headerText, { textAlign: 'center' }]}>
+                  <Text key={m.id} style={[tableStyles.cell, styles.cellInputCol, tableStyles.headerText, { textAlign: 'center' }]}>
                     {m.name}
                   </Text>
                 ))}
-                <Text style={[styles.cell, styles.cellAction, styles.headerText]}>操作</Text>
+                <Text style={[tableStyles.cell, styles.cellAction, tableStyles.headerText]}>操作</Text>
               </View>
 
               {receipt.items.map((item: any) => {
                 const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
 
                 return (
-                  <View key={item.id} style={styles.tableRow}>
-                    <Text style={[styles.cell, styles.cellName]} numberOfLines={2}>{item.name}</Text>
-                    <Text style={[styles.cell, styles.cellAmount]}>¥{itemTotal.toLocaleString()}</Text>
+                  <View key={item.id} style={[tableStyles.row, styles.tableRowWide]}>
+                    <Text style={[tableStyles.cell, styles.cellName, tableStyles.bodyText]} numberOfLines={2}>{item.name}</Text>
+                    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.bodyText, tableStyles.boldText]}>¥{itemTotal.toLocaleString()}</Text>
                     
                     {activeMembers.map((m, idx) => {
                       const amountValue = editSplits[item.id]?.[m.id] || 0;
@@ -411,7 +411,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                       const isFirst = idx === 0;
 
                       return (
-                        <View key={m.id} style={[styles.cell, styles.cellInputCol]}>
+                        <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
                           <View style={styles.dualInputWrapper}>
                             <View style={styles.inputGroup}>
                               <TextInput
@@ -441,7 +441,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                       );
                     })}
 
-                    <View style={[styles.cell, styles.cellAction]}>
+                    <View style={[tableStyles.cell, styles.cellAction]}>
                       <AppButton
                         title={BUTTON_LABELS.splitEqual}
                         onPress={() => splitItemEqually(item.id, itemTotal)}
@@ -454,9 +454,9 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
               })}
 
               {/* ★ 追加: 合計行 (Total) */}
-              <View style={[styles.tableRow, styles.totalRow]}>
-                <Text style={[styles.cell, styles.cellName, styles.totalText]}>一括調整（全体合計）</Text>
-                <Text style={[styles.cell, styles.cellAmount, styles.totalText]}>¥{receiptTotalAmount.toLocaleString()}</Text>
+              <View style={[tableStyles.row, styles.tableRowWide, styles.totalRow]}>
+                <Text style={[tableStyles.cell, styles.cellName, styles.totalText]}>一括調整（全体合計）</Text>
+                <Text style={[tableStyles.cell, styles.cellAmount, styles.totalText]}>¥{receiptTotalAmount.toLocaleString()}</Text>
                 
                 {activeMembers.map((m, idx) => {
                   const memberTotal = getMemberTotalAmount(m.id);
@@ -464,7 +464,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                   const isFirst = idx === 0;
 
                   return (
-                    <View key={m.id} style={[styles.cell, styles.cellInputCol]}>
+                    <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
                       <View style={styles.dualInputWrapper}>
                         <View style={[styles.inputGroup, styles.totalInputGroup]}>
                           <TextInput
@@ -494,7 +494,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                   );
                 })}
 
-                <View style={[styles.cell, styles.cellAction]}>
+                <View style={[tableStyles.cell, styles.cellAction]}>
                   <AppButton
                     title={BUTTON_LABELS.splitEqual}
                     onPress={splitWholeReceiptEqually}
@@ -504,6 +504,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                 </View>
               </View>
 
+              </View>
             </ScrollView>
           </ScrollView>
         </View>
@@ -547,19 +548,14 @@ const styles = StyleSheet.create({
   storeName: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
   
   tableScroll: { flex: 1 },
-  tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: sem.table.rowBorder, alignItems: 'center', minWidth: 800 },
-  tableHeader: { backgroundColor: sem.table.headerBg, borderBottomColor: theme.colors.border },
-  
+  tableRowWide: { minWidth: 800 },
   totalRow: { backgroundColor: sem.warning.bg, borderTopWidth: 2, borderTopColor: sem.warning.border },
   totalText: { fontWeight: 'bold', color: sem.warning.text },
   totalInputGroup: { borderColor: sem.warning.border, backgroundColor: sem.warning.inputBg },
   totalInputBox: { fontWeight: 'bold', color: sem.warning.text },
   totalUnitText: { color: sem.warning.text, fontWeight: 'bold' },
-
-  cell: { padding: 12, justifyContent: 'center' },
-  headerText: { fontWeight: 'bold', color: theme.colors.text.muted, fontSize: 13 },
-  cellName: { width: 160, fontSize: 14, color: theme.colors.text.main },
-  cellAmount: { width: 90, fontSize: 14, fontWeight: 'bold', textAlign: 'right', color: theme.colors.text.main },
+  cellName: { width: 160 },
+  cellAmount: { width: 90, textAlign: 'right' },
   cellInputCol: { width: 180, alignItems: 'center' },
   
   dualInputWrapper: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%' },

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,2 +1,2 @@
 /** @deprecated Import from `./theme/index` — kept for backward-compatible paths */
-export { theme, BREAKPOINTS, type Theme } from './theme/index';
+export { theme, BREAKPOINTS, tableStyles, listItemStyles, type Theme } from './theme/index';

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -5,6 +5,7 @@ import { borderRadius } from './radii';
 import { shadows } from './shadows';
 import { spacing } from './spacing';
 import { typography } from './typography';
+import { tableStyles, listItemStyles } from './tableStyles';
 
 export { BREAKPOINTS } from './breakpoints';
 export { colors } from './colors';
@@ -13,6 +14,7 @@ export { borderRadius } from './radii';
 export { shadows } from './shadows';
 export { spacing } from './spacing';
 export { typography } from './typography';
+export { tableStyles, listItemStyles } from './tableStyles';
 
 export const theme = {
   colors,
@@ -22,6 +24,8 @@ export const theme = {
   shadows,
   layout,
   breakpoints: BREAKPOINTS,
+  tableStyles,
+  listItemStyles,
 } as const;
 
 export type Theme = typeof theme;

--- a/frontend/src/theme/tableStyles.ts
+++ b/frontend/src/theme/tableStyles.ts
@@ -1,0 +1,79 @@
+import { StyleSheet } from 'react-native';
+import { colors } from './colors';
+import { spacing } from './spacing';
+import { typography } from './typography';
+
+/** Issue #84: データテーブル共通スタイル（精算・割勘エディタ等） */
+export const tableStyles = StyleSheet.create({
+  wrapper: {
+    borderWidth: 1,
+    borderColor: colors.semantic.table.rowBorder,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: colors.semantic.table.rowBorder,
+    alignItems: 'center',
+    minHeight: 48,
+  },
+  headerRow: {
+    backgroundColor: colors.semantic.table.headerBg,
+    borderBottomColor: colors.border,
+  },
+  cell: {
+    paddingHorizontal: spacing.md,
+    justifyContent: 'center',
+  },
+  headerText: {
+    fontWeight: 'bold',
+    color: colors.text.muted,
+    fontSize: 13,
+  },
+  bodyText: {
+    fontSize: 14,
+    color: colors.text.main,
+  },
+  boldText: {
+    fontWeight: 'bold',
+  },
+});
+
+export const listItemStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    padding: spacing.md,
+    borderRadius: 12,
+    marginBottom: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  main: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  title: {
+    ...typography.body,
+    fontWeight: '600',
+    color: colors.text.main,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginTop: 4,
+  },
+  colorDot: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    marginRight: spacing.md,
+  },
+  chevron: {
+    fontSize: 24,
+    color: colors.semantic.admin.arrow,
+    marginLeft: spacing.sm,
+  },
+});


### PR DESCRIPTION
## Summary
- `AppListItem` / `AppListColorDot` と `tableStyles` を追加し、theme から export
- カテゴリー・学習マスタ・管理者メニューを `AppListItem` に統一
- 家族間精算サマリー・割り勘エディタのテーブルを `tableStyles` に統一

## Test plan
- [x] `cd frontend && npx tsc --noEmit`
- [x] 手動: AdminMenu / Category / ProductMaster / SettlementSummary / SplitEditor（見た目・遷移・削除/按分）

Closes #244

Made with [Cursor](https://cursor.com)