### PR TITLE
feat(ui): [Issue #85] フォーム要素とモーダルダイアログの共通化

### DIFF
--- a/frontend/src/components/ui/AppFormField.tsx
+++ b/frontend/src/components/ui/AppFormField.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleProp, Text, View, ViewStyle } from 'react-native';
+import { formStyles } from '../../theme/formStyles';
+
+export interface AppFormFieldProps {
+  label?: string;
+  /** 表示すると入力にエラー枠を連動（子が AppTextInput のとき error prop も渡す） */
+  error?: string;
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const AppFormField: React.FC<AppFormFieldProps> = ({
+  label,
+  error,
+  children,
+  style,
+}) => (
+  <View style={[formStyles.field, style]}>
+    {label ? <Text style={formStyles.label}>{label}</Text> : null}
+    {children}
+    {error ? <Text style={formStyles.errorText}>{error}</Text> : null}
+  </View>
+);

--- a/frontend/src/components/ui/AppModal.tsx
+++ b/frontend/src/components/ui/AppModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Modal, Text, View } from 'react-native';
+import { modalStyles } from '../../theme/modalStyles';
+
+export interface AppModalProps {
+  visible: boolean;
+  onRequestClose: () => void;
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+/** 中央ダイアログ型モーダル（送金記録等） */
+export const AppModal: React.FC<AppModalProps> = ({
+  visible,
+  onRequestClose,
+  title,
+  description,
+  children,
+  footer,
+}) => (
+  <Modal
+    visible={visible}
+    transparent
+    animationType="fade"
+    onRequestClose={onRequestClose}
+  >
+    <View style={modalStyles.overlay}>
+      <View style={modalStyles.dialog}>
+        <Text style={modalStyles.title}>{title}</Text>
+        {description ? (
+          <Text style={modalStyles.description}>{description}</Text>
+        ) : null}
+        {children}
+        {footer ? <View style={modalStyles.footer}>{footer}</View> : null}
+      </View>
+    </View>
+  </Modal>
+);

--- a/frontend/src/components/ui/AppSelect.tsx
+++ b/frontend/src/components/ui/AppSelect.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Platform, StyleProp, View, ViewStyle } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { modalStyles } from '../../theme/modalStyles';
+import { colors } from '../../theme/colors';
+
+export interface AppSelectOption<T extends string | number | null = string | number | null> {
+  label: string;
+  value: T;
+}
+
+export interface AppSelectProps<T extends string | number | null = string | number | null> {
+  selectedValue: T;
+  onValueChange: (value: T) => void;
+  options: AppSelectOption<T>[];
+  placeholder?: string;
+  placeholderValue?: T;
+  error?: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function AppSelect<T extends string | number | null = string | number | null>({
+  selectedValue,
+  onValueChange,
+  options,
+  placeholder = '選択してください',
+  placeholderValue = null as T,
+  error,
+  style,
+}: AppSelectProps<T>) {
+  return (
+    <View
+      style={[
+        modalStyles.selectWrapper,
+        error && modalStyles.selectWrapperError,
+        style,
+      ]}
+    >
+      <Picker
+        selectedValue={selectedValue}
+        onValueChange={(value) => onValueChange(value as T)}
+        style={modalStyles.selectPicker}
+        {...Platform.select({ ios: { mode: 'dropdown' as const }, default: {} })}
+      >
+        <Picker.Item
+          label={placeholder}
+          value={placeholderValue as unknown as number}
+          color={colors.text.muted}
+        />
+        {options.map((opt) => (
+          <Picker.Item
+            key={String(opt.value)}
+            label={opt.label}
+            value={opt.value as unknown as number}
+          />
+        ))}
+      </Picker>
+    </View>
+  );
+}

--- a/frontend/src/components/ui/AppSelect.tsx
+++ b/frontend/src/components/ui/AppSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, StyleProp, View, ViewStyle } from 'react-native';
+import { Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { modalStyles } from '../../theme/modalStyles';
 import { colors } from '../../theme/colors';
@@ -15,6 +15,8 @@ export interface AppSelectProps<T extends string | number | null = string | numb
   options: AppSelectOption<T>[];
   placeholder?: string;
   placeholderValue?: T;
+  /** false のとき先頭の未選択肢を出さない（月選択など） */
+  includePlaceholder?: boolean;
   error?: boolean;
   style?: StyleProp<ViewStyle>;
 }
@@ -25,28 +27,65 @@ export function AppSelect<T extends string | number | null = string | number | n
   options,
   placeholder = '選択してください',
   placeholderValue = null as T,
