### PR TITLE
fix: [Issue #87-0] Category シーケンス修復とカテゴリー管理 UI 修正

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "backend:dev": "ts-node-dev --respawn src/server.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:seed": "prisma db seed"
+    "prisma:seed": "prisma db seed",
+    "prisma:sync-sequences": "npx tsx prisma/run-sync-sequences.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/backend/prisma/run-sync-sequences.ts
+++ b/backend/prisma/run-sync-sequences.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+import { syncAllSeedTableSequences } from './syncSequences';
+
+const prisma = new PrismaClient();
+
+syncAllSeedTableSequences(prisma)
+  .catch((e) => {
+    console.error('❌ Sequence sync failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { syncAllSeedTableSequences } from './syncSequences';
 
 const prisma = new PrismaClient();
 
@@ -59,6 +60,9 @@ async function main() {
   for (const c of categories) {
     await prisma.category.create({ data: c });
   }
+
+  // 明示 id 投入後は PostgreSQL の serial を同期（未同期だと Category 追加で id 重複）
+  await syncAllSeedTableSequences(prisma);
 
   // 4. 店舗正規化マスタ
   const stores = [

--- a/backend/prisma/syncSequences.ts
+++ b/backend/prisma/syncSequences.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from '@prisma/client';
+
+/** seed / upsert で明示 id を入れたあと、PostgreSQL の serial を MAX(id) に合わせる */
+const TABLES_WITH_EXPLICIT_SEED_IDS = [
+  'FamilyGroup',
+  'FamilyMember',
+  'Category',
+] as const;
+
+type SeedTable = (typeof TABLES_WITH_EXPLICIT_SEED_IDS)[number];
+
+/**
+ * 指定テーブルの id シーケンスを MAX(id) に同期する。
+ * 未同期のまま create() すると Unique constraint failed on (id) になる。
+ */
+export async function syncPostgresIdSequence(
+  prisma: PrismaClient,
+  tableName: SeedTable
+): Promise<void> {
+  await prisma.$executeRawUnsafe(`
+    SELECT setval(
+      pg_get_serial_sequence('"${tableName}"', 'id'),
+      COALESCE((SELECT MAX("id") FROM "${tableName}"), 1),
+      true
+    )
+  `);
+}
+
+export async function syncAllSeedTableSequences(prisma: PrismaClient): Promise<void> {
+  for (const table of TABLES_WITH_EXPLICIT_SEED_IDS) {
+    await syncPostgresIdSequence(prisma, table);
+  }
+  console.log(`✅ PostgreSQL id sequences synced: ${TABLES_WITH_EXPLICIT_SEED_IDS.join(', ')}`);
+}

--- a/backend/prisma/update-master.ts
+++ b/backend/prisma/update-master.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { syncPostgresIdSequence } from './syncSequences';
 
 const prisma = new PrismaClient();
 
@@ -23,6 +24,7 @@ async function main() {
   });
 
   console.log(`✅ Category updated: ${category9.name} (ID: ${category9.id})`);
+  await syncPostgresIdSequence(prisma, 'Category');
   console.log('--- 🚀 Master Data Update Completed ---');
 }
 

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prismaClient'; // テナント拡張済みのインスタンスを使用
 import { AppError } from '../utils/appError';
 import logger from '../utils/logger';
+import { pickNextCategoryColor } from '../utils/categoryColor';
 
 /**
  * 📂 カテゴリー一覧取得
@@ -32,11 +33,25 @@ export const createCategory = async (req: Request, res: Response, next: NextFunc
       return next(new AppError('Name is required', 400));
     }
 
+    const existing = await prisma.category.findMany({ select: { color: true } });
+    const existingColors = existing.map((c) => c.color);
+    const requested =
+      typeof color === 'string' && color.trim() ? color.trim() : '';
+    const isDuplicate =
+      requested &&
+      existingColors.some(
+        (c) => (c ?? '').trim().toLowerCase() === requested.toLowerCase()
+      );
+    const resolvedColor =
+      requested && !isDuplicate
+        ? requested
+        : pickNextCategoryColor(existingColors);
+
     const category = await prisma.category.create({
-      data: { 
-        name, 
-        color: color || '#2ecc71' 
-      }
+      data: {
+        name,
+        color: resolvedColor,
+      },
     });
 
     logger.info(`[CATEGORY] Created: ${name}`);

--- a/backend/src/utils/categoryColor.ts
+++ b/backend/src/utils/categoryColor.ts
@@ -1,0 +1,74 @@
+/** frontend/src/utils/categoryColor.ts と同期 */
+export const CATEGORY_COLOR_PALETTE = [
+  '#e74c3c',
+  '#3498db',
+  '#f59e0b',
+  '#10b981',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#f97316',
+  '#6366f1',
+  '#14b8a6',
+  '#84cc16',
+  '#a855f7',
+  '#795548',
+  '#64748b',
+  '#0d9488',
+  '#db2777',
+] as const;
+
+const normalizeHex = (color: string | null | undefined): string =>
+  (color ?? '').trim().toLowerCase();
+
+export function pickNextCategoryColor(
+  existingColors: (string | null | undefined)[]
+): string {
+  const used = new Set(
+    existingColors.map(normalizeHex).filter((c) => c.length > 0)
+  );
+
+  for (const candidate of CATEGORY_COLOR_PALETTE) {
+    if (!used.has(normalizeHex(candidate))) {
+      return candidate;
+    }
+  }
+
+  const hue = (used.size * 137.508) % 360;
+  return hslToHex(hue, 65, 45);
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+  const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lNorm - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  const toByte = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toByte(r)}${toByte(g)}${toByte(b)}`;
+}

--- a/docs/db-operations.md
+++ b/docs/db-operations.md
@@ -43,3 +43,30 @@
    ```bash
    # マスタのみ更新する場合
    docker compose exec backend npm run prisma:update
+   ```
+
+---
+
+## 5. トラブルシューティング: カテゴリー追加で `Unique constraint failed on (id)`
+
+### 原因
+
+`seed.ts` や `update-master.ts` で **明示的な `id`**（1〜9, 99 など）を投入すると、PostgreSQL の `Category_id_seq` が追従せず、次の `prisma.category.create()` が既存 id を採番して失敗します。
+
+### 対処（データを消さずに直す）
+
+```bash
+# backend コンテナ or ローカル backend ディレクトリで
+npm run prisma:sync-sequences
+```
+
+`FamilyGroup` / `FamilyMember` / `Category` の id シーケンスを `MAX(id)` に合わせます。
+
+### 再発防止
+
+- `npm run prisma:seed` 実行時は seed 内で自動同期されます。
+- `update-master.ts` 実行後も `Category` シーケンスを同期します。
+
+### 確認
+
+管理者メニュー → カテゴリー設定で新規追加が成功すること。

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -4,6 +4,7 @@ import apiClient from '../utils/apiClient';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
+import { pickNextCategoryColor } from '../utils/categoryColor';
 
 interface Category {
   id: number;
@@ -57,8 +58,10 @@ export const CategoryManagementScreen = ({
   const addCategory = async () => {
     if (!newName.trim() || !currentMemberId) return;
     try {
-      await apiClient.post('/categories', 
-        { name: newName, color: theme.colors.semantic.category.newDefault },
+      const color = pickNextCategoryColor(categories.map((c) => c.color));
+      await apiClient.post(
+        '/categories',
+        { name: newName, color },
         { headers: getHeaders() }
       );
       setNewName('');

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -5,6 +5,7 @@ import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } 
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { pickNextCategoryColor } from '../utils/categoryColor';
+import { showConfirmDialog } from '../utils/confirmDialog';
 
 interface Category {
   id: number;
@@ -71,48 +72,52 @@ export const CategoryManagementScreen = ({
     }
   };
 
-  const deleteCategory = async (id: number) => {
-    Alert.alert("削除の確認", "このカテゴリーを削除しますか？", [
-      { text: "キャンセル" },
-      { text: "削除", style: 'destructive', onPress: async () => {
+  const deleteCategory = (id: number) => {
+    showConfirmDialog('削除の確認', 'このカテゴリーを削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除',
+        style: 'destructive',
+        onPress: async () => {
           try {
             await apiClient.delete(`/categories/${id}`, { headers: getHeaders() });
             fetchCategories();
           } catch (e: any) {
             const status = e.response?.status;
             if (status === 400 || status === 409) {
-              Alert.alert("制限", "このカテゴリーは既に使用されているため削除できません。");
+              Alert.alert('制限', 'このカテゴリーは既に使用されているため削除できません。');
             } else {
-              Alert.alert("エラー", "削除に失敗しました。");
+              Alert.alert('エラー', '削除に失敗しました。');
             }
           }
-      }}
+        },
+      },
     ]);
   };
 
-  const handleOptimize = async () => {
-    Alert.alert(
-      "マスタ最適化",
-      "ProductMasterの統計に基づき、カテゴリーのキーワードを自動補強します。よろしいですか？",
+  const handleOptimize = () => {
+    showConfirmDialog(
+      'マスタ最適化',
+      'ProductMasterの統計に基づき、カテゴリーのキーワードを自動補強します。よろしいですか？',
       [
-        { text: "キャンセル", style: "cancel" },
-        { 
-          text: "実行", 
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '実行',
           onPress: async () => {
             setOptimizing(true);
             try {
               const res = await apiClient.post('/categories/optimize', {}, { headers: getHeaders() });
               if (res.data.success) {
-                Alert.alert("完了", res.data.data.message);
+                Alert.alert('完了', res.data.data.message);
                 fetchCategories();
               }
             } catch (e) {
-              Alert.alert("エラー", "最適化処理に失敗しました。");
+              Alert.alert('エラー', '最適化処理に失敗しました。');
             } finally {
               setOptimizing(false);
             }
-          }
-        }
+          },
+        },
       ]
     );
   };

--- a/frontend/src/utils/categoryColor.ts
+++ b/frontend/src/utils/categoryColor.ts
@@ -1,0 +1,75 @@
+/** カテゴリー用パレット（seed の色を含む。backend と同期すること） */
+export const CATEGORY_COLOR_PALETTE = [
+  '#e74c3c',
+  '#3498db',
+  '#f59e0b',
+  '#10b981',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#f97316',
+  '#6366f1',
+  '#14b8a6',
+  '#84cc16',
+  '#a855f7',
+  '#795548',
+  '#64748b',
+  '#0d9488',
+  '#db2777',
+] as const;
+
+const normalizeHex = (color: string | null | undefined): string =>
+  (color ?? '').trim().toLowerCase();
+
+/** 既存カテゴリーと異なる色をパレットから選ぶ。尽きたら色相をずらして生成 */
+export function pickNextCategoryColor(
+  existingColors: (string | null | undefined)[]
+): string {
+  const used = new Set(
+    existingColors.map(normalizeHex).filter((c) => c.length > 0)
+  );
+
+  for (const candidate of CATEGORY_COLOR_PALETTE) {
+    if (!used.has(normalizeHex(candidate))) {
+      return candidate;
+    }
+  }
+
+  const hue = (used.size * 137.508) % 360;
+  return hslToHex(hue, 65, 45);
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+  const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lNorm - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  const toByte = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toByte(r)}${toByte(g)}${toByte(b)}`;
+}

--- a/frontend/src/utils/confirmDialog.ts
+++ b/frontend/src/utils/confirmDialog.ts
@@ -1,0 +1,42 @@
+import { Alert, Platform } from 'react-native';
+
+export type ConfirmDialogButton = {
+  text: string;
+  style?: 'default' | 'cancel' | 'destructive';
+  onPress?: () => void | Promise<void>;
+};
+
+/**
+ * 確認ダイアログ。Web では Alert.alert のボタンが効かないため window.confirm を使う。
+ */
+export function showConfirmDialog(
+  title: string,
+  message: string,
+  buttons: ConfirmDialogButton[]
+): void {
+  if (Platform.OS === 'web') {
+    const cancelButton = buttons.find((b) => b.style === 'cancel');
+    const actionButton =
+      buttons.find((b) => b.style === 'destructive') ??
+      buttons.find((b) => b !== cancelButton && b.style !== 'cancel') ??
+      buttons[buttons.length - 1];
+
+    const confirmed = window.confirm(
+      message ? `${title}\n\n${message}` : title
+    );
+    if (confirmed && actionButton?.onPress) {
+      void Promise.resolve(actionButton.onPress());
+    }
+    return;
+  }
+
+  Alert.alert(
+    title,
+    message,
+    buttons.map((b) => ({
+      text: b.text,
+      style: b.style,
+      onPress: b.onPress,
+    }))
+  );
+}


### PR DESCRIPTION
## Summary

Issue #87 Epic の dev ブロッカー（#256）およびカテゴリー設定画面の動確で判明した不具合を修正しました。

- **DB:** seed / update-master 後に PostgreSQL の id シーケンスを `MAX(id)` に同期し、カテゴリー追加時の `Unique constraint failed on (id)` を解消
- **カテゴリー色:** 新規追加時に既存と重ならない色をパレットから自動割り当て（API でも重複色を差し替え）
- **Web UI:** 削除・最適化の確認ダイアログを `window.confirm` にフォールバック（`Alert.alert` が Web で効かない問題）

Closes #256

## Commits

1. seed 後の Category / FamilyGroup / FamilyMember シーケンス同期 + `npm run prisma:sync-sequences`
2. 新規カテゴリーの色自動割り当て
3. Web 削除・最適化確認ダイアログ

## Test plan

- [ ] `npm run prisma:sync-sequences`（backend）後、カテゴリー新規追加が成功する
- [ ] `prisma db seed` 後もカテゴリー追加が成功する
- [ ] 新規カテゴリーを複数追加し、一覧の色ドットが互いに異なる
- [ ] **Web:** カテゴリー削除で確認ダイアログ → OK で削除
- [ ] **Web:** キーワード自動最適化の確認ダイアログ
- [ ] **スマホ:** 削除・追加が従来どおり動作する


Made with [Cursor](https://cursor.com)