### PR TITLE
fix(frontend): [Issue #87-3] 按分保存の端数整合と精算画面の通知

### DIFF
--- a/docs/reviews/issue-87/results/frontend.md
+++ b/docs/reviews/issue-87/results/frontend.md
@@ -1,0 +1,49 @@
+# レビュー結果 — Issue #87-3 Frontend
+
+| 項目 | 値 |
+|------|-----|
+| 対象 Issue | #87-3 ([#259](https://github.com/yama180sx/receipt-ai-app/issues/259)) |
+| レビュー日 | 2026-05-30 |
+| ブランチ（作業用） | `feature/issue-87-3-frontend-settlement-review` |
+| 前提 | #87-2 Backend 按分端数ルール（配列最後に残額）マージ済み |
+
+## 採点サマリー
+
+| 観点 | スコア (/100) | 主な減点理由 |
+|------|---------------|----------------|
+| アーキテクチャ | 68 | SplitEditor 570行・計算ロジック直書き |
+| 型の堅牢性 | 62 | `receipt: any`, `summaryData: any[]` |
+| パフォーマンス・手戻り | 65 | 保存 payload と Backend 端数ルールの不一致、Web Alert |
+| **総合（参考）** | **65** | |
+
+## 指摘一覧
+
+| ID | 優先度 | 観点 | ファイル | 要約 | 対応 |
+|----|--------|------|----------|------|------|
+| R-F001 | **Must** | データ整合 | `SplitEditorScreen` | 端数は UI 先頭、API は配列最後。`amount>0` のみ送信でズレ | ✅ `splitEditorSplits.ts` |
+| R-F002 | **Must** | 手戻り | `SettlementSummaryScreen` | 取得失敗が console のみ | ✅ `showAlert` |
+| R-F003 | **Must** | 手戻り | 両画面 | Web で `Alert.alert` が効かない | ✅ `alertMessage.ts` |
+| R-F004 | Should | 型 | 両画面 | `any` 多用 | #87-4 |
+| R-F005 | Should | アーキ | `SplitEditorScreen` | 単一巨大コンポーネント | 未対応 |
+| R-F006 | Should | 手戻り | `SplitEditorScreen` | 小計計算の重複 | 一部 `calcItemTotal` 化 |
+
+## Must の実装方針
+
+### R-F001
+
+- `buildItemSplitSavePayload`: 全 activeMembers を送信、端数負担者（`activeMembers[0]`）を **配列末尾** に配置
+- `calcItemTotal` で小計計算を共通化（保存・表示の主要箇所）
+
+### R-F002 / R-F003
+
+- `showAlert` で Web / ネイティブ両対応
+- 精算取得失敗・送金・送金額バリデーション・割り勘保存完了で使用
+- 送金額のマイナス入力は `parsePositiveYenAmount.ts` で拒否（訂正機能は Issue #88 / #265）
+
+## 手動確認（マージ前）
+
+- [ ] 割り勘: 2〜3人、％/円編集 → 保存 → 精算サマリーと一致
+- [ ] 一括調整行のカスケード
+- [ ] 精算サマリー: 月切替・送金モーダル
+- [ ] Web: 保存完了・エラー・送金成功が表示される
+- [ ] スマホ: 上記の退行なし

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView, 
   ActivityIndicator, 
   useWindowDimensions,
-  Alert
 } from 'react-native';
 import {
   AppBackButton,
@@ -21,6 +20,11 @@ import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
+import { showAlert } from '../utils/alertMessage';
+import {
+  hasNegativeAmountSign,
+  parsePositiveYenAmount,
+} from '../utils/parsePositiveYenAmount';
 
 interface SettlementSummaryScreenProps {
   onBack: () => void;
@@ -77,9 +81,11 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       errors.amount = '金額を入力してください';
     } else if (transferFrom && transferTo && transferFrom === transferTo) {
       errors.to = '送金先は送金元と異なるメンバーを選んでください';
+    } else if (hasNegativeAmountSign(transferAmount)) {
+      errors.amount = '金額は0より大きい値を入力してください';
     } else {
-      const amountNum = parseInt(transferAmount.replace(/[^0-9]/g, ''), 10);
-      if (isNaN(amountNum) || amountNum <= 0) {
+      const amountNum = parsePositiveYenAmount(transferAmount);
+      if (amountNum === null) {
         errors.amount = '正しい金額を入力してください';
       }
     }
@@ -96,6 +102,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       }
     } catch (err) {
       console.error('精算サマリーの取得失敗:', err);
+      showAlert('エラー', '精算サマリーの取得に失敗しました。');
     } finally {
       setLoading(false);
     }
@@ -110,7 +117,10 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       return;
     }
 