+  includePlaceholder = true,
   error,
   style,
 }: AppSelectProps<T>) {
+  const wrapperStyle = [
+    modalStyles.selectWrapper,
+    error && modalStyles.selectWrapperError,
+    style,
+  ];
+
+  if (Platform.OS === 'web') {
+    const webValue =
+      selectedValue === null || selectedValue === undefined
+        ? ''
+        : String(selectedValue);
+
+    return (
+      <View style={wrapperStyle}>
+        <select
+          value={webValue}
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (includePlaceholder && raw === String(placeholderValue ?? '')) {
+              onValueChange(placeholderValue as T);
+              return;
+            }
+            const matched = options.find((o) => String(o.value) === raw);
+            onValueChange((matched?.value ?? raw) as T);
+          }}
+          style={StyleSheet.flatten(modalStyles.webSelect) as React.CSSProperties}
+        >
+          {includePlaceholder ? (
+            <option value={String(placeholderValue ?? '')}>{placeholder}</option>
+          ) : null}
+          {options.map((opt) => (
+            <option key={String(opt.value)} value={String(opt.value)}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </View>
+    );
+  }
+
   return (
-    <View
-      style={[
-        modalStyles.selectWrapper,
-        error && modalStyles.selectWrapperError,
-        style,
-      ]}
-    >
+    <View style={wrapperStyle}>
       <Picker
         selectedValue={selectedValue}
         onValueChange={(value) => onValueChange(value as T)}
         style={modalStyles.selectPicker}
         {...Platform.select({ ios: { mode: 'dropdown' as const }, default: {} })}
       >
-        <Picker.Item
-          label={placeholder}
-          value={placeholderValue as unknown as number}
-          color={colors.text.muted}
-        />
+        {includePlaceholder ? (
+          <Picker.Item
+            label={placeholder}
+            value={placeholderValue as unknown as number}
+            color={colors.text.muted}
+          />
+        ) : null}
         {options.map((opt) => (
           <Picker.Item
             key={String(opt.value)}

--- a/frontend/src/components/ui/AppTextInput.tsx
+++ b/frontend/src/components/ui/AppTextInput.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import {
+  StyleProp,
+  TextInput,
+  TextInputProps,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
+import { formStyles } from '../../theme/formStyles';
+import { colors } from '../../theme/colors';
+
+export type AppTextInputVariant = 'default' | 'textarea' | 'textareaFill';
+
+export interface AppTextInputProps
+  extends Pick<
+    TextInputProps,
+    | 'value'
+    | 'onChangeText'
+    | 'placeholder'
+    | 'keyboardType'
+    | 'multiline'
+    | 'numberOfLines'
+    | 'textAlignVertical'
+    | 'autoCapitalize'
+    | 'autoCorrect'
+    | 'editable'
+    | 'selectTextOnFocus'
+    | 'secureTextEntry'
+    | 'placeholderTextColor'
+    | 'onFocus'
+    | 'onBlur'
+  > {
+  /** true またはメッセージ文字列でエラー枠を表示（メッセージは AppFormField 側を推奨） */
+  error?: boolean | string;
+  variant?: AppTextInputVariant;
+  style?: StyleProp<ViewStyle>;
+  inputStyle?: StyleProp<TextStyle>;
+}
+
+export const AppTextInput: React.FC<AppTextInputProps> = ({
+  error,
+  variant = 'default',
+  style,
+  inputStyle,
+  placeholderTextColor = colors.text.muted,
+  multiline,
+  numberOfLines,
+  textAlignVertical,
+  onFocus,
+  onBlur,
+  ...rest
+}) => {
+  const [focused, setFocused] = useState(false);
+  const hasError = Boolean(error);
+
+  const isTextarea = variant === 'textarea' || variant === 'textareaFill';
+  const resolvedMultiline = multiline ?? isTextarea;
+  const resolvedNumberOfLines = numberOfLines ?? (isTextarea ? 4 : undefined);
+  const resolvedTextAlignVertical =
+    textAlignVertical ?? (isTextarea ? 'top' : undefined);
+
+  return (
+    <TextInput
+      {...rest}
+      multiline={resolvedMultiline}
+      numberOfLines={resolvedNumberOfLines}
+      textAlignVertical={resolvedTextAlignVertical}
+      placeholderTextColor={placeholderTextColor}
+      onFocus={(e) => {
+        setFocused(true);
+        onFocus?.(e);
+      }}
+      onBlur={(e) => {
+        setFocused(false);
+        onBlur?.(e);
+      }}
+      style={[
+        formStyles.input,
+        variant === 'textarea' && formStyles.textArea,
+        variant === 'textareaFill' && formStyles.textAreaFill,
+        focused && !hasError && formStyles.inputFocused,
+        hasError && formStyles.inputError,
+        style,
+        inputStyle,
+      ]}
+    />
+  );
+};

--- a/frontend/src/components/ui/AppTextInput.tsx
+++ b/frontend/src/components/ui/AppTextInput.tsx
@@ -9,7 +9,7 @@ import {
 import { formStyles } from '../../theme/formStyles';
 import { colors } from '../../theme/colors';
 
-export type AppTextInputVariant = 'default' | 'textarea' | 'textareaFill';
+export type AppTextInputVariant = 'default' | 'textarea' | 'textareaFill' | 'inline';
 
 export interface AppTextInputProps
   extends Pick<
@@ -53,6 +53,7 @@ export const AppTextInput: React.FC<AppTextInputProps> = ({
   const [focused, setFocused] = useState(false);
   const hasError = Boolean(error);
 
+  const isInline = variant === 'inline';
   const isTextarea = variant === 'textarea' || variant === 'textareaFill';
   const resolvedMultiline = multiline ?? isTextarea;
   const resolvedNumberOfLines = numberOfLines ?? (isTextarea ? 4 : undefined);
@@ -75,11 +76,11 @@ export const AppTextInput: React.FC<AppTextInputProps> = ({
         onBlur?.(e);
       }}
       style={[
-        formStyles.input,
+        isInline ? formStyles.inputInline : formStyles.input,
         variant === 'textarea' && formStyles.textArea,
         variant === 'textareaFill' && formStyles.textAreaFill,
-        focused && !hasError && formStyles.inputFocused,
-        hasError && formStyles.inputError,
+        !isInline && focused && !hasError && formStyles.inputFocused,
+        !isInline && hasError && formStyles.inputError,
         style,
         inputStyle,
       ]}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -8,3 +8,10 @@ export {
   type AppListItemVariant,
 } from './AppListItem';
 export { tableStyles, listItemStyles } from '../../theme/tableStyles';
+export { formStyles } from '../../theme/formStyles';
+export {
+  AppTextInput,
+  type AppTextInputProps,
+  type AppTextInputVariant,
+} from './AppTextInput';
+export { AppFormField, type AppFormFieldProps } from './AppFormField';

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,3 +15,10 @@ export {
   type AppTextInputVariant,
 } from './AppTextInput';
 export { AppFormField, type AppFormFieldProps } from './AppFormField';
+export { AppModal, type AppModalProps } from './AppModal';
+export {
+  AppSelect,
+  type AppSelectProps,
+  type AppSelectOption,
+} from './AppSelect';
+export { modalStyles } from '../../theme/modalStyles';

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, Text, FlatList, TextInput, Alert, ActivityIndicator, Platform } from 'react-native';
+import { StyleSheet, View, Text, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton, AppListColorDot, AppListItem } from '../components/ui';
+import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -122,12 +122,11 @@ export const CategoryManagementScreen = ({
       </View>
 
       <View style={styles.inputSection}>
-        <TextInput 
-          style={styles.input} 
-          value={newName} 
-          onChangeText={setNewName} 
+        <AppTextInput
+          style={styles.nameInput}
+          value={newName}
+          onChangeText={setNewName}
           placeholder="新しいカテゴリー"
-          placeholderTextColor={theme.colors.text.muted}
         />
         <AppButton title={BUTTON_LABELS.add} onPress={addCategory} size="md" />
       </View>
@@ -176,7 +175,7 @@ const styles = StyleSheet.create({
   header: { flexDirection: 'row', alignItems: 'center', marginBottom: 30 },
   title: { ...theme.typography.h1, marginLeft: 8, flex: 1 },
   inputSection: { flexDirection: 'row', marginBottom: 15, gap: 10, alignItems: 'center' },
-  input: { flex: 1, backgroundColor: theme.colors.surface, borderRadius: 10, padding: 14, borderWidth: 1, borderColor: theme.colors.border, color: theme.colors.text.main },
+  nameInput: { flex: 1 },
   list: { paddingBottom: 40 },
   emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted },
 });

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton, AppListItem } from '../components/ui';
+import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -177,21 +177,17 @@ export const ProductMasterScreen = ({
       </View>
 
       <View style={styles.searchBar}>
-        <TextInput 
-          placeholder="品名検索..." 
-          style={styles.input} 
-          value={searchQuery} 
-          onChangeText={setSearchQuery} 
-          clearButtonMode="while-editing"
-          placeholderTextColor={theme.colors.text.muted}
+        <AppTextInput
+          placeholder="品名検索..."
+          style={styles.searchInput}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
         />
-        <TextInput 
-          placeholder="店舗名..." 
-          style={styles.input} 
-          value={storeFilter} 
-          onChangeText={setStoreFilter} 
-          clearButtonMode="while-editing"
-          placeholderTextColor={theme.colors.text.muted}
+        <AppTextInput
+          placeholder="店舗名..."
+          style={styles.searchInput}
+          value={storeFilter}
+          onChangeText={setStoreFilter}
         />
       </View>
 
@@ -226,17 +222,8 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1, textAlign: 'center' },
   mergeText: { color: theme.colors.secondary, fontWeight: 'bold' },
-  searchBar: { padding: 10, flexDirection: 'row', backgroundColor: theme.colors.surface },
-  input: { 
-    flex: 1, 
-    backgroundColor: theme.colors.surface, 
-    marginHorizontal: 5, 
-    padding: 12, 
-    borderRadius: 8, 
-    borderWidth: 1, 
-    borderColor: theme.colors.border,
-    color: theme.colors.text.main 
-  },
+  searchBar: { padding: 10, flexDirection: 'row', gap: 10, backgroundColor: theme.colors.surface },
+  searchInput: { flex: 1 },
   listContent: { paddingHorizontal: 15, paddingBottom: 40 },
   badge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 3, borderRadius: 12, marginTop: 4 },
   badgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: 'bold' },

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -3,8 +3,6 @@ import {
   StyleSheet,
   View,
   Text,
-  TextInput,
-  TouchableOpacity,
   ScrollView,
   ActivityIndicator,
   Alert,
@@ -12,7 +10,7 @@ import {
 } from 'react-native';
 
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton } from '../components/ui';
+import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -221,29 +219,35 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
               />
             </View>
 
-            <View style={styles.section}>
-              <Text style={styles.label}>識別名 (管理用)</Text>
-              <TextInput style={styles.input} value={formName} onChangeText={setFormName} placeholder="例: テスト用(外税修正版)" />
-            </View>
-
-            <View style={styles.section}>
-              <Text style={styles.label}>System Prompt</Text>
-              <TextInput
-                style={[styles.input, styles.textArea]}
-                multiline numberOfLines={10} textAlignVertical="top"
-                value={formSystemPrompt} onChangeText={setFormSystemPrompt}
+            <AppFormField label="識別名 (管理用)">
+              <AppTextInput
+                value={formName}
+                onChangeText={setFormName}
+                placeholder="例: テスト用(外税修正版)"
               />
-            </View>
+            </AppFormField>
 
-            <View style={styles.section}>
-              <Text style={styles.label}>Domain Hints (JSON形式)</Text>
-              <TextInput
-                style={[styles.input, styles.jsonArea]}
-                multiline numberOfLines={8} textAlignVertical="top" autoCapitalize="none" autoCorrect={false}
-                value={formDomainHints} onChangeText={setFormDomainHints}
+            <AppFormField label="System Prompt">
+              <AppTextInput
+                variant="textarea"
+                style={styles.promptTextArea}
+                value={formSystemPrompt}
+                onChangeText={setFormSystemPrompt}
+              />
+            </AppFormField>
+
+            <AppFormField label="Domain Hints (JSON形式)">
+              <AppTextInput
+                variant="textarea"
+                style={styles.jsonTextArea}
+                inputStyle={styles.jsonInputFont}
+                value={formDomainHints}
+                onChangeText={setFormDomainHints}
+                autoCapitalize="none"
+                autoCorrect={false}
                 placeholder={`{\n  "gas_station": "ヒント..."\n}`}
               />
-            </View>
+            </AppFormField>
 
             <AppButton
               title={BUTTON_LABELS.save}
@@ -344,9 +348,7 @@ const styles = StyleSheet.create({
   formContainer: { backgroundColor: adm.surface, padding: 16, borderRadius: 8, borderWidth: 1, borderColor: adm.border },
   formHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 },
   formTitle: { fontSize: 18, fontWeight: 'bold', flex: 1 },
-  section: { marginBottom: 16 },
-  label: { fontSize: 14, fontWeight: 'bold', color: adm.textLabel, marginBottom: 6 },
-  input: { backgroundColor: adm.inputBg, borderWidth: 1, borderColor: adm.inputBorder, borderRadius: 6, padding: 12, fontSize: 14 },
-  textArea: { height: 200, fontFamily: 'System' },
-  jsonArea: { height: 150, fontFamily: 'Courier' },
+  promptTextArea: { minHeight: 200 },
+  jsonTextArea: { minHeight: 150 },
+  jsonInputFont: { fontFamily: 'Courier' },
 });

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -6,11 +6,9 @@ import {
   ScrollView, 
   TouchableOpacity, 
   ActivityIndicator, 
-  Platform,
   useWindowDimensions,
   Alert
 } from 'react-native';
-import { Picker } from '@react-native-picker/picker';
 import {
   AppBackButton,
   AppButton,
@@ -42,6 +40,11 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   const [transferTo, setTransferTo] = useState<number | null>(null);
   const [transferAmount, setTransferAmount] = useState<string>('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [transferFieldErrors, setTransferFieldErrors] = useState<{
+    from?: string;
+    to?: string;
+    amount?: string;
+  }>({});
 
   // 過去6ヶ月の選択肢を生成
   const months = useMemo(() => {
@@ -60,6 +63,42 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       })),
     [summaryData]
   );
+
+  const monthSelectOptions = useMemo(
+    () =>
+      months.map((m) => ({
+        label: `${m.split('-')[0]}年${m.split('-')[1]}月`,
+        value: m,
+      })),
+    [months]
+  );
+
+  const openTransferModal = () => {
+    setTransferFieldErrors({});
+    setTransferModalVisible(true);
+  };
+
+  const validateTransferForm = (): boolean => {
+    const errors: { from?: string; to?: string; amount?: string } = {};
+    if (!transferFrom) {
+      errors.from = '送金元を選択してください';
+    }
+    if (!transferTo) {
+      errors.to = '送金先を選択してください';
+    }
+    if (!transferAmount.trim()) {
+      errors.amount = '金額を入力してください';
+    } else if (transferFrom && transferTo && transferFrom === transferTo) {
+      errors.to = '送金先は送金元と異なるメンバーを選んでください';
+    } else {
+      const amountNum = parseInt(transferAmount.replace(/[^0-9]/g, ''), 10);
+      if (isNaN(amountNum) || amountNum <= 0) {
+        errors.amount = '正しい金額を入力してください';
+      }
+    }
+    setTransferFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
 
   const loadSettlementData = async () => {
     try {
@@ -80,27 +119,18 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   }, [selectedMonth]);
 
   const handleTransferSubmit = async () => {
-    if (!transferFrom || !transferTo || !transferAmount) {
-      Alert.alert('入力エラー', '送金元、送金先、金額をすべて入力してください。');
+    if (!validateTransferForm()) {
       return;
     }
-    if (transferFrom === transferTo) {
-      Alert.alert('入力エラー', '送金元と送金先は異なるメンバーを選択してください。');
-      return;
-    }
-    
+
     const amountNum = parseInt(transferAmount.replace(/[^0-9]/g, ''), 10);
-    if (isNaN(amountNum) || amountNum <= 0) {
-      Alert.alert('入力エラー', '正しい金額を入力してください。');
-      return;
-    }
 
     setIsSubmitting(true);
     try {
       const res = await api.addSettlementTransfer({
         month: selectedMonth,
-        fromMemberId: transferFrom,
-        toMemberId: transferTo,
+        fromMemberId: transferFrom!,
+        toMemberId: transferTo!,
         amount: amountNum
       });
       if (res.success) {
@@ -109,6 +139,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
         setTransferFrom(null);
         setTransferTo(null);
         setTransferAmount('');
+        setTransferFieldErrors({});
         loadSettlementData(); // 再読み込みして残額を更新
       }
     } catch (err) {
@@ -117,35 +148,6 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
     } finally {
       setIsSubmitting(false);
     }
-  };
-
-  const renderMonthPicker = () => {
-    if (Platform.OS === 'web') {
-      return (
-        <select
-          value={selectedMonth}
-          onChange={(e) => setSelectedMonth(e.target.value)}
-          style={StyleSheet.flatten(styles.webSelect)}
-        >
-          {months.map(m => (
-            <option key={m} value={m}>{`${m.split('-')[0]}年${m.split('-')[1]}月`}</option>
-          ))}
-        </select>
-      );
-    }
-
-    return (
-      <Picker 
-        selectedValue={selectedMonth} 
-        onValueChange={setSelectedMonth} 
-        style={styles.filterPicker}
-        mode="dropdown"
-      >
-        {months.map(m => (
-          <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
-        ))}
-      </Picker>
-    );
   };
 
   return (
@@ -157,12 +159,18 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
         <View style={styles.headerRight}>
           <AppButton
             title={`＋ ${BUTTON_LABELS.recordTransfer}`}
-            onPress={() => setTransferModalVisible(true)}
+            onPress={openTransferModal}
             size="sm"
             style={styles.addTransferButton}
           />
           <View style={styles.monthPickerContainer}>
-            {renderMonthPicker()}
+            <AppSelect<string>
+              selectedValue={selectedMonth}
+              onValueChange={setSelectedMonth}
+              options={monthSelectOptions}
+              includePlaceholder={false}
+              style={styles.monthSelect}
+            />
           </View>
         </View>
       </View>
@@ -293,30 +301,53 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
           </>
         }
       >
-        <AppFormField label="送金元 (払った人)">
+        <AppFormField label="送金元 (払った人)" error={transferFieldErrors.from}>
           <AppSelect<number | null>
             selectedValue={transferFrom}
-            onValueChange={setTransferFrom}
+            onValueChange={(v) => {
+              setTransferFrom(v);
+              if (transferFieldErrors.from) {
+                setTransferFieldErrors((prev) => ({ ...prev, from: undefined }));
+              }
+            }}
             options={memberSelectOptions}
+            error={Boolean(transferFieldErrors.from)}
           />
         </AppFormField>
 
-        <AppFormField label="送金先 (受け取った人)">
+        <AppFormField label="送金先 (受け取った人)" error={transferFieldErrors.to}>
           <AppSelect<number | null>
             selectedValue={transferTo}
-            onValueChange={setTransferTo}
+            onValueChange={(v) => {
+              setTransferTo(v);
+              if (transferFieldErrors.to) {
+                setTransferFieldErrors((prev) => ({ ...prev, to: undefined }));
+              }
+            }}
             options={memberSelectOptions}
+            error={Boolean(transferFieldErrors.to)}
           />
         </AppFormField>
 
-        <AppFormField label="送金額">
-          <View style={modalStyles.inputWithUnit}>
+        <AppFormField label="送金額" error={transferFieldErrors.amount}>
+          <View
+            style={[
+              modalStyles.inputWithUnit,
+              transferFieldErrors.amount && modalStyles.selectWrapperError,
+            ]}
+          >
             <AppTextInput
               variant="inline"
               value={transferAmount}
-              onChangeText={setTransferAmount}
+              onChangeText={(v) => {
+                setTransferAmount(v);
+                if (transferFieldErrors.amount) {
+                  setTransferFieldErrors((prev) => ({ ...prev, amount: undefined }));
+                }
+              }}
               keyboardType="number-pad"
               placeholder="例: 5000"
+              error={Boolean(transferFieldErrors.amount)}
             />
             <Text style={modalStyles.unitSuffix}>円</Text>
           </View>
@@ -336,9 +367,8 @@ const styles = StyleSheet.create({
   headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
   headerRight: { flexDirection: 'row', alignItems: 'center', gap: 15 },
   addTransferButton: { paddingHorizontal: 4 },
-  monthPickerContainer: { width: 140, height: 36, backgroundColor: theme.colors.surface, borderRadius: 6, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
-  filterPicker: { width: '100%' },
-  webSelect: { width: '100%', height: '100%', borderWidth: 0, backgroundColor: 'transparent', paddingLeft: 10, fontSize: 14, color: theme.colors.text.main, ...Platform.select({ web: { outlineStyle: 'none' } as any }) } as any,
+  monthPickerContainer: { width: 140, justifyContent: 'center' },
+  monthSelect: { minHeight: 36 },
   scrollContainer: { flex: 1 },
   scrollContent: { padding: 20, paddingBottom: 40 },
   rowLayout: { flexDirection: 'row' },

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -8,12 +8,18 @@ import {
   ActivityIndicator, 
   Platform,
   useWindowDimensions,
-  Modal,
-  TextInput,
   Alert
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
-import { AppBackButton, AppButton } from '../components/ui';
+import {
+  AppBackButton,
+  AppButton,
+  AppFormField,
+  AppModal,
+  AppSelect,
+  AppTextInput,
+  modalStyles,
+} from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
@@ -45,6 +51,15 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       return d.toISOString().slice(0, 7);
     });
   }, []);
+
+  const memberSelectOptions = useMemo(
+    () =>
+      summaryData.map((m: { memberId: number; name: string }) => ({
+        label: m.name,
+        value: m.memberId,
+      })),
+    [summaryData]
+  );
 
   const loadSettlementData = async () => {
     try {
@@ -254,70 +269,59 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
         </ScrollView>
       )}
 
-      {/* 送金記録モーダル */}
-      <Modal
+      <AppModal
         visible={isTransferModalVisible}
-        transparent={true}
-        animationType="fade"
+        onRequestClose={() => setTransferModalVisible(false)}
+        title="送金・受取の記録"
+        description="実際に現金やPayPay等で精算した金額を記録します。"
+        footer={
+          <>
+            <AppButton
+              title={BUTTON_LABELS.cancel}
+              onPress={() => setTransferModalVisible(false)}
+              variant="secondary"
+              size="md"
+            />
+            <AppButton
+              title={BUTTON_LABELS.save}
+              onPress={handleTransferSubmit}
+              loading={isSubmitting}
+              disabled={isSubmitting}
+              size="md"
+              style={modalStyles.footerPrimaryButton}
+            />
+          </>
+        }
       >
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>送金・受取の記録</Text>
-            <Text style={styles.modalDesc}>実際に現金やPayPay等で精算した金額を記録します。</Text>
+        <AppFormField label="送金元 (払った人)">
+          <AppSelect<number | null>
+            selectedValue={transferFrom}
+            onValueChange={setTransferFrom}
+            options={memberSelectOptions}
+          />
+        </AppFormField>
 
-            <View style={styles.formGroup}>
-              <Text style={styles.formLabel}>送金元 (払った人)</Text>
-              <View style={styles.pickerWrapper}>
-                <Picker selectedValue={transferFrom} onValueChange={setTransferFrom} style={styles.modalPicker}>
-                  <Picker.Item label="選択してください" value={null} color={theme.colors.text.muted} />
-                  {summaryData.map(m => <Picker.Item key={`from-${m.memberId}`} label={m.name} value={m.memberId} />)}
-                </Picker>
-              </View>
-            </View>
+        <AppFormField label="送金先 (受け取った人)">
+          <AppSelect<number | null>
+            selectedValue={transferTo}
+            onValueChange={setTransferTo}
+            options={memberSelectOptions}
+          />
+        </AppFormField>
 
-            <View style={styles.formGroup}>
-              <Text style={styles.formLabel}>送金先 (受け取った人)</Text>
-              <View style={styles.pickerWrapper}>
-                <Picker selectedValue={transferTo} onValueChange={setTransferTo} style={styles.modalPicker}>
-                  <Picker.Item label="選択してください" value={null} color={theme.colors.text.muted} />
-                  {summaryData.map(m => <Picker.Item key={`to-${m.memberId}`} label={m.name} value={m.memberId} />)}
-                </Picker>
-              </View>
-            </View>
-
-            <View style={styles.formGroup}>
-              <Text style={styles.formLabel}>送金額</Text>
-              <View style={styles.inputWithUnit}>
-                <TextInput
-                  style={styles.modalInput}
-                  value={transferAmount}
-                  onChangeText={setTransferAmount}
-                  keyboardType="number-pad"
-                  placeholder="例: 5000"
-                />
-                <Text style={styles.unitText}>円</Text>
-              </View>
-            </View>
-
-            <View style={styles.modalActions}>
-              <AppButton
-                title={BUTTON_LABELS.cancel}
-                onPress={() => setTransferModalVisible(false)}
-                variant="secondary"
-                size="md"
-              />
-              <AppButton
-                title={BUTTON_LABELS.save}
-                onPress={handleTransferSubmit}
-                loading={isSubmitting}
-                disabled={isSubmitting}
-                size="md"
-                style={styles.modalSubmitBtn}
-              />
-            </View>
+        <AppFormField label="送金額">
+          <View style={modalStyles.inputWithUnit}>
+            <AppTextInput
+              variant="inline"
+              value={transferAmount}
+              onChangeText={setTransferAmount}
+              keyboardType="number-pad"
+              placeholder="例: 5000"
+            />
+            <Text style={modalStyles.unitSuffix}>円</Text>
           </View>
-        </View>
-      </Modal>
+        </AppFormField>
+      </AppModal>
 
     </View>
   );
@@ -371,18 +375,4 @@ const styles = StyleSheet.create({
   tableTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, color: theme.colors.text.main },
   cellName: { flex: 1.5, minWidth: 100 },
   cellAmount: { flex: 1, textAlign: 'right' },
-
-  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
-  modalContent: { backgroundColor: theme.colors.surface, width: 400, maxWidth: '90%', padding: 25, borderRadius: 12, elevation: 5 },
-  modalTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, marginBottom: 5 },
-  modalDesc: { fontSize: 13, color: theme.colors.text.muted, marginBottom: 20 },
-  formGroup: { marginBottom: 15 },
-  formLabel: { fontSize: 13, fontWeight: '600', color: theme.colors.text.main, marginBottom: 5 },
-  pickerWrapper: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: 6, backgroundColor: theme.colors.surface, height: 40, justifyContent: 'center' },
-  modalPicker: { width: '100%', height: 40, ...Platform.select({ web: { outlineStyle: 'none', border: 'none' } as any }) },
-  inputWithUnit: { flexDirection: 'row', alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border, borderRadius: 6, backgroundColor: theme.colors.surface, height: 40, paddingHorizontal: 10 },
-  modalInput: { flex: 1, height: '100%', fontSize: 16, ...Platform.select({ web: { outlineStyle: 'none' } as any }) },
-  unitText: { fontSize: 14, color: theme.colors.text.muted, marginLeft: 8 },
-  modalActions: { flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10, gap: 10 },
-  modalSubmitBtn: { minWidth: 100 },
 });

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,2 +1,2 @@
 /** @deprecated Import from `./theme/index` — kept for backward-compatible paths */
-export { theme, BREAKPOINTS, tableStyles, listItemStyles, type Theme } from './theme/index';
+export { theme, BREAKPOINTS, tableStyles, listItemStyles, formStyles, type Theme } from './theme/index';

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,2 +1,10 @@
 /** @deprecated Import from `./theme/index` — kept for backward-compatible paths */
-export { theme, BREAKPOINTS, tableStyles, listItemStyles, formStyles, type Theme } from './theme/index';
+export {
+  theme,
+  BREAKPOINTS,
+  tableStyles,
+  listItemStyles,
+  formStyles,
+  modalStyles,
+  type Theme,
+} from './theme/index';

--- a/frontend/src/theme/formStyles.ts
+++ b/frontend/src/theme/formStyles.ts
@@ -1,0 +1,53 @@
+import { StyleSheet } from 'react-native';
+import { colors } from './colors';
+import { borderRadius } from './radii';
+import { spacing } from './spacing';
+import { typography } from './typography';
+
+/** Issue #85: フォーム入力・ラベル・エラー表示の共通スタイル */
+export const formStyles = StyleSheet.create({
+  field: {
+    marginBottom: spacing.md,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.main,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 14,
+    fontSize: 14,
+    color: colors.text.main,
+    minHeight: 48,
+  },
+  inputFocused: {
+    borderColor: colors.primary,
+  },
+  inputError: {
+    borderColor: colors.error,
+    backgroundColor: colors.semantic.deficit.bg,
+  },
+  textArea: {
+    minHeight: 120,
+    textAlignVertical: 'top',
+    paddingTop: spacing.md,
+  },
+  /** プロンプト編集ペイン等: 親 flex 内で縦に伸ばす */
+  textAreaFill: {
+    flex: 1,
+    minHeight: 120,
+    textAlignVertical: 'top',
+    paddingTop: spacing.md,
+  },
+  errorText: {
+    ...typography.caption,
+    color: colors.error,
+    marginTop: spacing.xs,
+  },
+});

--- a/frontend/src/theme/formStyles.ts
+++ b/frontend/src/theme/formStyles.ts
@@ -50,4 +50,15 @@ export const formStyles = StyleSheet.create({
     color: colors.error,
     marginTop: spacing.xs,
   },
+  /** 単位付き入力の内側（外枠は modalStyles.inputWithUnit） */
+  inputInline: {
+    flex: 1,
+    borderWidth: 0,
+    backgroundColor: 'transparent',
+    minHeight: 40,
+    paddingVertical: 8,
+    paddingHorizontal: spacing.sm,
+    fontSize: 16,
+    color: colors.text.main,
+  },
 });

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -6,6 +6,7 @@ import { shadows } from './shadows';
 import { spacing } from './spacing';
 import { typography } from './typography';
 import { tableStyles, listItemStyles } from './tableStyles';
+import { formStyles } from './formStyles';
 
 export { BREAKPOINTS } from './breakpoints';
 export { colors } from './colors';
@@ -15,6 +16,7 @@ export { shadows } from './shadows';
 export { spacing } from './spacing';
 export { typography } from './typography';
 export { tableStyles, listItemStyles } from './tableStyles';
+export { formStyles } from './formStyles';
 
 export const theme = {
   colors,
@@ -26,6 +28,7 @@ export const theme = {
   breakpoints: BREAKPOINTS,
   tableStyles,
   listItemStyles,
+  formStyles,
 } as const;
 
 export type Theme = typeof theme;

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -7,6 +7,7 @@ import { spacing } from './spacing';
 import { typography } from './typography';
 import { tableStyles, listItemStyles } from './tableStyles';
 import { formStyles } from './formStyles';
+import { modalStyles } from './modalStyles';
 
 export { BREAKPOINTS } from './breakpoints';
 export { colors } from './colors';
@@ -17,6 +18,7 @@ export { spacing } from './spacing';
 export { typography } from './typography';
 export { tableStyles, listItemStyles } from './tableStyles';
 export { formStyles } from './formStyles';
+export { modalStyles } from './modalStyles';
 
 export const theme = {
   colors,
@@ -29,6 +31,7 @@ export const theme = {
   tableStyles,
   listItemStyles,
   formStyles,
+  modalStyles,
 } as const;
 
 export type Theme = typeof theme;

--- a/frontend/src/theme/modalStyles.ts
+++ b/frontend/src/theme/modalStyles.ts
@@ -81,4 +81,14 @@ export const modalStyles = StyleSheet.create({
     color: colors.text.muted,
     marginLeft: spacing.sm,
   },
+  webSelect: {
+    width: '100%',
+    height: 40,
+    borderWidth: 0,
+    backgroundColor: 'transparent',
+    paddingLeft: spacing.sm,
+    fontSize: 14,
+    color: colors.text.main,
+    ...Platform.select({ web: { outlineStyle: 'none' } as object }),
+  },
 });

--- a/frontend/src/theme/modalStyles.ts
+++ b/frontend/src/theme/modalStyles.ts
@@ -1,0 +1,84 @@
+import { StyleSheet, Platform } from 'react-native';
+import { colors } from './colors';
+import { borderRadius } from './radii';
+import { spacing } from './spacing';
+
+/** Issue #85: ダイアログ型モーダル・セレクト枠の共通スタイル */
+export const modalStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dialog: {
+    backgroundColor: colors.surface,
+    width: 400,
+    maxWidth: '90%',
+    padding: 25,
+    borderRadius: borderRadius.md,
+    ...Platform.select({
+      android: { elevation: 5 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.15,
+        shadowRadius: 8,
+      },
+      default: {},
+    }),
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text.main,
+    marginBottom: 5,
+  },
+  description: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginBottom: 20,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 10,
+    gap: 10,
+  },
+  footerPrimaryButton: {
+    minWidth: 100,
+  },
+  selectWrapper: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.surface,
+    minHeight: 40,
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  selectWrapperError: {
+    borderColor: colors.error,
+    backgroundColor: colors.semantic.deficit.bg,
+  },
+  selectPicker: {
+    width: '100%',
+    height: 40,
+    ...Platform.select({ web: { outlineStyle: 'none', border: 'none' } as object }),
+  },
+  inputWithUnit: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.surface,
+    minHeight: 48,
+    paddingRight: spacing.md,
+  },
+  unitSuffix: {
+    fontSize: 14,
+    color: colors.text.muted,
+    marginLeft: spacing.sm,
+  },
+});


### PR DESCRIPTION
## Summary
- **PR-1:** `formStyles` / `AppTextInput` / `AppFormField` 基盤、CategoryManagement パイロット
- **PR-2:** `modalStyles` / `AppModal` / `AppSelect`、送金記録モーダルの共通化
- **PR-3:** ProductMaster・PromptEditor のフォーム置換、精算の月選択・送金バリデーション UI（赤枠・メッセージ）

## Test plan
- [x] `cd frontend && npx tsc --noEmit`
- [x] 手動: CategoryManagement（入力フォーカス・追加）
- [x] 手動: 精算サマリー（月選択・送金モーダル）
- [x] 手動: プロンプト編集（保存・一覧はロジック未変更）
- [x] 手動: 学習マスタ検索フィルタ

## スコープ外（Issue #86 で対応予定）
- ReceiptDetail / ReceiptScan の TextInput
- History / Statistics のフルスクリーンモーダル
- Home / AdminStats 等のボタン・ナビ取りこぼし

Closes #245

Made with [Cursor](https://cursor.com)