### PR TITLE
fix(backend): [Issue #87-2] 精算・按分 API の堅牢化と履歴の世帯全体フィルタ

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -6,6 +6,8 @@ import { getCleanText } from '../utils/normalizer';
 import { receiptQueue } from '../queues/receiptQueue';
 import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService'; 
 import { getFamilyGroupId, getMemberId } from '../utils/context';
+import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
+import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
 
 /**
  * [Issue #43] ジョブステータス取得
@@ -281,17 +283,29 @@ export const updateItemCategory = async (req: Request, res: Response, next: Next
  */
 export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const memberId = req.query.memberId || req.headers['x-member-id'];
     const { month } = req.query;
     const familyGroupId = getFamilyGroupId();
-    
+
     const where: any = { familyGroupId };
-    if (memberId) where.memberId = Number(memberId);
-    
-    if (typeof month === 'string' && month) {
-      const start = new Date(`${month}-01`);
-      const end = new Date(start);
-      end.setMonth(start.getMonth() + 1);
+
+    // 「世帯全体」は memberId="" → 世帯全件。空文字を x-member-id にフォールバックしない
+    const rawMemberId = req.query.memberId;
+    if (
+      rawMemberId !== undefined &&
+      rawMemberId !== null &&
+      String(rawMemberId).trim() !== ''
+    ) {
+      const filterMemberId = Number(rawMemberId);
+      if (!Number.isNaN(filterMemberId)) {
+        where.memberId = filterMemberId;
+      }
+    }
+
+    const normalizedMonth = normalizeYearMonth(
+      typeof month === 'string' ? month : undefined
+    );
+    if (normalizedMonth) {
+      const { start, end } = getLocalMonthDateRange(normalizedMonth);
       where.date = { gte: start, lt: end };
     }
 
@@ -487,37 +501,25 @@ export const updateItemSplits = async (req: Request, res: Response, next: NextFu
         return { message: 'Splits cleared (Fallback to default payer)' };
       }
 
-      // 3. 単価×数量を基準とする元金額の算出
-      const totalAmount = Math.round((item.price || 0) * (item.quantity || 1));
-      let allocatedAmount = 0;
-      const finalSplits: { familyMemberId: number; amount: number }[] = [];
+      const totalAmount = Math.round(Number(item.price || 0) * Number(item.quantity || 1));
+      const splitInputs: SplitInput[] = splits.map((split: SplitInput) => ({
+        familyMemberId: Number(split.familyMemberId),
+        ratio: split.ratio,
+        amount: split.amount,
+      }));
 
-      // 4. 各メンバーへの金額割り当て計算
-      splits.forEach((split: any, index: number) => {
-        let amount = 0;
-
-        if (index === splits.length - 1) {
-          // ★ 端数丸め: 配列の最後のメンバーに「残額すべて」を寄せて合計不一致を防ぐ
-          amount = totalAmount - allocatedAmount;
-        } else if (split.amount !== undefined) {
-          amount = Math.round(Number(split.amount));
-        } else if (split.ratio !== undefined) {
-          amount = Math.round(totalAmount * Number(split.ratio));
-        }
-
-        allocatedAmount += amount;
-        finalSplits.push({
-          familyMemberId: Number(split.familyMemberId),
-          amount: amount,
-        });
+      const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
+      const validMembers = await tx.familyMember.findMany({
+        where: { id: { in: memberIds }, familyGroupId },
+        select: { id: true },
       });
-
-      // 5. 先頭要素への端数補正（allocatedAmountが超過・不足した場合のセーフティネット）
-      if (allocatedAmount !== totalAmount && finalSplits.length > 0) {
-        finalSplits[0].amount += (totalAmount - allocatedAmount);
+      if (validMembers.length !== memberIds.length) {
+        throw new AppError('Invalid familyMemberId in splits', 403);
       }
 
-      // 6. DBの洗い替え（Delete & Insert）
+      const finalSplits = allocateItemSplits(totalAmount, splitInputs);
+
+      // DBの洗い替え（Delete & Insert）
       await tx.itemSplit.deleteMany({ where: { itemId: Number(itemId) } });
       await tx.itemSplit.createMany({
         data: finalSplits.map(fs => ({

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,6 +1,11 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prismaClient';
 import { getFamilyGroupId } from '../utils/context';
+import {
+  getCurrentYearMonthLocal,
+  getLocalMonthDateRange,
+  normalizeYearMonth,
+} from '../utils/yearMonth';
 
 /**
  * [Issue #78 / #81] 月間精算ステータスの取得（暗黙的デフォルト対応 ＆ 送金実績の反映）
@@ -10,13 +15,11 @@ import { getFamilyGroupId } from '../utils/context';
 export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
   const familyGroupId = getFamilyGroupId();
   
-  // 対象月 (YYYY-MM形式)。指定がなければ今月。
-  const targetMonth = (req.query.month as string) || new Date().toISOString().slice(0, 7);
+  const queryMonth = normalizeYearMonth(req.query.month as string);
+  const targetMonth = queryMonth ?? getCurrentYearMonthLocal();
+  const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
 
   try {
-    const startDate = new Date(`${targetMonth}-01T00:00:00.000Z`);
-    const endDate = new Date(startDate);
-    endDate.setMonth(startDate.getMonth() + 1);
 
     // 1. 対象グループの全メンバーを取得して初期化
     const members = await prisma.familyMember.findMany({
@@ -149,12 +152,16 @@ export const addSettlementTransfer = async (req: Request, res: Response, next: N
   const familyGroupId = getFamilyGroupId();
   
   const { month, fromMemberId, toMemberId, amount } = req.body;
+  const normalizedMonth = normalizeYearMonth(month);
+  const fromId = Number(fromMemberId);
+  const toId = Number(toMemberId);
+  const transferAmount = Math.round(Number(amount));
 
-  if (!month || !fromMemberId || !toMemberId || !amount || amount <= 0) {
+  if (!normalizedMonth || !fromMemberId || !toMemberId || !Number.isFinite(transferAmount) || transferAmount <= 0) {
     return res.status(400).json({ success: false, message: '必要なパラメータが不足しているか、金額が不正です。' });
   }
 
-  if (fromMemberId === toMemberId) {
+  if (fromId === toId) {
     return res.status(400).json({ success: false, message: '自分自身への送金は登録できません。' });
   }
 
@@ -162,7 +169,7 @@ export const addSettlementTransfer = async (req: Request, res: Response, next: N
     // 送信者・受信者が同一世帯に属しているか（テナント検証）
     const validMembers = await prisma.familyMember.findMany({
       where: {
-        id: { in: [fromMemberId, toMemberId] },
+        id: { in: [fromId, toId] },
         familyGroupId
       }
     });
@@ -174,10 +181,10 @@ export const addSettlementTransfer = async (req: Request, res: Response, next: N
     // 送金記録の作成
     const newTransfer = await prisma.settlementTransfer.create({
       data: {
-        month,
-        fromMemberId,
-        toMemberId,
-        amount,
+        month: normalizedMonth,
+        fromMemberId: fromId,
+        toMemberId: toId,
+        amount: transferAmount,
         // settledAt は default(now()) で自動採番
       }
     });

--- a/backend/src/utils/itemSplitAllocation.ts
+++ b/backend/src/utils/itemSplitAllocation.ts
@@ -1,0 +1,69 @@
+import { AppError } from './appError';
+
+export type SplitInput = {
+  familyMemberId: number;
+  ratio?: number;
+  amount?: number;
+};
+
+export type AllocatedSplit = {
+  familyMemberId: number;
+  amount: number;
+};
+
+/**
+ * 明細小計に対する按分額を算出。端数は配列の最後のメンバーに寄せる。
+ */
+export function allocateItemSplits(
+  totalAmount: number,
+  splits: SplitInput[]
+): AllocatedSplit[] {
+  if (totalAmount < 0) {
+    throw new AppError('Invalid item total amount', 400);
+  }
+  if (splits.length === 0) {
+    return [];
+  }
+
+  const memberIds = splits.map((s) => Number(s.familyMemberId));
+  if (memberIds.some((id) => !Number.isFinite(id) || id <= 0)) {
+    throw new AppError('Invalid familyMemberId in splits', 400);
+  }
+  if (new Set(memberIds).size !== memberIds.length) {
+    throw new AppError('Duplicate familyMemberId in splits', 400);
+  }
+
+  let allocatedAmount = 0;
+  const finalSplits: AllocatedSplit[] = [];
+
+  splits.forEach((split, index) => {
+    let amount = 0;
+
+    if (index === splits.length - 1) {
+      amount = totalAmount - allocatedAmount;
+    } else if (split.amount !== undefined && split.amount !== null) {
+      amount = Math.round(Number(split.amount));
+    } else if (split.ratio !== undefined && split.ratio !== null) {
+      amount = Math.round(totalAmount * Number(split.ratio));
+    } else {
+      throw new AppError('Each split requires ratio or amount (except last member)', 400);
+    }
+
+    if (amount < 0) {
+      throw new AppError('Split amount cannot be negative', 400);
+    }
+
+    allocatedAmount += amount;
+    finalSplits.push({
+      familyMemberId: Number(split.familyMemberId),
+      amount,
+    });
+  });
+
+  const sum = finalSplits.reduce((acc, s) => acc + s.amount, 0);
+  if (sum !== totalAmount) {
+    throw new AppError('Split amounts do not sum to item total', 400);
+  }
+
+  return finalSplits;
+}

--- a/backend/src/utils/yearMonth.ts
+++ b/backend/src/utils/yearMonth.ts
@@ -1,0 +1,35 @@
+/** YYYY-MM（ローカル TZ。receipt.date の保存方式と揃える） */
+const YEAR_MONTH_RE = /^(\d{4})-(\d{1,2})$/;
+
+export function getCurrentYearMonthLocal(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function normalizeYearMonth(input: string | undefined | null): string | null {
+  if (!input || typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  const match = trimmed.match(YEAR_MONTH_RE);
+  if (!match) return null;
+  const y = match[1];
+  const m = String(parseInt(match[2], 10)).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+/** 指定月の [start, end) をローカル日付で返す（parseSafeDate と同系） */
+export function getLocalMonthDateRange(yearMonth: string): { start: Date; end: Date } {
+  const normalized = normalizeYearMonth(yearMonth);
+  if (!normalized) {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = now.getMonth();
+    return { start: new Date(y, m, 1, 0, 0, 0, 0), end: new Date(y, m + 1, 1, 0, 0, 0, 0) };
+  }
+  const [yStr, mStr] = normalized.split('-');
+  const y = parseInt(yStr, 10);
+  const m = parseInt(mStr, 10) - 1;
+  return {
+    start: new Date(y, m, 1, 0, 0, 0, 0),
+    end: new Date(y, m + 1, 1, 0, 0, 0, 0),
+  };
+}

--- a/docs/reviews/issue-87/results/backend.md
+++ b/docs/reviews/issue-87/results/backend.md
@@ -1,0 +1,65 @@
+# レビュー結果 — Issue #87-2 Backend
+
+| 項目 | 値 |
+|------|-----|
+| 対象 Issue | #87-2 ([#258](https://github.com/yama180sx/receipt-ai-app/issues/258)) |
+| レビュー日 | 2026-05-30 |
+| ブランチ（作業用） | `feature/issue-87-2-backend-settlement-review` |
+| 対象 | `statsController.ts`, `receiptController.updateItemSplits`, routes |
+
+## 採点サマリー
+
+| 観点 | スコア (/100) | 主な減点理由 |
+|------|---------------|----------------|
+| アーキテクチャ | 72 | 集計・按分計算が Controller に直書き。責務分離は Should |
+| 型の堅牢性 | 65 | `splits: any`、送金 API の body 型なし |
+| パフォーマンス・手戻り | 70 | 月境界 UTC/ISO ずれ、按分の二重端数補正、メンバー未検証 |
+| **総合（参考）** | **69** | |
+
+## 指摘一覧
+
+| ID | 優先度 | 観点 | ファイル | 要約 | 振り分け | 対応 |
+|----|--------|------|----------|------|----------|------|
+| R-B001 | **Must** | 手戻り | `statsController.ts` | 対象月デフォルト・範囲が `toISOString`/UTC 基準で、レシート `date`（ローカル/JST 生成）とずれる | #87-2 | ✅ `yearMonth.ts` でローカル月範囲 |
+| R-B002 | **Must** | データ整合 | `updateItemSplits` | `familyMemberId` が同一世帯か未検証 | #87-2 | ✅ 保存前に世帯メンバー照合 |
+| R-B003 | **Must** | データ整合 | `updateItemSplits` | 端数を「最後のメンバー」に寄せた後、先頭へ再補正する二重ロジックで意図と不一致 | #87-2 | ✅ `itemSplitAllocation.ts` に一本化 |
+| R-B004 | **Must** | データ整合 | `updateItemSplits` | 按分合計≠小計・負の按分額を許容しうる | #87-2 | ✅ 合計検証・負数拒否 |
+| R-B005 | Should | 型 | `updateItemSplits` | `split: any` | #87-4 | 未対応（Epic 外子） |
+| R-B006 | Should | アーキ | `statsController` | `AppError` と直 `res.status` 混在 | #87-2 | 未対応 |
+| R-B007 | Should | 型 | `addSettlementTransfer` | `month` 形式未検証 | #87-2 | ✅ `normalizeYearMonth` |
+| R-B008 | Later | 性能 | `getSettlementStatus` | レシート全件+明細 include（世帯小なら許容） | — | 未対応 |
+| R-B009 | **Must** | データ整合 | `getReceipts` | `memberId=""`（世帯全体）でも `x-member-id` にフォールバックし自分のレシートのみ | #87-2 | ✅ 空文字は全件、月範囲もローカル TZ |
+
+## Must の実装方針（実装済み・未コミット）
+
+### R-B001
+
+- `getCurrentYearMonthLocal()` / `getLocalMonthDateRange()` を `backend/src/utils/yearMonth.ts` に追加
+- `getSettlementStatus` のデフォルト月・`date` フィルタに適用
+
+### R-B002〜R-B004
+
+- `allocateItemSplits()` を `backend/src/utils/itemSplitAllocation.ts` に抽出
+- 保存前に `familyMemberId in splits` が `familyGroupId` 所属か検証
+- 二重端数補正ブロックを削除
+
+### R-B007
+
+- 送金登録時 `month` を `normalizeYearMonth` で検証
+
+### R-B009
+
+- `getReceipts`: `memberId` クエリが空のときは世帯全件（ヘッダーにフォールバックしない）
+- 履歴の月フィルタも `getLocalMonthDateRange` に統一
+
+## 手動確認（マージ前）
+
+- [ ] 精算サマリー: 当月・前月切替で件数・金額が妥当
+- [ ] 割り勘保存: ％/円保存後、精算サマリーと一致
+- [ ] 他世帯 memberId を splits に含めた POST → 403/400
+- [ ] 送金記録: 正常登録、同一人物・不正 month は拒否
+- [ ] **履歴: メンバー「世帯全体」で妻・息子など全員分のレシートが表示される**
+
+## Should / Later（バックログ）
+
+- R-B005, R-B006, R-B008 は別 PR または #87-4 で検討

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -85,10 +85,11 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
     try {
       setLoading(true);
       const res = await apiClient.get('/receipts', {
-        params: { 
-          memberId: selectedMember, 
-          month: selectedMonth 
-        }
+        params: {
+          ...(selectedMonth ? { month: selectedMonth } : {}),
+          // 世帯全体: memberId を空で送る（省略すると API がログインユーザーに絞る旧挙動になる）
+          memberId: selectedMember,
+        },
       });
       if (res.data?.success) {
         const data = res.data.data;


### PR DESCRIPTION
## Summary

Issue #87-2（#258）: 精算・按分 Backend のレビュー Must 対応と、動確で判明した履歴フィルタ不具合の修正。

- 精算サマリー・履歴の月境界をローカル TZ に統一（`yearMonth.ts`）
- 按分保存（`updateItemSplits`）: 世帯メンバー検証、端数ロジック一本化、合計・負数チェック（`itemSplitAllocation.ts`）
- 送金記録の `month` 正規化
- **履歴「世帯全体」**: `memberId=""` 時に `x-member-id` へフォールバックせず世帯全レシートを返す
- レビュー記録: `docs/reviews/issue-87/results/backend.md`

Closes #258

## Must 対応一覧

| ID | 内容 |
|----|------|
| R-B001 | 精算の月境界（UTC → ローカル） |
| R-B002 | 按分の世帯メンバー検証 |
| R-B003 | 端数補正の二重ロジック解消 |
| R-B004 | 按分合計・負数の検証 |
| R-B007 | 送金 month 検証 |
| R-B009 | 履歴「世帯全体」フィルタ |

Should（R-B005, R-B006, R-B008）は #87-4 / バックログ。

## Test plan

- [ ] 精算サマリー: 当月・前月で金額が妥当
- [ ] 割り勘保存後、精算サマリーと按分合計が一致
- [ ] 履歴: 「世帯全体」で全メンバーのレシートが表示される
- [ ] 履歴: 特定メンバー絞り込みが従来どおり動作
- [ ] 送金記録の登録・不正 month の拒否


Made with [Cursor](https://cursor.com)