-    const amountNum = parseInt(transferAmount.replace(/[^0-9]/g, ''), 10);
+    const amountNum = parsePositiveYenAmount(transferAmount);
+    if (amountNum === null) {
+      return;
+    }
 
     setIsSubmitting(true);
     try {
@@ -121,7 +131,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
         amount: amountNum
       });
       if (res.success) {
-        Alert.alert('成功', '送金記録を登録しました。');
+        showAlert('成功', '送金記録を登録しました。');
         setTransferModalVisible(false);
         setTransferFrom(null);
         setTransferTo(null);
@@ -131,7 +141,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       }
     } catch (err) {
       console.error('送金記録エラー', err);
-      Alert.alert('エラー', '送金記録の登録に失敗しました。');
+      showAlert('エラー', '送金記録の登録に失敗しました。');
     } finally {
       setIsSubmitting(false);
     }
@@ -349,7 +359,14 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
               variant="inline"
               value={transferAmount}
               onChangeText={(v) => {
-                setTransferAmount(v);
+                if (hasNegativeAmountSign(v)) {
+                  setTransferFieldErrors((prev) => ({
+                    ...prev,
+                    amount: '金額は0より大きい値を入力してください',
+                  }));
+                  return;
+                }
+                setTransferAmount(v.replace(/[^0-9]/g, ''));
                 if (transferFieldErrors.amount) {
                   setTransferFieldErrors((prev) => ({ ...prev, amount: undefined }));
                 }

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -8,7 +8,6 @@ import {
   TextInput, 
   TouchableOpacity, 
   ActivityIndicator, 
-  Alert, 
   Platform,
   useWindowDimensions
 } from 'react-native';
@@ -17,6 +16,11 @@ import { AppBackButton, AppButton } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
+import { showAlert } from '../utils/alertMessage';
+import {
+  buildItemSplitSavePayload,
+  calcItemTotal,
+} from '../utils/splitEditorSplits';
 
 interface SplitEditorScreenProps {
   receipt: any;
@@ -84,7 +88,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
         }
       } catch (err) {
         console.error('メンバー取得失敗', err);
-        Alert.alert('エラー', 'メンバー情報の取得に失敗しました。');
+        showAlert('エラー', 'メンバー情報の取得に失敗しました。');
       } finally {
         setLoading(false);
       }
@@ -98,7 +102,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     const initialData: Record<number, Record<number, number>> = {};
     receipt.items.forEach((item: any) => {
       initialData[item.id] = {};
-      const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+      const itemTotal = calcItemTotal(item);
 
       if (item.splits && item.splits.length > 0) {
         targetMembers.forEach(m => {
@@ -133,7 +137,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
 
   const removeMember = (memberId: number) => {
     if (activeMembers.length <= 1) {
-      Alert.alert('エラー', '対象者は最低1人必要です。');
+      showAlert('エラー', '対象者は最低1人必要です。');
       return;
     }
     const newActive = activeMembers.filter(m => m.id !== memberId);
@@ -220,7 +224,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     setEditSplits(prev => {
       const next = { ...prev };
       receipt.items.forEach((item: any) => {
-        const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+        const itemTotal = calcItemTotal(item);
         const newData = { ...next[item.id] };
 
         // 入力された％に基づいて金額を算出
@@ -263,28 +267,34 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   // ★ 追加: レシート全体を均等割り
   const splitWholeReceiptEqually = () => {
     receipt.items.forEach((item: any) => {
-      const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
-      splitItemEqually(item.id, itemTotal);
+      splitItemEqually(item.id, calcItemTotal(item));
     });
   };
 
   const handleSave = async () => {
+    if (activeMembers.length === 0) {
+      showAlert('エラー', '対象者を1人以上選択してください。');
+      return;
+    }
+
+    const remainderMemberId = activeMembers[0].id;
     setSaving(true);
     try {
       const savePromises = receipt.items.map(async (item: any) => {
-        const payloadSplits = activeMembers.map(m => ({
-          familyMemberId: m.id,
-          amount: editSplits[item.id]?.[m.id] || 0
-        })).filter(p => p.amount > 0);
-
+        const amounts = editSplits[item.id] ?? {};
+        const payloadSplits = buildItemSplitSavePayload(
+          activeMembers,
+          amounts,
+          remainderMemberId
+        );
         return api.saveItemSplits(item.id, payloadSplits);
       });
 
       await Promise.all(savePromises);
-      Alert.alert('保存完了', '割り勘設定を保存しました。', [{ text: 'OK', onPress: onBack }]);
+      showAlert('保存完了', '割り勘設定を保存しました。', { onOk: onBack });
     } catch (err) {
       console.error('保存エラー', err);
-      Alert.alert('エラー', '保存に失敗しました。');
+      showAlert('エラー', '保存に失敗しました。');
     } finally {
       setSaving(false);
     }
@@ -301,9 +311,10 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   const getImageUrl = () => receipt.imagePath ? `${BASE_URL}/${receipt.imagePath}` : null;
 
   // レシート全体の合計額を算出
-  const receiptTotalAmount = receipt.items.reduce((sum: number, item: any) => {
-    return sum + Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
-  }, 0);
+  const receiptTotalAmount = receipt.items.reduce(
+    (sum: number, item: any) => sum + calcItemTotal(item),
+    0
+  );
 
   // 合計行表示用: メンバーごとの合計額を計算
   const getMemberTotalAmount = (memberId: number) => {
@@ -398,7 +409,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
               </View>
 
               {receipt.items.map((item: any) => {
-                const itemTotal = Math.round((parseFloat(item.price) || 0) * (parseFloat(item.quantity) || 1));
+                const itemTotal = calcItemTotal(item);
 
                 return (
                   <View key={item.id} style={[tableStyles.row, styles.tableRowWide]}>

--- a/frontend/src/utils/alertMessage.ts
+++ b/frontend/src/utils/alertMessage.ts
@@ -1,0 +1,24 @@
+import { Alert, Platform } from 'react-native';
+
+/**
+ * 通知ダイアログ。Web では Alert.alert が表示されないことがあるため window.alert を使う。
+ */
+export function showAlert(
+  title: string,
+  message?: string,
+  options?: { onOk?: () => void }
+): void {
+  const body = message ? `${title}\n\n${message}` : title;
+
+  if (Platform.OS === 'web') {
+    window.alert(body);
+    options?.onOk?.();
+    return;
+  }
+
+  if (options?.onOk) {
+    Alert.alert(title, message, [{ text: 'OK', onPress: options.onOk }]);
+  } else {
+    Alert.alert(title, message);
+  }
+}

--- a/frontend/src/utils/parsePositiveYenAmount.ts
+++ b/frontend/src/utils/parsePositiveYenAmount.ts
@@ -1,0 +1,26 @@
+const NEGATIVE_AMOUNT_PATTERN = /[-－−]/;
+
+/** 入力にマイナス記号（半角・全角・数学記号）が含まれるか */
+export function hasNegativeAmountSign(raw: string): boolean {
+  return NEGATIVE_AMOUNT_PATTERN.test(raw.trim());
+}
+
+/**
+ * 送金額など、正の整数円のみ受け付けるパース。
+ * 「-5000」のようにマイナスを含む場合は null（数字だけ抜いて正にしない）。
+ */
+export function parsePositiveYenAmount(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed || hasNegativeAmountSign(trimmed)) {
+    return null;
+  }
+  const digitsOnly = trimmed.replace(/[^0-9]/g, '');
+  if (!digitsOnly) {
+    return null;
+  }
+  const amount = parseInt(digitsOnly, 10);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null;
+  }
+  return amount;
+}

--- a/frontend/src/utils/splitEditorSplits.ts
+++ b/frontend/src/utils/splitEditorSplits.ts
@@ -1,0 +1,33 @@
+/** 明細の税込小計（Backend の updateItemSplits と同じ丸め） */
+export function calcItemTotal(item: {
+  price?: unknown;
+  quantity?: unknown;
+}): number {
+  return Math.round(
+    (parseFloat(String(item.price ?? 0)) || 0) *
+      (parseFloat(String(item.quantity ?? 1)) || 1)
+  );
+}
+
+export type SplitSaveMember = { id: number };
+
+/**
+ * 按分保存用 payload。UI の端数負担者（先頭）を配列末尾に置き、
+ * Backend（#87-2）の「最後の要素に残額」ルールと一致させる。
+ */
+export function buildItemSplitSavePayload(
+  activeMembers: SplitSaveMember[],
+  amountsByMemberId: Record<number, number>,
+  remainderMemberId: number
+): { familyMemberId: number; amount: number }[] {
+  if (activeMembers.length === 0) return [];
+
+  const others = activeMembers.filter((m) => m.id !== remainderMemberId);
+  const remainder = activeMembers.find((m) => m.id === remainderMemberId);
+  const ordered = remainder ? [...others, remainder] : activeMembers;
+
+  return ordered.map((m) => ({
+    familyMemberId: m.id,
+    amount: amountsByMemberId[m.id] ?? 0,
+  }));
+}


### PR DESCRIPTION
## Summary

Issue #87-3（#259）の **Must** 3件を対応しました。

- **R-F001**: `buildItemSplitSavePayload` で全メンバー送信・端数負担者を配列末尾に配置（Backend #87-2 と一致）
- **R-F002**: 精算サマリー取得失敗時に `showAlert` で通知
- **R-F003**: Web でも動作する `showAlert`（`alertMessage.ts`）を割り勘・精算画面に適用
- 送金額のマイナス入力が正の値に化ける不具合を `parsePositiveYenAmount` で拒否（訂正 UI は Issue #88 / #265）

## 成果物

- `docs/reviews/issue-87/results/frontend.md` — レビュー記録

## スコープ外（子 Issue へ）

- Should（`any` 整理・巨大コンポーネント分割）→ #87-4
- 送金記録の取消・訂正 → Issue #88 (#265)

## Test plan

- [ ] 割り勘 2〜3人で保存 → 精算サマリーと金額一致
- [ ] Web: 保存完了・エラー・送金成功のダイアログ表示
- [ ] 送金額 `-5000` はエラー、正の金額のみ登録可
- [ ] スマホ: 上記の退行なし

Closes #259

Made with [Cursor](https://cursor.com)