### PR TITLE
feat(ui): [Issue #86] 画面横断 UI クリーンアップとスマホ AppSelect 修正

### DIFF
--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -6,14 +6,9 @@ import {
   Image, 
   ScrollView, 
   useWindowDimensions, 
-  Platform, 
-  TextInput, 
-  TouchableOpacity, 
-  ActivityIndicator, 
   Alert 
 } from 'react-native';
-import { Picker } from '@react-native-picker/picker';
-import { AppButton } from '../components/ui';
+import { AppButton, AppSelect, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, BREAKPOINTS } from '../theme';
 import apiClient from '../utils/apiClient';
@@ -49,6 +44,11 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   const [editData, setEditData] = useState<any>(null);
 
   const cacheKey = useMemo(() => Date.now(), []);
+
+  const categorySelectOptions = useMemo(
+    () => categories.map((c) => ({ label: c.name, value: c.id as number })),
+    [categories]
+  );
 
   useEffect(() => {
     if (receipt) {
@@ -189,8 +189,9 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
 
         <View style={styles.detailHeaderInner}>
           {isEditing ? (
-            <TextInput 
+            <AppTextInput
               style={styles.titleInput}
+              inputStyle={styles.titleInputText}
               value={editData.storeName}
               onChangeText={(val) => updateEditField('storeName', val)}
               placeholder="店舗名"
@@ -200,7 +201,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
           )}
           
           {isEditing ? (
-            <TextInput 
+            <AppTextInput
               style={styles.dateInput}
               value={editData.date ? new Date(editData.date).toISOString().replace('T', ' ').substring(0, 16) : ''}
               onChangeText={(val) => updateEditField('date', val)}
@@ -228,7 +229,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
             <View key={item.id || idx} style={styles.detailItemRow}>
               <View style={styles.detailItemTop}>
                 {isEditing ? (
-                  <TextInput 
+                  <AppTextInput
                     style={styles.itemNameInput}
                     value={item.name}
                     onChangeText={(val) => updateEditItem(idx, 'name', val)}
@@ -241,14 +242,14 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
                   {isEditing ? (
                     <View style={styles.editPriceRow}>
                       <Text style={styles.currencySymbol}>¥</Text>
-                      <TextInput 
+                      <AppTextInput
                         style={styles.priceInput}
                         value={String(item.price)}
                         keyboardType="decimal-pad"
                         onChangeText={(val) => updateEditItem(idx, 'price', val)}
                       />
                       <Text style={styles.multiplier}>×</Text>
-                      <TextInput 
+                      <AppTextInput
                         style={styles.quantityInput}
                         value={String(item.quantity)}
                         keyboardType="decimal-pad"
@@ -269,17 +270,15 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
               </View>
               
               <View style={styles.detailItemBottom}>
-                <View style={styles.detailPickerWrapper}>
-                  <Picker
-                    selectedValue={item.categoryId}
-                    onValueChange={(val) => isEditing ? updateEditItem(idx, 'categoryId', val) : onCategoryChange(item.id, val)}
-                    style={styles.detailPicker}
-                    mode="dropdown"
-                  >
-                    <Picker.Item label="カテゴリーを選択..." value={null} color={theme.colors.text.muted} />
-                    {categories.map(c => <Picker.Item key={c.id} label={c.name} value={c.id} color={theme.colors.semantic.picker.text} />)}
-                  </Picker>
-                </View>
+                <AppSelect<number | null>
+                  selectedValue={item.categoryId ?? null}
+                  onValueChange={(val) =>
+                    isEditing ? updateEditItem(idx, 'categoryId', val) : onCategoryChange(item.id, val)
+                  }
+                  options={categorySelectOptions}
+                  placeholder="カテゴリーを選択..."
+                  style={styles.categorySelect}
+                />
               </View>
             </View>
           ))}
@@ -290,7 +289,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
               {isEditing ? (
                 <View style={styles.editTaxRow}>
                   <Text style={styles.currencySymbol}>+ ¥</Text>
-                  <TextInput 
+                  <AppTextInput
                     style={styles.taxInput}
                     value={String(editData.taxAmount)}
                     keyboardType="decimal-pad"
@@ -333,9 +332,10 @@ const styles = StyleSheet.create({
   receiptImage: { width: '100%', height: '100%' },
   detailHeaderInner: { marginBottom: 20 },
   detailTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text.main },
-  titleInput: { fontSize: 24, fontWeight: 'bold', color: theme.colors.primary, borderBottomWidth: 1, borderBottomColor: theme.colors.primary, marginBottom: 4 },
+  titleInput: { marginBottom: 4 },
+  titleInputText: { fontSize: 24, fontWeight: 'bold' },
   detailDate: { fontSize: 16, color: theme.colors.text.muted, marginTop: 4 },
-  dateInput: { fontSize: 16, color: theme.colors.primary, borderBottomWidth: 1, borderBottomColor: theme.colors.primary, marginTop: 4 },
+  dateInput: { marginTop: 4 },
   detailTotalContainer: { alignItems: 'flex-end', marginBottom: 30, paddingBottom: 15, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
   detailTotalLabel: { fontSize: 13, color: theme.colors.text.muted },
   detailTotalValue: { fontSize: 38, fontWeight: 'bold', color: theme.colors.text.main },
@@ -344,7 +344,7 @@ const styles = StyleSheet.create({
   detailItemRow: { flexDirection: 'column', paddingVertical: 15, borderBottomWidth: 1, borderBottomColor: sem.table.rowBorder },
   detailItemTop: { marginBottom: 10 },
   detailItemName: { fontSize: 17, fontWeight: '600', color: theme.colors.text.main, marginBottom: 4 },
-  itemNameInput: { fontSize: 17, fontWeight: '600', color: theme.colors.primary, borderBottomWidth: 1, borderBottomColor: theme.colors.primary, marginBottom: 4 },
+  itemNameInput: { marginBottom: 4 },
   detailPriceContainer: { flexDirection: 'row', alignItems: 'baseline' },
   detailItemPrice: { fontWeight: '700', color: theme.colors.primary, fontSize: 16 },
   detailItemSub: { fontSize: 12, color: theme.colors.text.muted, marginLeft: 6 },
@@ -352,18 +352,17 @@ const styles = StyleSheet.create({
   editControls: { flexDirection: 'row', justifyContent: 'flex-end', marginBottom: 10, gap: 10 },
   splitButtonOverride: { backgroundColor: sem.info.bg, borderColor: sem.info.border },
   editPriceRow: { flexDirection: 'row', alignItems: 'center', gap: 5 },
-  priceInput: { borderBottomWidth: 1, borderBottomColor: theme.colors.primary, width: 80, fontSize: 15, textAlign: 'right', color: theme.colors.primary },
-  quantityInput: { borderBottomWidth: 1, borderBottomColor: theme.colors.primary, width: 50, fontSize: 15, textAlign: 'center', color: theme.colors.primary },
+  priceInput: { width: 100, minHeight: 40 },
+  quantityInput: { width: 72, minHeight: 40 },
   currencySymbol: { fontSize: 14, color: theme.colors.text.muted },
   multiplier: { fontSize: 14, color: theme.colors.text.muted },
-  detailPickerWrapper: { height: 55, backgroundColor: theme.colors.surface, borderRadius: 8, borderWidth: 1, borderColor: theme.colors.border, overflow: 'visible', justifyContent: 'center', marginTop: 4 },
-  detailPicker: { width: '100%', height: 55, color: sem.picker.text, ...Platform.select({ android: { marginLeft: -10 }, web: { outlineStyle: 'none' } as any }) },
+  categorySelect: { marginTop: 4, minHeight: 48 },
   taxSection: { marginTop: 20, paddingVertical: 15, borderTopWidth: 2, borderTopColor: sem.divider, borderStyle: 'dashed' },
   taxRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   taxLabel: { fontSize: 14, color: theme.colors.text.muted, fontWeight: '600' },
   taxValue: { fontSize: 16, color: theme.colors.text.main, fontWeight: '700' },
   editTaxRow: { flexDirection: 'row', alignItems: 'center' },
-  taxInput: { borderBottomWidth: 1, borderBottomColor: theme.colors.primary, width: 100, fontSize: 16, textAlign: 'right', color: theme.colors.primary, fontWeight: 'bold' },
+  taxInput: { width: 120, minHeight: 40 },
 });
 
 export default ReceiptDetailComponent;

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -356,7 +356,7 @@ const styles = StyleSheet.create({
   quantityInput: { width: 72, minHeight: 40 },
   currencySymbol: { fontSize: 14, color: theme.colors.text.muted },
   multiplier: { fontSize: 14, color: theme.colors.text.muted },
-  categorySelect: { marginTop: 4, minHeight: 48 },
+  categorySelect: { marginTop: 4 },
   taxSection: { marginTop: 20, paddingVertical: 15, borderTopWidth: 2, borderTopColor: sem.divider, borderStyle: 'dashed' },
   taxRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   taxLabel: { fontSize: 14, color: theme.colors.text.muted, fontWeight: '600' },

--- a/frontend/src/components/ui/AppModal.tsx
+++ b/frontend/src/components/ui/AppModal.tsx
@@ -1,40 +1,89 @@
 import React from 'react';
 import { Modal, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { modalStyles } from '../../theme/modalStyles';
+import { AppModalCloseButton } from './AppModalCloseButton';
+
+export type AppModalVariant = 'dialog' | 'sheet';
+
+/** sheet: fullscreen = モバイル全画面 / wide = 大画面中央カード */
+export type AppModalSheetPresentation = 'fullscreen' | 'wide';
 
 export interface AppModalProps {
   visible: boolean;
   onRequestClose: () => void;
+  variant?: AppModalVariant;
   title: string;
   description?: string;
   children?: React.ReactNode;
   footer?: React.ReactNode;
+  sheetPresentation?: AppModalSheetPresentation;
 }
 
-/** 中央ダイアログ型モーダル（送金記録等） */
+const SheetHeader: React.FC<{ title: string; onClose: () => void }> = ({ title, onClose }) => (
+  <View style={modalStyles.sheetHeader}>
+    <Text style={modalStyles.sheetHeaderTitle} numberOfLines={1}>
+      {title}
+    </Text>
+    <AppModalCloseButton onPress={onClose} />
+  </View>
+);
+
+/** dialog: 中央ダイアログ（送金記録等） / sheet: レシート詳細等 */
 export const AppModal: React.FC<AppModalProps> = ({
   visible,
   onRequestClose,
+  variant = 'dialog',
   title,
   description,
   children,
   footer,
-}) => (
-  <Modal
-    visible={visible}
-    transparent
-    animationType="fade"
-    onRequestClose={onRequestClose}
-  >
-    <View style={modalStyles.overlay}>
-      <View style={modalStyles.dialog}>
-        <Text style={modalStyles.title}>{title}</Text>
-        {description ? (
-          <Text style={modalStyles.description}>{description}</Text>
-        ) : null}
-        {children}
-        {footer ? <View style={modalStyles.footer}>{footer}</View> : null}
-      </View>
-    </View>
-  </Modal>
-);
+  sheetPresentation = 'fullscreen',
+}) => {
+  if (variant === 'dialog') {
+    return (
+      <Modal
+        visible={visible}
+        transparent
+        animationType="fade"
+        onRequestClose={onRequestClose}
+      >
+        <View style={modalStyles.overlay}>
+          <View style={modalStyles.dialog}>
+            <Text style={modalStyles.title}>{title}</Text>
+            {description ? (
+              <Text style={modalStyles.description}>{description}</Text>
+            ) : null}
+            {children}
+            {footer ? <View style={modalStyles.footer}>{footer}</View> : null}
+          </View>
+        </View>
+      </Modal>
+    );
+  }
+
+  const isWideSheet = sheetPresentation === 'wide';
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={isWideSheet}
+      onRequestClose={onRequestClose}
+    >
+      {isWideSheet ? (
+        <View style={modalStyles.sheetOverlay}>
+          <SafeAreaView style={modalStyles.sheetWide}>
+            <SheetHeader title={title} onClose={onRequestClose} />
+            <View style={modalStyles.sheetBody}>{children}</View>
+          </SafeAreaView>
+        </View>
+      ) : (
+        <SafeAreaView style={modalStyles.sheetContainer}>
+          <SheetHeader title={title} onClose={onRequestClose} />
+          <View style={modalStyles.sheetBody}>{children}</View>
+        </SafeAreaView>
+      )}
+    </Modal>
+  );
+};

--- a/frontend/src/components/ui/AppSelect.tsx
+++ b/frontend/src/components/ui/AppSelect.tsx
@@ -1,6 +1,16 @@
-import React from 'react';
-import { Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
-import { Picker } from '@react-native-picker/picker';
+import React, { useMemo, useState } from 'react';
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
 import { modalStyles } from '../../theme/modalStyles';
 import { colors } from '../../theme/colors';
 
@@ -21,6 +31,12 @@ export interface AppSelectProps<T extends string | number | null = string | numb
   style?: StyleProp<ViewStyle>;
 }
 
+function valuesEqual<T>(a: T, b: T): boolean {
+  if (a === b) return true;
+  if (a === null || a === undefined || b === null || b === undefined) return false;
+  return String(a) === String(b);
+}
+
 export function AppSelect<T extends string | number | null = string | number | null>({
   selectedValue,
   onValueChange,
@@ -36,6 +52,27 @@ export function AppSelect<T extends string | number | null = string | number | n
     error && modalStyles.selectWrapperError,
     style,
   ];
+
+  const displayLabel = useMemo(() => {
+    if (
+      includePlaceholder &&
+      (selectedValue === null ||
+        selectedValue === undefined ||
+        valuesEqual(selectedValue, placeholderValue as T))
+    ) {
+      return placeholder;
+    }
+    const found = options.find((o) => valuesEqual(o.value, selectedValue));
+    return found?.label ?? placeholder;
+  }, [includePlaceholder, selectedValue, placeholderValue, options, placeholder]);
+
+  const listOptions = useMemo(() => {
+    const items: AppSelectOption<T>[] = [...options];
+    if (includePlaceholder) {
+      items.unshift({ label: placeholder, value: placeholderValue as T });
+    }
+    return items;
+  }, [options, includePlaceholder, placeholder, placeholderValue]);
 
   if (Platform.OS === 'web') {
     const webValue =
@@ -71,29 +108,53 @@ export function AppSelect<T extends string | number | null = string | number | n
     );
   }
 
+  const [open, setOpen] = useState(false);
+
   return (
-    <View style={wrapperStyle}>
-      <Picker
-        selectedValue={selectedValue}
-        onValueChange={(value) => onValueChange(value as T)}
-        style={modalStyles.selectPicker}
-        {...Platform.select({ ios: { mode: 'dropdown' as const }, default: {} })}
+    <>
+      <TouchableOpacity
+        style={[wrapperStyle, modalStyles.selectTrigger]}
+        onPress={() => setOpen(true)}
+        activeOpacity={0.7}
+        accessibilityRole="button"
       >
-        {includePlaceholder ? (
-          <Picker.Item
-            label={placeholder}
-            value={placeholderValue as unknown as number}
-            color={colors.text.muted}
-          />
-        ) : null}
-        {options.map((opt) => (
-          <Picker.Item
-            key={String(opt.value)}
-            label={opt.label}
-            value={opt.value as unknown as number}
-          />
-        ))}
-      </Picker>
-    </View>
+        <Text style={modalStyles.selectTriggerText} numberOfLines={1}>
+          {displayLabel}
+        </Text>
+        <Text style={modalStyles.selectChevron}>▼</Text>
+      </TouchableOpacity>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        <Pressable style={modalStyles.selectOverlay} onPress={() => setOpen(false)}>
+          <Pressable style={modalStyles.selectSheet} onPress={(e) => e.stopPropagation()}>
+            <ScrollView keyboardShouldPersistTaps="handled">
+              {listOptions.map((opt, index) => {
+                const selected = valuesEqual(opt.value, selectedValue);
+                return (
+                  <TouchableOpacity
+                    key={`${index}-${String(opt.value)}`}
+                    style={[modalStyles.selectOptionRow, selected && modalStyles.selectOptionRowSelected]}
+                    onPress={() => {
+                      onValueChange(opt.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <Text
+                      style={[
+                        modalStyles.selectOptionText,
+                        selected && modalStyles.selectOptionTextSelected,
+                      ]}
+                      numberOfLines={2}
+                    >
+                      {opt.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,7 +15,12 @@ export {
   type AppTextInputVariant,
 } from './AppTextInput';
 export { AppFormField, type AppFormFieldProps } from './AppFormField';
-export { AppModal, type AppModalProps } from './AppModal';
+export {
+  AppModal,
+  type AppModalProps,
+  type AppModalVariant,
+  type AppModalSheetPresentation,
+} from './AppModal';
 export {
   AppSelect,
   type AppSelectProps,

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -5,10 +5,9 @@ import {
   StyleSheet, 
   ActivityIndicator, 
   ScrollView,
-  TouchableOpacity
 } from 'react-native';
 import { AppBackButton } from '../components/ui';
-import { theme } from '../theme';
+import { theme, tableStyles } from '../theme';
 import apiClient from '../utils/apiClient';
 
 interface StatData {
@@ -82,33 +81,35 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
               <Text style={styles.summaryNote}>※為替レート150円/$、Gemini 2.0 Flashでの算出</Text>
             </View>
 
-            <View style={styles.tableHeader}>
-              <Text style={[styles.tableCell, { flex: 1.5 }]}>年月</Text>
-              <Text style={[styles.tableCell, { flex: 2 }]}>In / Out (Tokens)</Text>
-              <Text style={[styles.tableCell, { flex: 1.5, textAlign: 'right' }]}>概算(円)</Text>
-            </View>
-
-            {stats.length === 0 ? (
-              <View style={styles.emptyContainer}>
-                <Text style={styles.emptyText}>データがありません</Text>
+            <View style={tableStyles.wrapper}>
+              <View style={[tableStyles.row, tableStyles.headerRow]}>
+                <Text style={[tableStyles.cell, styles.colMonth, tableStyles.headerText]}>年月</Text>
+                <Text style={[tableStyles.cell, styles.colTokens, tableStyles.headerText]}>In / Out (Tokens)</Text>
+                <Text style={[tableStyles.cell, styles.colCost, tableStyles.headerText]}>概算(円)</Text>
               </View>
-            ) : (
-              stats.map((item, index) => (
-                <View key={`${item.month}-${item.modelId}-${index}`} style={styles.tableRow}>
-                  <View style={{ flex: 1.5 }}>
-                    <Text style={styles.cellMainText}>{item.month}</Text>
-                    <Text style={styles.cellSubText} numberOfLines={1}>{item.modelId}</Text>
-                  </View>
-                  <View style={{ flex: 2 }}>
-                    <Text style={styles.cellMainText}>{item.totalPromptTokens.toLocaleString()}</Text>
-                    <Text style={styles.cellSubText}>{item.totalCandidatesTokens.toLocaleString()}</Text>
-                  </View>
-                  <Text style={[styles.cellMainText, { flex: 1.5, textAlign: 'right', fontWeight: 'bold' }]}>
-                    ¥{item.estimatedCostJpy.toFixed(2)}
-                  </Text>
+
+              {stats.length === 0 ? (
+                <View style={[tableStyles.row, styles.emptyRow]}>
+                  <Text style={[tableStyles.cell, tableStyles.bodyText]}>データがありません</Text>
                 </View>
-              ))
-            )}
+              ) : (
+                stats.map((item, index) => (
+                  <View key={`${item.month}-${item.modelId}-${index}`} style={tableStyles.row}>
+                    <View style={[tableStyles.cell, styles.colMonth]}>
+                      <Text style={tableStyles.bodyText}>{item.month}</Text>
+                      <Text style={styles.cellSubText} numberOfLines={1}>{item.modelId}</Text>
+                    </View>
+                    <View style={[tableStyles.cell, styles.colTokens]}>
+                      <Text style={tableStyles.bodyText}>{item.totalPromptTokens.toLocaleString()}</Text>
+                      <Text style={styles.cellSubText}>{item.totalCandidatesTokens.toLocaleString()}</Text>
+                    </View>
+                    <Text style={[tableStyles.cell, styles.colCost, tableStyles.bodyText, tableStyles.boldText]}>
+                      ¥{item.estimatedCostJpy.toFixed(2)}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </View>
           </>
         )}
       </ScrollView>
@@ -164,28 +165,9 @@ const styles = StyleSheet.create({
   summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, marginBottom: 8 },
   summaryAmount: { color: theme.colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
   summaryNote: { color: 'rgba(255,255,255,0.6)', fontSize: 12, marginTop: 8 },
-  tableHeader: {
-    flexDirection: 'row',
-    backgroundColor: adm.border,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 8,
-    marginBottom: 8,
-  },
-  tableCell: { fontSize: 13, fontWeight: 'bold', color: theme.colors.text.muted },
-  tableRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: adm.surface,
-    paddingVertical: 16,
-    paddingHorizontal: 16,
-    borderRadius: 8,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: adm.border,
-  },
-  cellMainText: { fontSize: 15, color: theme.colors.text.main },
+  colMonth: { flex: 1.5 },
+  colTokens: { flex: 2 },
+  colCost: { flex: 1.5, textAlign: 'right' },
   cellSubText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 4 },
-  emptyContainer: { padding: 32, alignItems: 'center' },
-  emptyText: { color: theme.colors.text.muted, fontSize: 16 },
+  emptyRow: { justifyContent: 'center', paddingVertical: 24 },
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -13,8 +13,9 @@ import {
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
+import { toMonthSelectOptions } from '../utils/monthSelectOptions';
 // Issue #66: BREAKPOINTS 参照
-import { AppBackButton, AppModalCloseButton } from '../components/ui';
+import { AppBackButton, AppModalCloseButton, AppSelect } from '../components/ui';
 import { theme, BREAKPOINTS } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -48,6 +49,11 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
       return d.toISOString().slice(0, 7);
     });
   }, []);
+
+  const monthSelectOptions = useMemo(
+    () => toMonthSelectOptions(months),
+    [months]
+  );
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
@@ -176,37 +182,6 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
     );
   };
 
-  const renderMonthPicker = () => {
-    if (Platform.OS === 'web') {
-      return (
-        <select
-          value={selectedMonth}
-          onChange={(e) => setSelectedMonth(e.target.value)}
-          style={StyleSheet.flatten(styles.webSelect)}
-        >
-          <option value="">全期間</option>
-          {months.map(m => (
-            <option key={m} value={m}>{`${m.split('-')[0]}年${m.split('-')[1]}月`}</option>
-          ))}
-        </select>
-      );
-    }
-
-    return (
-      <Picker 
-        selectedValue={selectedMonth} 
-        onValueChange={setSelectedMonth} 
-        style={styles.filterPicker}
-        mode="dropdown"
-      >
-        <Picker.Item label="全期間" value="" />
-        {months.map(m => (
-          <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
-        ))}
-      </Picker>
-    );
-  };
-
   const renderMemberPicker = () => {
     if (Platform.OS === 'web') {
       return (
@@ -254,8 +229,15 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
         </View>
 
         <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
-          <View style={[styles.pickerBox, isWide && { width: 250, minWidth: 250, flexGrow: 0, flexShrink: 0 }]}>
-            {renderMonthPicker()}
+          <View style={[styles.filterSelectWrap, isWide && styles.filterSelectWrapWide]}>
+            <AppSelect<string>
+              selectedValue={selectedMonth}
+              onValueChange={setSelectedMonth}
+              options={monthSelectOptions}
+              placeholder="全期間"
+              placeholderValue=""
+              style={styles.monthSelect}
+            />
           </View>
           <View style={[styles.pickerBox, isWide && { width: 200, minWidth: 200, flexGrow: 0, flexShrink: 0 }]}>
             {renderMemberPicker()}
@@ -336,6 +318,9 @@ const styles = StyleSheet.create({
   title: { ...theme.typography.h2, color: theme.colors.text.main },
   filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 10 },
   wideFilter: { justifyContent: 'flex-start' },
+  filterSelectWrap: { flex: 1, minWidth: 140, justifyContent: 'center' },
+  filterSelectWrapWide: { width: 180, flexGrow: 0, flexShrink: 0 },
+  monthSelect: { minHeight: 36 },
   pickerBox: { flex: 1, height: 44, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
   filterPicker: { width: '100%' },
   webSelect: {

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -6,7 +6,6 @@ import {
   FlatList, 
   TouchableOpacity, 
   ActivityIndicator, 
-  Modal, 
   Platform, 
   Alert, 
   useWindowDimensions 
@@ -15,7 +14,7 @@ import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
 import { toMonthSelectOptions } from '../utils/monthSelectOptions';
 // Issue #66: BREAKPOINTS 参照
-import { AppBackButton, AppModalCloseButton, AppSelect } from '../components/ui';
+import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme, BREAKPOINTS } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -285,27 +284,24 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
       </View>
 
       {!isWide && (
-        <Modal visible={!!selectedReceipt} animationType="slide" onRequestClose={() => setSelectedReceipt(null)}>
-          <View style={styles.modalContent}>
-            <View style={styles.detailHeader}>
-              <Text style={styles.detailTitleMobile} numberOfLines={1}>
-                {selectedReceipt?.storeName || '店名不明'}
-              </Text>
-              <AppModalCloseButton onPress={() => setSelectedReceipt(null)} />
-            </View>
-            {selectedReceipt && (
-              <ReceiptDetailComponent 
-                receipt={selectedReceipt}
-                categories={categories}
-                onCategoryChange={handleCategoryChange}
-                baseUrl={BASE_URL}
-                fullWidth={true}
-                onSaveSuccess={fetchReceipts}
-                onGoToSplitEditor={onGoToSplitEditor} // ★ 追加
-              />
-            )}
-          </View>
-        </Modal>
+        <AppModal
+          visible={!!selectedReceipt}
+          onRequestClose={() => setSelectedReceipt(null)}
+          variant="sheet"
+          title={selectedReceipt?.storeName || '店名不明'}
+        >
+          {selectedReceipt ? (
+            <ReceiptDetailComponent
+              receipt={selectedReceipt}
+              categories={categories}
+              onCategoryChange={handleCategoryChange}
+              baseUrl={BASE_URL}
+              fullWidth={true}
+              onSaveSuccess={fetchReceipts}
+              onGoToSplitEditor={onGoToSplitEditor}
+            />
+          ) : null}
+        </AppModal>
       )}
     </View>
   );
@@ -354,9 +350,6 @@ const styles = StyleSheet.create({
   itemCountBadge: { backgroundColor: theme.colors.background, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
   itemCountText: { fontSize: 10, color: theme.colors.secondary },
   empty: { textAlign: 'center', marginTop: 50, color: theme.colors.text.muted },
-  modalContent: { flex: 1, backgroundColor: theme.colors.background },
-  detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  detailTitleMobile: { fontSize: 18, fontWeight: 'bold', flex: 1 },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center', marginTop: 50 },
   emptyDetailWrapper: { flex: 1, justifyContent: 'center', alignItems: 'center' }
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -10,9 +10,8 @@ import {
   Alert, 
   useWindowDimensions 
 } from 'react-native';
-import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
-import { toMonthSelectOptions } from '../utils/monthSelectOptions';
+import { getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 // Issue #66: BREAKPOINTS 参照
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme, BREAKPOINTS } from '../theme';
@@ -41,17 +40,17 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
   const [selectedMonth, setSelectedMonth] = useState('');
   const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
 
-  const months = useMemo(() => {
-    return Array.from({ length: 6 }).map((_, i) => {
-      const d = new Date();
-      d.setMonth(d.getMonth() - i);
-      return d.toISOString().slice(0, 7);
-    });
-  }, []);
+  const months = useMemo(() => getRecentYearMonths(6), []);
 
-  const monthSelectOptions = useMemo(
-    () => toMonthSelectOptions(months),
-    [months]
+  const monthSelectOptions = useMonthSelectOptions(months, isWide);
+
+  const memberSelectOptions = useMemo(
+    () =>
+      members.map((m) => ({
+        label: m.id === currentMemberId ? `自分 (${m.name})` : m.name,
+        value: m.id.toString(),
+      })),
+    [members, currentMemberId]
   );
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
@@ -181,43 +180,6 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
     );
   };
 
-  const renderMemberPicker = () => {
-    if (Platform.OS === 'web') {
-      return (
-        <select
-          value={selectedMember}
-          onChange={(e) => setSelectedMember(e.target.value)}
-          style={StyleSheet.flatten(styles.webSelect)} 
-        >
-          <option value="">世帯全体</option>
-          {members.map(m => (
-            <option key={m.id} value={m.id.toString()}>
-              {m.id === currentMemberId ? `自分 (${m.name})` : m.name}
-            </option>
-          ))}
-        </select>
-      );
-    }
-
-    return (
-      <Picker 
-        selectedValue={selectedMember} 
-        onValueChange={setSelectedMember} 
-        style={styles.filterPicker}
-        mode="dropdown"
-      >
-        <Picker.Item label="世帯全体" value="" />
-        {members.map(m => (
-          <Picker.Item 
-            key={m.id} 
-            label={m.id === currentMemberId ? `自分 (${m.name})` : m.name} 
-            value={m.id.toString()} 
-          />
-        ))}
-      </Picker>
-    );
-  };
-
   return (
     <View style={styles.container}>
       <View style={styles.mainWrapper}>
@@ -227,7 +189,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
           <View style={{ width: 40 }} />
         </View>
 
-        <View style={[styles.filterContainer, isWide && styles.wideFilter]}>
+        <View style={[styles.filterContainer, isWide ? styles.filterContainerWide : styles.filterContainerMobile]}>
           <View style={[styles.filterSelectWrap, isWide && styles.filterSelectWrapWide]}>
             <AppSelect<string>
               selectedValue={selectedMonth}
@@ -235,11 +197,16 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
               options={monthSelectOptions}
               placeholder="全期間"
               placeholderValue=""
-              style={styles.monthSelect}
             />
           </View>
-          <View style={[styles.pickerBox, isWide && { width: 200, minWidth: 200, flexGrow: 0, flexShrink: 0 }]}>
-            {renderMemberPicker()}
+          <View style={[styles.filterSelectWrap, isWide && styles.filterSelectWrapWide]}>
+            <AppSelect<string>
+              selectedValue={selectedMember}
+              onValueChange={setSelectedMember}
+              options={memberSelectOptions}
+              placeholder="世帯全体"
+              placeholderValue=""
+            />
           </View>
         </View>
 
@@ -312,28 +279,11 @@ const styles = StyleSheet.create({
   mainWrapper: { flex: 1, width: '100%', alignSelf: 'stretch', paddingTop: Platform.OS === 'ios' ? 60 : 20 },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
   title: { ...theme.typography.h2, color: theme.colors.text.main },
-  filterContainer: { flexDirection: 'row', paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 10 },
-  wideFilter: { justifyContent: 'flex-start' },
-  filterSelectWrap: { flex: 1, minWidth: 140, justifyContent: 'center' },
-  filterSelectWrapWide: { width: 180, flexGrow: 0, flexShrink: 0 },
-  monthSelect: { minHeight: 36 },
-  pickerBox: { flex: 1, height: 44, backgroundColor: theme.colors.surface, borderRadius: 8, justifyContent: 'center', borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
-  filterPicker: { width: '100%' },
-  webSelect: {
-    width: '100%',
-    height: '100%',
-    borderWidth: 0,
-    backgroundColor: 'transparent',
-    paddingLeft: 10,
-    fontSize: 14,
-    color: theme.colors.text.main,
-    ...Platform.select({
-      web: {
-        outlineStyle: 'none',
-      },
-      default: {},
-    }),
-  } as any,
+  filterContainer: { paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 8 },
+  filterContainerMobile: { flexDirection: 'column' },
+  filterContainerWide: { flexDirection: 'row', justifyContent: 'flex-start' },
+  filterSelectWrap: { width: '100%', justifyContent: 'center' },
+  filterSelectWrapWide: { flex: 1, width: undefined, minWidth: 160, maxWidth: 220 },
   mainContentMobile: { flex: 1 },
   mainContentWide: { flex: 1, flexDirection: 'row', borderTopWidth: 1, borderTopColor: theme.colors.border },
   masterPane: { width: 350, height: '100%', backgroundColor: theme.colors.surface, borderRightWidth: 1, borderRightColor: theme.colors.border },

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
+import { AppButton, AppListItem } from '../components/ui';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
 
@@ -171,9 +172,14 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             <Text style={styles.summaryAmount}>{monthlyTotal.toLocaleString()}</Text>
           </View>
           <View style={styles.summaryDivider} />
-          <TouchableOpacity onPress={onGoToStats}>
-            <Text style={styles.summaryLink}>統計の詳細を見る ›</Text>
-          </TouchableOpacity>
+          <AppButton
+            title="統計の詳細を見る ›"
+            onPress={onGoToStats}
+            variant="ghost"
+            size="sm"
+            style={styles.summaryLinkButton}
+            textStyle={styles.summaryLinkText}
+          />
         </View>
 
         <TouchableOpacity 
@@ -195,34 +201,49 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
 
         {/* メニューカード群：グリッド表示 */}
         <View style={styles.gridContainer}>
-          <TouchableOpacity style={styles.gridCard} onPress={onGoToHistory}>
-            <Text style={{ fontSize: 28, marginBottom: 8 }}>📋</Text>
-            <Text style={styles.menuLabel}>履歴一覧</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.gridCard} onPress={onGoToStats}>
-            <Text style={{ fontSize: 28, marginBottom: 8 }}>📊</Text>
-            <Text style={styles.menuLabel}>支出統計</Text>
-          </TouchableOpacity>
-          {/* ★ [Issue #80] 精算サマリーへの遷移ボタン（スマホ非表示） */}
+          <AppListItem
+            variant="nav"
+            onPress={onGoToHistory}
+            title="履歴一覧"
+            left={<Text style={styles.gridEmoji}>📋</Text>}
+            right={<View />}
+            style={styles.gridCard}
+          />
+          <AppListItem
+            variant="nav"
+            onPress={onGoToStats}
+            title="支出統計"
+            left={<Text style={styles.gridEmoji}>📊</Text>}
+            right={<View />}
+            style={styles.gridCard}
+          />
           {onGoToSettlement && isWide && (
-            <TouchableOpacity style={styles.gridCard} onPress={onGoToSettlement}>
-              <Text style={{ fontSize: 28, marginBottom: 8 }}>🤝</Text>
-              <Text style={styles.menuLabel}>精算サマリー</Text>
-            </TouchableOpacity>
+            <AppListItem
+              variant="nav"
+              onPress={onGoToSettlement}
+              title="精算サマリー"
+              left={<Text style={styles.gridEmoji}>🤝</Text>}
+              right={<View />}
+              style={styles.gridCard}
+            />
           )}
         </View>
 
         {/* 管理者限定メニューへのハブ導線 */}
         {isAdmin && (
           <View style={styles.section}>
-            <TouchableOpacity style={[styles.settingsCard, { backgroundColor: theme.colors.semantic.icon.adminSettings }]} onPress={onGoToAdminMenu}>
-              <View style={[styles.settingsIconWrapper, { backgroundColor: theme.colors.semantic.icon.adminCard }]}><Text>🛡️</Text></View>
-              <View style={styles.settingsTextWrapper}>
-                <Text style={styles.settingsLabel}>管理者メニュー</Text>
-                <Text style={{ fontSize: 12, color: theme.colors.text.muted, marginTop: 2 }}>マスタ管理・システム設定</Text>
-              </View>
-              <Text style={styles.arrowIcon}>›</Text>
-            </TouchableOpacity>
+            <AppListItem
+              variant="nav"
+              onPress={onGoToAdminMenu}
+              title="管理者メニュー"
+              subtitle="マスタ管理・システム設定"
+              style={{ backgroundColor: theme.colors.semantic.icon.adminSettings }}
+              left={
+                <View style={[styles.settingsIconWrapper, { backgroundColor: theme.colors.semantic.icon.adminCard }]}>
+                  <Text>🛡️</Text>
+                </View>
+              }
+            />
           </View>
         )}
 
@@ -231,15 +252,22 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           {loading ? (
             <ActivityIndicator color={theme.colors.primary} style={{ marginTop: 10 }} />
           ) : latestReceipt ? (
-            <TouchableOpacity style={styles.latestCard} onPress={onGoToHistory}>
-              <View style={styles.cardInfo}>
-                <Text style={styles.storeName} numberOfLines={1}>{latestReceipt.storeName || '店名不明'}</Text>
-                <Text style={styles.dateText}>{latestReceipt.date ? new Date(latestReceipt.date).toLocaleDateString('ja-JP') : '日付不明'}</Text>
-              </View>
-              <Text style={styles.amountText}>
-                ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
-              </Text>
-            </TouchableOpacity>
+            <AppListItem
+              variant="nav"
+              onPress={onGoToHistory}
+              title={latestReceipt.storeName || '店名不明'}
+              subtitle={
+                latestReceipt.date
+                  ? new Date(latestReceipt.date).toLocaleDateString('ja-JP')
+                  : '日付不明'
+              }
+              right={
+                <Text style={styles.amountText}>
+                  ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
+                </Text>
+              }
+              style={styles.latestCard}
+            />
           ) : (
             <View style={[styles.latestCard, { justifyContent: 'center' }]}><Text style={styles.dateText}>表示できるデータがありません</Text></View>
           )}
@@ -261,7 +289,8 @@ const styles = StyleSheet.create({
   summarySymbol: { color: theme.colors.text.inverse, fontSize: 20, marginRight: 4, fontWeight: 'bold' },
   summaryAmount: { color: theme.colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
   summaryDivider: { height: 1, backgroundColor: 'rgba(255,255,255,0.2)', marginVertical: theme.spacing.md },
-  summaryLink: { color: theme.colors.text.inverse, fontSize: 14, fontWeight: '600', textAlign: 'right' },
+  summaryLinkButton: { alignSelf: 'flex-end', marginTop: theme.spacing.xs },
+  summaryLinkText: { color: theme.colors.text.inverse, fontSize: 14, fontWeight: '600' },
   captureButton: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.lg, padding: theme.spacing.lg, flexDirection: 'row', alignItems: 'center', marginBottom: theme.spacing.lg, borderWidth: 2, borderColor: theme.colors.primary, borderStyle: 'dashed' },
   captureButtonDisabled: { borderColor: theme.colors.border, backgroundColor: theme.colors.semantic.disabled.bg },
   iconCircle: { width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.primary, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
@@ -270,19 +299,12 @@ const styles = StyleSheet.create({
   
   // ★ メニュー部分を Grid (flexWrap) 対応に変更
   gridContainer: { flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.md, marginBottom: theme.spacing.md },
-  gridCard: { flexGrow: 1, minWidth: 100, flexBasis: '30%', backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.lg, alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border },
-  
-  menuLabel: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text.main },
+  gridCard: { flexGrow: 1, minWidth: 100, flexBasis: '30%' },
+  gridEmoji: { fontSize: 28 },
   section: { marginTop: theme.spacing.lg },
   sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.sm },
-  settingsCard: { flexDirection: 'row', alignItems: 'center', backgroundColor: theme.colors.surface, padding: theme.spacing.md, borderRadius: theme.borderRadius.md, borderWidth: 1, borderColor: theme.colors.border, marginBottom: theme.spacing.md },
   settingsIconWrapper: { width: 36, height: 36, borderRadius: 18, backgroundColor: theme.colors.background, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
-  settingsTextWrapper: { flex: 1 },
-  settingsLabel: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text.main },
-  arrowIcon: { fontSize: 20, color: theme.colors.text.muted },
-  latestCard: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.md, padding: theme.spacing.md, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderColor: theme.colors.border },
-  cardInfo: { flex: 1 },
-  storeName: { ...theme.typography.body, fontWeight: '700', color: theme.colors.text.main },
+  latestCard: { marginBottom: 0 },
+  amountText: { ...theme.typography.h2, color: theme.colors.primary, fontWeight: 'bold' },
   dateText: { ...theme.typography.caption, color: theme.colors.text.muted },
-  amountText: { ...theme.typography.h2, color: theme.colors.primary }
 });

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { AppButton, AppListItem } from '../components/ui';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
+import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 
 const { width: windowWidth } = Dimensions.get('window');
 
@@ -48,7 +49,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const currentMonth = new Date().toISOString().slice(0, 7);
+      const currentMonth = getCurrentYearMonth();
       const [latestRes, statsRes] = await Promise.all([
         apiClient.get('/receipts/latest', { params: { memberId: currentMemberId } }),
         apiClient.get('/stats/monthly', { params: { month: currentMonth } })
@@ -175,7 +176,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           <AppButton
             title="統計の詳細を見る ›"
             onPress={onGoToStats}
-            variant="ghost"
+            variant="outline"
             size="sm"
             style={styles.summaryLinkButton}
             textStyle={styles.summaryLinkText}
@@ -289,7 +290,12 @@ const styles = StyleSheet.create({
   summarySymbol: { color: theme.colors.text.inverse, fontSize: 20, marginRight: 4, fontWeight: 'bold' },
   summaryAmount: { color: theme.colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
   summaryDivider: { height: 1, backgroundColor: 'rgba(255,255,255,0.2)', marginVertical: theme.spacing.md },
-  summaryLinkButton: { alignSelf: 'flex-end', marginTop: theme.spacing.xs },
+  summaryLinkButton: {
+    alignSelf: 'flex-end',
+    marginTop: theme.spacing.xs,
+    backgroundColor: 'transparent',
+    borderColor: 'rgba(255,255,255,0.7)',
+  },
   summaryLinkText: { color: theme.colors.text.inverse, fontSize: 14, fontWeight: '600' },
   captureButton: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.lg, padding: theme.spacing.lg, flexDirection: 'row', alignItems: 'center', marginBottom: theme.spacing.lg, borderWidth: 2, borderColor: theme.colors.primary, borderStyle: 'dashed' },
   captureButtonDisabled: { borderColor: theme.colors.border, backgroundColor: theme.colors.semantic.disabled.bg },

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert, ActivityIndicator, Platform } from 'react-native';
+import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
@@ -171,9 +171,12 @@ export const ProductMasterScreen = ({
       <View style={styles.header}>
         <AppBackButton onPress={onBack} />
         <Text style={styles.title}>学習マスタ ({currentMemberId === 1 ? '個人' : 'その他'})</Text>
-        <TouchableOpacity onPress={handleMergeStores}>
-          <Text style={styles.mergeText}>店舗統合</Text>
-        </TouchableOpacity>
+        <AppButton
+          title="店舗統合"
+          onPress={handleMergeStores}
+          variant="ghost"
+          size="sm"
+        />
       </View>
 
       <View style={styles.searchBar}>
@@ -221,7 +224,6 @@ const styles = StyleSheet.create({
     borderBottomColor: theme.colors.border 
   },
   title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1, textAlign: 'center' },
-  mergeText: { color: theme.colors.secondary, fontWeight: 'bold' },
   searchBar: { padding: 10, flexDirection: 'row', gap: 10, backgroundColor: theme.colors.surface },
   searchInput: { flex: 1 },
   listContent: { paddingHorizontal: 15, paddingBottom: 40 },

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   StyleSheet,
   ScrollView,
-  TextInput,
   TouchableOpacity,
   ActivityIndicator,
   Alert,
@@ -13,9 +12,9 @@ import {
   Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppButton } from '../components/ui';
+import { AppBackButton, AppButton, AppFormField, AppSelect, AppTextInput } from '../components/ui';
+import { modalStyles } from '../theme';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
@@ -69,6 +68,11 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
     ...initialData.parsedData,
     taxAmount: initialData.parsedData.taxAmount ?? '0',
   });
+
+  const categorySelectOptions = useMemo(
+    () => categories.map((c) => ({ label: c.name, value: c.id })),
+    [categories]
+  );
 
   const imageUri = useMemo(() => {
     if (!initialData.imagePath) return null;
@@ -176,29 +180,32 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
 
           <View style={styles.card}>
             <Text style={styles.sectionLabel}>基本情報</Text>
-            <TextInput 
-              style={styles.input} 
-              value={receiptData.storeName} 
-              onChangeText={(val) => setReceiptData({...receiptData, storeName: val})} 
-              placeholder="店舗名" 
-            />
-            <TextInput 
-              style={styles.input} 
-              value={receiptData.purchaseDate} 
-              onChangeText={(val) => setReceiptData({...receiptData, purchaseDate: val})} 
-              placeholder="購入日時 (YYYY-MM-DD HH:mm)" 
-            />
-            
-            {/* [Issue #71] 消費税(外税)入力フィールド */}
-            <View style={styles.taxInputRow}>
-              <Text style={styles.taxLabel}>消費税 (外税・加算額)</Text>
-              <TextInput 
-                style={styles.taxInput} 
-                value={String(receiptData.taxAmount)} 
-                keyboardType="decimal-pad"
-                onChangeText={(val) => setReceiptData({...receiptData, taxAmount: val})} 
+            <AppFormField label="店舗名">
+              <AppTextInput
+                value={receiptData.storeName}
+                onChangeText={(val) => setReceiptData({ ...receiptData, storeName: val })}
+                placeholder="店舗名"
               />
-            </View>
+            </AppFormField>
+            <AppFormField label="購入日時">
+              <AppTextInput
+                value={receiptData.purchaseDate}
+                onChangeText={(val) => setReceiptData({ ...receiptData, purchaseDate: val })}
+                placeholder="YYYY-MM-DD HH:mm"
+              />
+            </AppFormField>
+
+            <AppFormField label="消費税 (外税・加算額)">
+              <View style={modalStyles.inputWithUnit}>
+                <AppTextInput
+                  variant="inline"
+                  value={String(receiptData.taxAmount)}
+                  keyboardType="decimal-pad"
+                  onChangeText={(val) => setReceiptData({ ...receiptData, taxAmount: val })}
+                />
+                <Text style={modalStyles.unitSuffix}>円</Text>
+              </View>
+            </AppFormField>
 
             <View style={styles.totalDisplay}>
               <Text style={styles.totalLabel}>支払合計 (税込)</Text>
@@ -219,10 +226,11 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
           {receiptData.items.map((item, idx) => (
             <View key={idx} style={styles.itemCard}>
               <View style={styles.itemHeaderRow}>
-                <TextInput 
-                  style={styles.itemNameInput} 
-                  value={item.name} 
-                  onChangeText={(val) => updateItem(idx, 'name', val)} 
+                <AppTextInput
+                  style={styles.itemNameInput}
+                  value={item.name}
+                  onChangeText={(val) => updateItem(idx, 'name', val)}
+                  placeholder="商品名"
                 />
                 <TouchableOpacity onPress={() => removeItem(idx)}>
                   <Text style={styles.deleteIcon}>🗑️</Text>
@@ -232,20 +240,18 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
               <View style={styles.itemDetailRow}>
                 <View style={styles.itemSubGroup}>
                   <Text style={styles.subLabel}>単価 (¥)</Text>
-                  <TextInput 
-                    style={styles.inputSmall} 
-                    value={String(item.price)} 
-                    keyboardType="decimal-pad" 
-                    onChangeText={(val) => updateItem(idx, 'price', val)} 
+                  <AppTextInput
+                    value={String(item.price)}
+                    keyboardType="decimal-pad"
+                    onChangeText={(val) => updateItem(idx, 'price', val)}
                   />
                 </View>
                 <View style={[styles.itemSubGroup, { flex: 0.6 }]}>
                   <Text style={styles.subLabel}>数量</Text>
-                  <TextInput 
-                    style={styles.inputSmall} 
-                    value={String(item.quantity)} 
-                    keyboardType="decimal-pad" 
-                    onChangeText={(val) => updateItem(idx, 'quantity', val)} 
+                  <AppTextInput
+                    value={String(item.quantity)}
+                    keyboardType="decimal-pad"
+                    onChangeText={(val) => updateItem(idx, 'quantity', val)}
                   />
                 </View>
                 <View style={[styles.itemSubGroup, { alignItems: 'flex-end' }]}>
@@ -256,22 +262,14 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
                 </View>
               </View>
 
-              <View style={styles.categoryRow}>
-                <Text style={styles.subLabel}>カテゴリ</Text>
-                <View style={styles.pickerWrapper}>
-                  <Picker
-                    selectedValue={item.categoryId}
-                    onValueChange={(val) => updateItem(idx, 'categoryId', val)}
-                    style={styles.picker}
-                    mode="dropdown"
-                  >
-                    <Picker.Item label="未選択" value={null} color={theme.colors.semantic.picker.muted} />
-                    {categories.map(c => (
-                      <Picker.Item key={c.id} label={c.name} value={c.id} color={theme.colors.semantic.picker.text} />
-                    ))}
-                  </Picker>
-                </View>
-              </View>
+              <AppFormField label="カテゴリ">
+                <AppSelect<number | null>
+                  selectedValue={item.categoryId}
+                  onValueChange={(val) => updateItem(idx, 'categoryId', val)}
+                  options={categorySelectOptions}
+                  placeholder="未選択"
+                />
+              </AppFormField>
             </View>
           ))}
           <View style={{ height: 60 }} />
@@ -301,43 +299,16 @@ const styles = StyleSheet.create({
   imageLabelText: { color: c.text.inverse, fontSize: 10, fontWeight: 'bold' },
   card: { backgroundColor: c.surface, margin: theme.spacing.md, marginTop: 0, borderRadius: theme.spacing.md, padding: theme.spacing.md, elevation: 2 },
   sectionLabel: { fontSize: 12, fontWeight: 'bold', color: s.textMuted, textTransform: 'uppercase', marginBottom: 12 },
-  input: { borderBottomWidth: 1, borderBottomColor: s.borderInput, paddingVertical: 8, fontSize: 16, color: s.textBody, marginBottom: 12 },
-  taxInputRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12, paddingVertical: 4 },
-  taxLabel: { fontSize: 14, color: s.textSub },
-  taxInput: { borderBottomWidth: 1, borderBottomColor: c.primary, fontSize: 16, color: c.primary, fontWeight: 'bold', minWidth: 80, textAlign: 'right' },
   totalDisplay: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 8, paddingTop: theme.spacing.md, borderTopWidth: 1, borderTopColor: s.borderInput },
   totalLabel: { fontSize: 14, color: s.textSecondary },
   totalValue: { fontSize: 24, fontWeight: 'bold', color: c.primary },
   itemsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginHorizontal: theme.spacing.md, marginBottom: 12 },
   itemCard: { backgroundColor: c.surface, marginHorizontal: theme.spacing.md, marginBottom: 12, borderRadius: theme.spacing.md, padding: theme.spacing.md, borderLeftWidth: 4, borderLeftColor: c.primary, elevation: 1 },
   itemHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
-  itemNameInput: { flex: 1, fontSize: 15, fontWeight: 'bold', color: s.textBody },
+  itemNameInput: { flex: 1, marginRight: 8 },
   deleteIcon: { fontSize: 18, color: s.deleteIcon },
   itemDetailRow: { flexDirection: 'row', gap: 12, alignItems: 'center', marginBottom: 12 },
   itemSubGroup: { flex: 1 },
   subLabel: { fontSize: 10, color: s.textMuted, fontWeight: 'bold', marginBottom: 4 },
-  inputSmall: { borderBottomWidth: 1, borderBottomColor: s.borderInput, paddingVertical: 4, fontSize: 14, color: s.textItem, fontWeight: '600' },
   subTotalText: { fontSize: 14, fontWeight: '700', color: s.textItem, paddingTop: 4 },
-  categoryRow: { borderTopWidth: 1, borderTopColor: s.background, paddingTop: theme.spacing.sm },
-  pickerWrapper: {
-    borderWidth: 1,
-    borderColor: s.borderInput,
-    borderRadius: theme.borderRadius.sm,
-    backgroundColor: s.pickerBg,
-    height: 55,
-    justifyContent: 'center',
-    marginTop: 4,
-    overflow: 'visible',
-  },
-  picker: {
-    width: '100%',
-    height: 55,
-    color: theme.colors.semantic.picker.text,
-    ...Platform.select({
-      android: {
-        marginLeft: -10,
-      },
-    }),
-  },
-  headerButton: { padding: 4 },
 });

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -4,7 +4,6 @@ import {
   Text, 
   View, 
   ScrollView, 
-  TouchableOpacity, 
   ActivityIndicator, 
   useWindowDimensions,
   Alert

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -20,6 +20,7 @@ import {
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
+import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 
 interface SettlementSummaryScreenProps {
   onBack: () => void;
@@ -30,7 +31,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   const isWide = width >= BREAKPOINTS.TABLET;
 
   const [loading, setLoading] = useState(true);
-  const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
   const [summaryData, setSummaryData] = useState<any[]>([]);
 
   // 送金モーダル用ステート
@@ -46,13 +47,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   }>({});
 
   // 過去6ヶ月の選択肢を生成
-  const months = useMemo(() => {
-    return Array.from({ length: 6 }).map((_, i) => {
-      const d = new Date();
-      d.setMonth(d.getMonth() - i);
-      return d.toISOString().slice(0, 7);
-    });
-  }, []);
+  const months = useMemo(() => getRecentYearMonths(6), []);
 
   const memberSelectOptions = useMemo(
     () =>
@@ -63,14 +58,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
     [summaryData]
   );
 
-  const monthSelectOptions = useMemo(
-    () =>
-      months.map((m) => ({
-        label: `${m.split('-')[0]}年${m.split('-')[1]}月`,
-        value: m,
-      })),
-    [months]
-  );
+  const monthSelectOptions = useMonthSelectOptions(months, isWide);
 
   const openTransferModal = () => {
     setTransferFieldErrors({});
@@ -152,27 +140,49 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   return (
     <View style={styles.container}>
       {/* ヘッダー */}
-      <View style={styles.header}>
-        <AppBackButton onPress={onBack} />
-        <Text style={styles.headerTitle}>家族間精算サマリー</Text>
-        <View style={styles.headerRight}>
+      {isWide ? (
+        <View style={styles.header}>
+          <AppBackButton onPress={onBack} />
+          <Text style={styles.headerTitle}>家族間精算サマリー</Text>
+          <View style={styles.headerRight}>
+            <View style={styles.monthPickerContainerWide}>
+              <AppSelect<string>
+                selectedValue={selectedMonth}
+                onValueChange={setSelectedMonth}
+                options={monthSelectOptions}
+                includePlaceholder={false}
+              />
+            </View>
+            <AppButton
+              title={`＋ ${BUTTON_LABELS.recordTransfer}`}
+              onPress={openTransferModal}
+              size="sm"
+              style={styles.addTransferButton}
+            />
+          </View>
+        </View>
+      ) : (
+        <View style={[styles.header, styles.headerMobile]}>
+          <View style={styles.headerTopRow}>
+            <AppBackButton onPress={onBack} />
+            <Text style={styles.headerTitleMobile}>家族間精算サマリー</Text>
+          </View>
+          <View style={styles.monthPickerContainerMobile}>
+            <AppSelect<string>
+              selectedValue={selectedMonth}
+              onValueChange={setSelectedMonth}
+              options={monthSelectOptions}
+              includePlaceholder={false}
+            />
+          </View>
           <AppButton
             title={`＋ ${BUTTON_LABELS.recordTransfer}`}
             onPress={openTransferModal}
             size="sm"
             style={styles.addTransferButton}
           />
-          <View style={styles.monthPickerContainer}>
-            <AppSelect<string>
-              selectedValue={selectedMonth}
-              onValueChange={setSelectedMonth}
-              options={monthSelectOptions}
-              includePlaceholder={false}
-              style={styles.monthSelect}
-            />
-          </View>
         </View>
-      </View>
+      )}
 
       {loading ? (
         <View style={styles.centerLoading}>
@@ -362,12 +372,24 @@ const sem = theme.colors.semantic;
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, backgroundColor: theme.colors.surface, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: theme.colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    gap: 12,
+  },
+  headerMobile: { flexDirection: 'column', alignItems: 'stretch', gap: 10 },
+  headerTopRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
-  headerRight: { flexDirection: 'row', alignItems: 'center', gap: 15 },
+  headerTitleMobile: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1 },
+  headerRight: { flexDirection: 'row', alignItems: 'center', gap: 12, flexShrink: 0 },
   addTransferButton: { paddingHorizontal: 4 },
-  monthPickerContainer: { width: 140, justifyContent: 'center' },
-  monthSelect: { minHeight: 36 },
+  monthPickerContainerMobile: { width: '100%' },
+  monthPickerContainerWide: { width: 140, justifyContent: 'center' },
   scrollContainer: { flex: 1 },
   scrollContent: { padding: 20, paddingBottom: 40 },
   rowLayout: { flexDirection: 'row' },

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -325,7 +325,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
             onPress={handleSave}
             loading={saving}
             disabled={saving}
-            size="md"
+            size="sm"
           />
         </View>
       </View>

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -16,9 +16,9 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
-import { Picker } from '@react-native-picker/picker';
 import apiClient from '../utils/apiClient';
-import { AppBackButton, AppModalCloseButton } from '../components/ui';
+import { toMonthSelectOptions } from '../utils/monthSelectOptions';
+import { AppBackButton, AppModalCloseButton, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -84,6 +84,11 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       return d.toISOString().slice(0, 7);
     });
   }, []);
+
+  const monthSelectOptions = useMemo(
+    () => toMonthSelectOptions(monthOptions),
+    [monthOptions]
+  );
 
   const fetchData = useCallback(async () => {
     if (!currentMemberId) return;
@@ -170,12 +175,14 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.topInfo}>
           <Text style={styles.headerSubtitle}>{currentMemberId === 1 ? 'PERSONAL REPORT' : 'FAMILY REPORT'}</Text>
-          <View style={[styles.monthPickerContainer, isWide && { width: 300 }]}>
-            <Picker selectedValue={selectedMonth} onValueChange={(val) => setSelectedMonth(val)} style={styles.monthPicker}>
-              {monthOptions.map(m => (
-                <Picker.Item key={m} label={`${m.split('-')[0]}年${m.split('-')[1]}月`} value={m} />
-              ))}
-            </Picker>
+          <View style={[styles.monthPickerContainer, isWide && styles.monthPickerContainerWide]}>
+            <AppSelect<string>
+              selectedValue={selectedMonth}
+              onValueChange={setSelectedMonth}
+              options={monthSelectOptions}
+              includePlaceholder={false}
+              style={styles.monthSelect}
+            />
           </View>
         </View>
         
@@ -314,8 +321,9 @@ const styles = StyleSheet.create({
   scrollContent: { padding: 20 },
   topInfo: { marginBottom: 15 },
   headerSubtitle: { fontSize: 10, color: theme.colors.text.muted, letterSpacing: 1 },
-  monthPickerContainer: { backgroundColor: theme.colors.surface, borderRadius: 10, marginTop: 8, borderWidth: 1, borderColor: theme.colors.border, height: 50, justifyContent: 'center' },
-  monthPicker: { width: '100%' },
+  monthPickerContainer: { width: 140, marginTop: 8, justifyContent: 'center' },
+  monthPickerContainerWide: { width: 180 },
+  monthSelect: { minHeight: 36 },
   dashboardGrid: { flexDirection: 'row', justifyContent: 'space-between' },
   leftColumn: { flex: 1.2, marginRight: 20 },
   rightColumn: { flex: 1 },

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -3,22 +3,19 @@ import {
   View, 
   Text, 
   StyleSheet, 
-  Dimensions, 
   ScrollView, 
   ActivityIndicator, 
   Image, 
   TouchableOpacity, 
-  Modal, 
   Alert, 
   FlatList, 
   useWindowDimensions, 
-  Platform 
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import apiClient from '../utils/apiClient';
 import { toMonthSelectOptions } from '../utils/monthSelectOptions';
-import { AppBackButton, AppModalCloseButton, AppSelect } from '../components/ui';
+import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
@@ -290,26 +287,22 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         )}
       </ScrollView>
 
-      {/* 解析レシート詳細 Modal */}
-      <Modal visible={isMainModalVisible} animationType="slide" transparent={isWide} onRequestClose={() => setMainModalVisible(false)}>
-        <View style={isWide ? styles.modalOverlay : styles.modalContainer}>
-          <SafeAreaView style={[styles.modalContainer, isWide && styles.wideModal]}>
-            <View style={styles.modalHeader}>
-              <Text style={styles.modalTitle}>解析レシート詳細</Text>
-              <AppModalCloseButton onPress={() => setMainModalVisible(false)} />
-            </View>
-            
-            <ReceiptDetailComponent 
-              receipt={data?.latestReceipt}
-              categories={allCategories}
-              onCategoryChange={handleCategoryChange}
-              baseUrl={BASE_URL}
-              fullWidth={true}
-              onSaveSuccess={fetchData} 
-            />
-          </SafeAreaView>
-        </View>
-      </Modal>
+      <AppModal
+        visible={isMainModalVisible}
+        onRequestClose={() => setMainModalVisible(false)}
+        variant="sheet"
+        sheetPresentation={isWide ? 'wide' : 'fullscreen'}
+        title="解析レシート詳細"
+      >
+        <ReceiptDetailComponent
+          receipt={data?.latestReceipt}
+          categories={allCategories}
+          onCategoryChange={handleCategoryChange}
+          baseUrl={BASE_URL}
+          fullWidth={true}
+          onSaveSuccess={fetchData}
+        />
+      </AppModal>
     </SafeAreaView>
   );
 };
@@ -356,9 +349,4 @@ const styles = StyleSheet.create({
   receiptAmount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary, minWidth: 80, textAlign: 'right' },
   taxSubText: { fontSize: 11, color: theme.colors.text.muted, marginTop: 2 },
   noImageBox: { height: 100, backgroundColor: theme.colors.border, borderRadius: 12, justifyContent: 'center', alignItems: 'center' },
-  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'center', alignItems: 'center' },
-  modalContainer: { flex: 1, backgroundColor: theme.colors.background },
-  wideModal: { width: '95%', maxWidth: 1400, height: '90%', borderRadius: 20, overflow: 'hidden' },
-  modalHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, borderBottomWidth: 1, borderBottomColor: theme.colors.border },
-  modalTitle: { fontSize: 18, fontWeight: 'bold' },
 });

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -14,7 +14,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PieChart } from 'react-native-chart-kit';
 import apiClient from '../utils/apiClient';
-import { toMonthSelectOptions } from '../utils/monthSelectOptions';
+import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
@@ -64,7 +64,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const isWide = windowWidth > 768;
 
   const [loading, setLoading] = useState(true);
-  const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
   const [data, setData] = useState<MonthlyData | null>(null);
   const [advancedData, setAdvancedData] = useState<AdvancedStats | null>(null);
   const [allCategories, setAllCategories] = useState<Category[]>([]);
@@ -74,18 +74,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
 
-  const monthOptions = useMemo(() => {
-    return Array.from({ length: 12 }).map((_, i) => {
-      const d = new Date();
-      d.setMonth(d.getMonth() - i);
-      return d.toISOString().slice(0, 7);
-    });
-  }, []);
+  const monthOptions = useMemo(() => getRecentYearMonths(12), []);
 
-  const monthSelectOptions = useMemo(
-    () => toMonthSelectOptions(monthOptions),
-    [monthOptions]
-  );
+  const monthSelectOptions = useMonthSelectOptions(monthOptions, isWide);
 
   const fetchData = useCallback(async () => {
     if (!currentMemberId) return;
@@ -172,13 +163,12 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.topInfo}>
           <Text style={styles.headerSubtitle}>{currentMemberId === 1 ? 'PERSONAL REPORT' : 'FAMILY REPORT'}</Text>
-          <View style={[styles.monthPickerContainer, isWide && styles.monthPickerContainerWide]}>
+          <View style={[styles.monthPickerContainer, isWide ? styles.monthPickerContainerWide : styles.monthPickerContainerMobile]}>
             <AppSelect<string>
               selectedValue={selectedMonth}
               onValueChange={setSelectedMonth}
               options={monthSelectOptions}
               includePlaceholder={false}
-              style={styles.monthSelect}
             />
           </View>
         </View>
@@ -314,9 +304,9 @@ const styles = StyleSheet.create({
   scrollContent: { padding: 20 },
   topInfo: { marginBottom: 15 },
   headerSubtitle: { fontSize: 10, color: theme.colors.text.muted, letterSpacing: 1 },
-  monthPickerContainer: { width: 140, marginTop: 8, justifyContent: 'center' },
+  monthPickerContainer: { marginTop: 8, justifyContent: 'center' },
+  monthPickerContainerMobile: { width: '100%', alignSelf: 'stretch' },
   monthPickerContainerWide: { width: 180 },
-  monthSelect: { minHeight: 36 },
   dashboardGrid: { flexDirection: 'row', justifyContent: 'space-between' },
   leftColumn: { flex: 1.2, marginRight: 20 },
   rightColumn: { flex: 1 },

--- a/frontend/src/theme/modalStyles.ts
+++ b/frontend/src/theme/modalStyles.ts
@@ -91,4 +91,46 @@ export const modalStyles = StyleSheet.create({
     color: colors.text.main,
     ...Platform.select({ web: { outlineStyle: 'none' } as object }),
   },
+  /** フルスクリーン sheet（履歴詳細等） */
+  sheetContainer: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  sheetOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  sheetWide: {
+    width: '95%',
+    maxWidth: 1400,
+    height: '90%',
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.md,
+    overflow: 'hidden',
+    ...Platform.select({
+      android: { elevation: 8 },
+      default: {},
+    }),
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  sheetHeaderTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text.main,
+    marginRight: spacing.sm,
+  },
+  sheetBody: {
+    flex: 1,
+  },
 });

--- a/frontend/src/theme/modalStyles.ts
+++ b/frontend/src/theme/modalStyles.ts
@@ -55,16 +55,73 @@ export const modalStyles = StyleSheet.create({
     backgroundColor: colors.surface,
     minHeight: 40,
     justifyContent: 'center',
-    overflow: 'hidden',
+    paddingHorizontal: spacing.sm,
+    ...Platform.select({
+      android: { overflow: 'visible' as const },
+      ios: { overflow: 'visible' as const },
+      default: { overflow: 'hidden' as const },
+    }),
   },
   selectWrapperError: {
     borderColor: colors.error,
     backgroundColor: colors.semantic.deficit.bg,
   },
-  selectPicker: {
-    width: '100%',
-    height: 40,
-    ...Platform.select({ web: { outlineStyle: 'none', border: 'none' } as object }),
+  /** ネイティブ: タップで開く選択 UI（Picker の文字切れ回避） */
+  selectTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 44,
+    paddingVertical: spacing.xs,
+  },
+  selectTriggerText: {
+    flex: 1,
+    fontSize: 14,
+    color: colors.text.main,
+    marginRight: spacing.sm,
+  },
+  selectChevron: {
+    fontSize: 10,
+    color: colors.text.muted,
+  },
+  selectOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'flex-end',
+  },
+  selectSheet: {
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: borderRadius.md,
+    borderTopRightRadius: borderRadius.md,
+    maxHeight: '55%',
+    paddingBottom: spacing.lg,
+    ...Platform.select({
+      android: { elevation: 8 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: -2 },
+        shadowOpacity: 0.12,
+        shadowRadius: 8,
+      },
+      default: {},
+    }),
+  },
+  selectOptionRow: {
+    paddingVertical: 14,
+    paddingHorizontal: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  selectOptionRowSelected: {
+    backgroundColor: colors.semantic.active.bg,
+  },
+  selectOptionText: {
+    fontSize: 16,
+    color: colors.text.main,
+  },
+  selectOptionTextSelected: {
+    color: colors.primary,
+    fontWeight: '600',
   },
   inputWithUnit: {
     flexDirection: 'row',
@@ -86,8 +143,8 @@ export const modalStyles = StyleSheet.create({
     height: 40,
     borderWidth: 0,
     backgroundColor: 'transparent',
-    paddingLeft: spacing.sm,
-    fontSize: 14,
+    paddingLeft: spacing.xs,
+    fontSize: 13,
     color: colors.text.main,
     ...Platform.select({ web: { outlineStyle: 'none' } as object }),
   },

--- a/frontend/src/utils/monthSelectOptions.ts
+++ b/frontend/src/utils/monthSelectOptions.ts
@@ -1,8 +1,59 @@
-/** YYYY-MM → 「2026年05月」形式（月選択 AppSelect 用） */
-export const formatMonthLabel = (yearMonth: string): string => {
-  const [y, m] = yearMonth.split('-');
-  return `${y}年${m}月`;
+import { useMemo } from 'react';
+
+/** ローカルタイムゾーンで YYYY-MM（toISOString は UTC で月がずれる・重複する） */
+export const formatYearMonthLocal = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  return `${y}-${String(m).padStart(2, '0')}`;
 };
 
-export const toMonthSelectOptions = (months: string[]) =>
-  months.map((m) => ({ label: formatMonthLabel(m), value: m }));
+export const getCurrentYearMonth = (): string => formatYearMonthLocal(new Date());
+
+/** 直近 count ヶ月分（重複なし・古い順ではなく新しい順） */
+export const getRecentYearMonths = (count: number): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const now = new Date();
+  for (let i = 0; i < count; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const ym = formatYearMonthLocal(d);
+    if (!seen.has(ym)) {
+      seen.add(ym);
+      result.push(ym);
+    }
+  }
+  return result;
+};
+
+/** YYYY-MM → 「2026年05月」（ワイド画面・Web 向け） */
+export const formatMonthLabel = (yearMonth: string): string => {
+  const [y, m] = yearMonth.split('-');
+  const monthNum = parseInt(m, 10);
+  return `${y}年${monthNum}月`;
+};
+
+/** YYYY-MM → 「2026/5」（狭い Picker 向け・横スクロール切れ防止） */
+export const formatMonthLabelCompact = (yearMonth: string): string => {
+  const [y, m] = yearMonth.split('-');
+  const monthNum = parseInt(m, 10);
+  return `${y}/${monthNum}`;
+};
+
+export type MonthLabelStyle = 'full' | 'compact';
+
+export const toMonthSelectOptions = (
+  months: string[],
+  labelStyle: MonthLabelStyle = 'full'
+) =>
+  months.map((m) => ({
+    label: labelStyle === 'compact' ? formatMonthLabelCompact(m) : formatMonthLabel(m),
+    value: m,
+  }));
+
+/** 狭い画面では compact ラベル（例: 2026/5） */
+export function useMonthSelectOptions(months: string[], isWide: boolean) {
+  return useMemo(
+    () => toMonthSelectOptions(months, isWide ? 'full' : 'compact'),
+    [months, isWide]
+  );
+}

--- a/frontend/src/utils/monthSelectOptions.ts
+++ b/frontend/src/utils/monthSelectOptions.ts
@@ -1,0 +1,8 @@
+/** YYYY-MM → 「2026年05月」形式（月選択 AppSelect 用） */
+export const formatMonthLabel = (yearMonth: string): string => {
+  const [y, m] = yearMonth.split('-');
+  return `${y}年${m}月`;
+};
+
+export const toMonthSelectOptions = (months: string[]) =>
+  months.map((m) => ({ label: formatMonthLabel(m), value: m }));


### PR DESCRIPTION
## Summary

- Issue #86: 月選択の `AppSelect` 統一、ReceiptDetail / ReceiptScan フォーム共通化、履歴・統計の詳細モーダル（sheet）、Home / ProductMaster / AdminStats のナビ・ボタン統一
- 動確で判明した表示不具合を修正: ネイティブ `AppSelect` をタップ式ボトムシートに変更（文字切れ解消）、月リストをローカル TZ で生成（UTC 重複・React key エラー解消）、履歴フィルタのスマホ縦並び、精算サマリーヘッダー、ホーム統計リンク、割り勘エディタ保存ボタンサイズ

## Commits

- PR-1: 月選択を AppSelect に統一（統計・履歴）
- PR-2: ReceiptDetail・ReceiptScan のフォーム共通化
- PR-3: AppModal sheet variant と履歴・統計の詳細モーダル統一
- PR-4: Home・ProductMaster・AdminStats のナビ・ボタン統一
- fix: スマホ AppSelect・月選択・各画面レイアウトの表示修正

Closes #252

## Test plan

- [ ] ホーム: 「統計の詳細を見る」ボタンが青カード上で読める
- [ ] 履歴（スマホ）: 月・メンバーコンボが縦並びで表示・選択でき、エラーが出ない
- [ ] 家計分析（スマホ）: 月コンボの表示・選択
- [ ] レシート詳細 / 解析確認: カテゴリコンボの表示・選択
- [ ] 精算サマリー（PC）: タイトルが横1行、月選択・送金ボタンが並ぶ
- [ ] 割り勘エディタ: 保存ボタンサイズ
- [ ] Web: 各画面の `<select>` が従来どおり動作する


Made with [Cursor](https://cursor.com)