### PR TITLE
refactor(settlement): [Issue #87-4] 精算ドメインの型整理と明細小計の共通化

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -7,6 +7,7 @@ import { receiptQueue } from '../queues/receiptQueue';
 import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService'; 
 import { getFamilyGroupId, getMemberId } from '../utils/context';
 import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
+import { calcItemLineTotal } from '../utils/itemLineTotal';
 import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
 
 /**
@@ -501,7 +502,7 @@ export const updateItemSplits = async (req: Request, res: Response, next: NextFu
         return { message: 'Splits cleared (Fallback to default payer)' };
       }
 
-      const totalAmount = Math.round(Number(item.price || 0) * Number(item.quantity || 1));
+      const totalAmount = calcItemLineTotal(item.price, item.quantity);
       const splitInputs: SplitInput[] = splits.map((split: SplitInput) => ({
         familyMemberId: Number(split.familyMemberId),
         ratio: split.ratio,

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -6,6 +6,7 @@ import {
   getLocalMonthDateRange,
   normalizeYearMonth,
 } from '../utils/yearMonth';
+import { calcItemLineTotal } from '../utils/itemLineTotal';
 
 /**
  * [Issue #78 / #81] 月間精算ステータスの取得（暗黙的デフォルト対応 ＆ 送金実績の反映）
@@ -60,7 +61,7 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
 
       receipt.items.forEach(item => {
         // 金額は整数（Int）丸めで計算
-        const itemPriceInt = Math.round((item.price || 0) * (item.quantity || 1));
+        const itemPriceInt = calcItemLineTotal(item.price, item.quantity);
         receiptTotalPaid += itemPriceInt;
 
         if (item.splits.length > 0) {

--- a/backend/src/utils/itemLineTotal.ts
+++ b/backend/src/utils/itemLineTotal.ts
@@ -1,0 +1,13 @@
+/**
+ * 明細行の税込小計（円・整数丸め）。
+ * Frontend の calcItemTotal（splitEditorSplits.ts）と同じ式。
+ */
+export function calcItemLineTotal(price: unknown, quantity: unknown = 1): number {
+  const unit =
+    typeof price === 'number' ? price : parseFloat(String(price ?? 0)) || 0;
+  const qty =
+    typeof quantity === 'number'
+      ? quantity
+      : parseFloat(String(quantity ?? 1)) || 1;
+  return Math.round(unit * qty);
+}

--- a/docs/reviews/issue-87/results/backend.md
+++ b/docs/reviews/issue-87/results/backend.md
@@ -24,7 +24,7 @@
 | R-B002 | **Must** | データ整合 | `updateItemSplits` | `familyMemberId` が同一世帯か未検証 | #87-2 | ✅ 保存前に世帯メンバー照合 |
 | R-B003 | **Must** | データ整合 | `updateItemSplits` | 端数を「最後のメンバー」に寄せた後、先頭へ再補正する二重ロジックで意図と不一致 | #87-2 | ✅ `itemSplitAllocation.ts` に一本化 |
 | R-B004 | **Must** | データ整合 | `updateItemSplits` | 按分合計≠小計・負の按分額を許容しうる | #87-2 | ✅ 合計検証・負数拒否 |
-| R-B005 | Should | 型 | `updateItemSplits` | `split: any` | #87-4 | 未対応（Epic 外子） |
+| R-B005 | Should | 型 | `updateItemSplits` | `split: any` | #87-4 | ✅ #87-2 で `SplitInput`（#87-4 で記録） |
 | R-B006 | Should | アーキ | `statsController` | `AppError` と直 `res.status` 混在 | #87-2 | 未対応 |
 | R-B007 | Should | 型 | `addSettlementTransfer` | `month` 形式未検証 | #87-2 | ✅ `normalizeYearMonth` |
 | R-B008 | Later | 性能 | `getSettlementStatus` | レシート全件+明細 include（世帯小なら許容） | — | 未対応 |

--- a/docs/reviews/issue-87/results/cross-cutting.md
+++ b/docs/reviews/issue-87/results/cross-cutting.md
@@ -1,0 +1,41 @@
+# レビュー結果 — Issue #87-4 横断
+
+| 項目 | 値 |
+|------|-----|
+| 対象 Issue | Issue #87-4 ([#260](https://github.com/yama180sx/receipt-ai-app/issues/260)) |
+| レビュー日 | 2026-05-31 |
+| ブランチ（作業用） | `feature/issue-87-4-settlement-types` |
+| 前提 | #87-2 / #87-3 マージ済み |
+
+## 対応一覧
+
+| ID | 元 Issue | 内容 | 対応 |
+|----|----------|------|------|
+| 横断-01 | #87-3 R-F004 | 精算・割り勘画面の `any` | ✅ `frontend/src/types/settlement.ts` |
+| 横断-02 | #87-3 R-F006 | 小計計算の FE/BE 明示的一致 | ✅ `itemLineTotal.ts` / `calcItemTotal` |
+| 横断-03 | #87-2 R-B005 | `split: any` | ✅ 既に `SplitInput`（#87-2）。追記のみ |
+| — | apiClient | 精算 API 戻り値型 | ✅ `getSettlementStatus` 等 |
+
+## 見送り（本 Issue スコープ外）
+
+| ID | 理由 |
+|----|------|
+| R-F005 | SplitEditor のコンポーネント分割 → Later |
+| R-B006 | AppError / res.status 統一 → 精算以外も波及 |
+| R-B008 | 精算 API の include 最適化 → Later |
+| — | Issue #88 送金の取消・訂正 → #265 |
+| — | `HistoryScreen` の `receipt: any` → 精算ドメイン外 |
+
+## 明細小計の丸め規則
+
+| 層 | 関数 | 式 |
+|----|------|-----|
+| Frontend | `calcItemTotal` | `Math.round(parseFloat(price) * parseFloat(quantity))` |
+| Backend | `calcItemLineTotal` | 同上（`itemLineTotal.ts`） |
+| 使用箇所 | `statsController`, `updateItemSplits` | `calcItemLineTotal(item.price, item.quantity)` |
+
+## 手動確認（マージ前）
+
+- [ ] 割り勘保存 → 精算サマリー金額一致（挙動不変）
+- [ ] 精算サマリー月切替・送金モーダル
+- [ ] `cd frontend && npx tsc --noEmit`

--- a/docs/reviews/issue-87/results/frontend.md
+++ b/docs/reviews/issue-87/results/frontend.md
@@ -23,7 +23,7 @@
 | R-F001 | **Must** | データ整合 | `SplitEditorScreen` | 端数は UI 先頭、API は配列最後。`amount>0` のみ送信でズレ | ✅ `splitEditorSplits.ts` |
 | R-F002 | **Must** | 手戻り | `SettlementSummaryScreen` | 取得失敗が console のみ | ✅ `showAlert` |
 | R-F003 | **Must** | 手戻り | 両画面 | Web で `Alert.alert` が効かない | ✅ `alertMessage.ts` |
-| R-F004 | Should | 型 | 両画面 | `any` 多用 | #87-4 |
+| R-F004 | Should | 型 | 両画面 | `any` 多用 | #87-4 | ✅ Issue #87-4 |
 | R-F005 | Should | アーキ | `SplitEditorScreen` | 単一巨大コンポーネント | 未対応 |
 | R-F006 | Should | 手戻り | `SplitEditorScreen` | 小計計算の重複 | 一部 `calcItemTotal` 化 |
 

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -25,6 +25,7 @@ import {
   hasNegativeAmountSign,
   parsePositiveYenAmount,
 } from '../utils/parsePositiveYenAmount';
+import type { SettlementMemberSummary } from '../types/settlement';
 
 interface SettlementSummaryScreenProps {
   onBack: () => void;
@@ -36,7 +37,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
 
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
-  const [summaryData, setSummaryData] = useState<any[]>([]);
+  const [summaryData, setSummaryData] = useState<SettlementMemberSummary[]>([]);
 
   // 送金モーダル用ステート
   const [isTransferModalVisible, setTransferModalVisible] = useState(false);
@@ -55,7 +56,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
 
   const memberSelectOptions = useMemo(
     () =>
-      summaryData.map((m: { memberId: number; name: string }) => ({
+      summaryData.map((m) => ({
         label: m.name,
         value: m.memberId,
       })),
@@ -98,7 +99,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
       setLoading(true);
       const res = await api.getSettlementStatus(selectedMonth);
       if (res.success) {
-        setSummaryData(res.data.members || []);
+        setSummaryData(res.data?.members ?? []);
       }
     } catch (err) {
       console.error('精算サマリーの取得失敗:', err);

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -21,9 +21,14 @@ import {
   buildItemSplitSavePayload,
   calcItemTotal,
 } from '../utils/splitEditorSplits';
+import type {
+  FamilyMemberSummary,
+  ReceiptForSplitEditor,
+  ReceiptItemForSplit,
+} from '../types/settlement';
 
 interface SplitEditorScreenProps {
-  receipt: any;
+  receipt: ReceiptForSplitEditor;
   onBack: () => void;
 }
 
@@ -31,8 +36,8 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   const { width } = useWindowDimensions();
   const isWide = width >= BREAKPOINTS.TABLET;
 
-  const [allMembers, setAllMembers] = useState<any[]>([]); 
-  const [activeMembers, setActiveMembers] = useState<any[]>([]); 
+  const [allMembers, setAllMembers] = useState<FamilyMemberSummary[]>([]);
+  const [activeMembers, setActiveMembers] = useState<FamilyMemberSummary[]>([]); 
   
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -51,31 +56,33 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
         if (res.success) {
           setAllMembers(res.data);
           
-          let initialActive: any[] = [];
-          
-          const hasExistingSplits = receipt.items.some((item: any) => item.splits && item.splits.length > 0);
+          let initialActive: FamilyMemberSummary[] = [];
+
+          const hasExistingSplits = receipt.items.some(
+            (item) => item.splits && item.splits.length > 0
+          );
 
           if (hasExistingSplits) {
             const splitMemberIds = new Set<number>();
-            receipt.items.forEach((item: any) => {
+            receipt.items.forEach((item) => {
               if (item.splits) {
-                item.splits.forEach((s: any) => splitMemberIds.add(s.familyMemberId));
+                item.splits.forEach((s) => splitMemberIds.add(s.familyMemberId));
               }
             });
-            
-            const payer = res.data.find((m: any) => m.id === receipt.memberId);
+
+            const payer = res.data.find((m) => m.id === receipt.memberId);
             if (payer) initialActive.push(payer);
-            
-            res.data.forEach((m: any) => {
+
+            res.data.forEach((m) => {
               if (splitMemberIds.has(m.id) && m.id !== receipt.memberId) {
                 initialActive.push(m);
               }
             });
 
           } else {
-            const payer = res.data.find((m: any) => m.id === receipt.memberId);
+            const payer = res.data.find((m) => m.id === receipt.memberId);
             if (payer) initialActive.push(payer);
-            const others = res.data.filter((m: any) => m.id !== receipt.memberId);
+            const others = res.data.filter((m) => m.id !== receipt.memberId);
             if (others.length > 0) initialActive.push(others[0]);
           }
 
@@ -96,17 +103,20 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     init();
   }, [receipt]);
 
-  const initializeSplits = (familyMembers: any[], targetMembers: any[]) => {
+  const initializeSplits = (
+    _familyMembers: FamilyMemberSummary[],
+    targetMembers: FamilyMemberSummary[]
+  ) => {
     if (!receipt || !receipt.items) return;
-    
+
     const initialData: Record<number, Record<number, number>> = {};
-    receipt.items.forEach((item: any) => {
+    receipt.items.forEach((item) => {
       initialData[item.id] = {};
       const itemTotal = calcItemTotal(item);
 
       if (item.splits && item.splits.length > 0) {
         targetMembers.forEach(m => {
-          const split = item.splits.find((s: any) => s.familyMemberId === m.id);
+          const split = item.splits!.find((s) => s.familyMemberId === m.id);
           initialData[item.id][m.id] = split ? split.amount : 0;
         });
       } else {
@@ -223,7 +233,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
 
     setEditSplits(prev => {
       const next = { ...prev };
-      receipt.items.forEach((item: any) => {
+      receipt.items.forEach((item) => {
         const itemTotal = calcItemTotal(item);
         const newData = { ...next[item.id] };
 
@@ -266,7 +276,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
 
   // ★ 追加: レシート全体を均等割り
   const splitWholeReceiptEqually = () => {
-    receipt.items.forEach((item: any) => {
+    receipt.items.forEach((item) => {
       splitItemEqually(item.id, calcItemTotal(item));
     });
   };
@@ -280,7 +290,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     const remainderMemberId = activeMembers[0].id;
     setSaving(true);
     try {
-      const savePromises = receipt.items.map(async (item: any) => {
+      const savePromises = receipt.items.map(async (item) => {
         const amounts = editSplits[item.id] ?? {};
         const payloadSplits = buildItemSplitSavePayload(
           activeMembers,
@@ -312,14 +322,14 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
 
   // レシート全体の合計額を算出
   const receiptTotalAmount = receipt.items.reduce(
-    (sum: number, item: any) => sum + calcItemTotal(item),
+    (sum, item) => sum + calcItemTotal(item),
     0
   );
 
   // 合計行表示用: メンバーごとの合計額を計算
   const getMemberTotalAmount = (memberId: number) => {
     let sum = 0;
-    receipt.items.forEach((item: any) => {
+    receipt.items.forEach((item) => {
       sum += editSplits[item.id]?.[memberId] || 0;
     });
     return sum;
@@ -408,7 +418,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
                 <Text style={[tableStyles.cell, styles.cellAction, tableStyles.headerText]}>操作</Text>
               </View>
 
-              {receipt.items.map((item: any) => {
+              {receipt.items.map((item: ReceiptItemForSplit) => {
                 const itemTotal = calcItemTotal(item);
 
                 return (

--- a/frontend/src/types/settlement.ts
+++ b/frontend/src/types/settlement.ts
@@ -1,0 +1,63 @@
+/** API 成功レスポンス（精算・按分ドメイン） */
+export type ApiSuccessResponse<T> = {
+  success: true;
+  data: T;
+};
+
+export type FamilyMemberSummary = {
+  id: number;
+  name: string;
+};
+
+export type ItemSplitRecord = {
+  familyMemberId: number;
+  amount: number;
+};
+
+/** 割り勘エディタで扱うレシート明細 */
+export type ReceiptItemForSplit = {
+  id: number;
+  name?: string;
+  price?: number;
+  quantity?: number;
+  splits?: ItemSplitRecord[];
+};
+
+/** 履歴から渡される割り勘対象レシート */
+export type ReceiptForSplitEditor = {
+  id: number;
+  memberId: number;
+  imagePath?: string | null;
+  storeName?: string;
+  items: ReceiptItemForSplit[];
+};
+
+export type ItemSplitSavePayload = {
+  familyMemberId: number;
+  amount: number;
+};
+
+export type SettlementMemberSummary = {
+  memberId: number;
+  name: string;
+  totalPaid: number;
+  totalOwed: number;
+  baseBalance: number;
+  transferredOut: number;
+  transferredIn: number;
+  balance: number;
+};
+
+export type SettlementTransfer = {
+  id: number;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  settledAt: string;
+};
+
+export type SettlementStatusData = {
+  month: string;
+  members: SettlementMemberSummary[];
+  transfers: SettlementTransfer[];
+};

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -93,26 +93,46 @@ apiClient.interceptors.response.use(
   }
 );
 
+import type {
+  ApiSuccessResponse,
+  FamilyMemberSummary,
+  ItemSplitSavePayload,
+  SettlementStatusData,
+  SettlementTransfer,
+} from '../types/settlement';
+
+export type ItemSplitSaveRequest = ItemSplitSavePayload & {
+  ratio?: number;
+};
+
 // ★ [Issue #78/#79/#80/#81] 各種APIコール用ラッパー
 export const api = {
-  getFamilyMembers: async () => {
+  getFamilyMembers: async (): Promise<ApiSuccessResponse<FamilyMemberSummary[]>> => {
     const res = await apiClient.get('/family-groups/members');
     return res.data;
   },
-  saveItemSplits: async (itemId: number, splits: { familyMemberId: number; amount?: number; ratio?: number }[]) => {
+  saveItemSplits: async (
+    itemId: number,
+    splits: ItemSplitSaveRequest[]
+  ): Promise<ApiSuccessResponse<unknown>> => {
     const res = await apiClient.post(`/receipts/items/${itemId}/splits`, { splits });
     return res.data;
   },
-  // [Issue #80] 月間精算ステータスの取得メソッド
-  getSettlementStatus: async (month: string) => {
+  getSettlementStatus: async (
+    month: string
+  ): Promise<ApiSuccessResponse<SettlementStatusData>> => {
     const res = await apiClient.get('/stats/settlement', { params: { month } });
     return res.data;
   },
-  // ★ [Issue #81] 送金記録の登録メソッドを追加
-  addSettlementTransfer: async (payload: { month: string; fromMemberId: number; toMemberId: number; amount: number }) => {
+  addSettlementTransfer: async (payload: {
+    month: string;
+    fromMemberId: number;
+    toMemberId: number;
+    amount: number;
+  }): Promise<ApiSuccessResponse<SettlementTransfer>> => {
     const res = await apiClient.post('/stats/settlement/transfers', payload);
     return res.data;
-  }
+  },
 };
 
 export default apiClient;

--- a/frontend/src/utils/splitEditorSplits.ts
+++ b/frontend/src/utils/splitEditorSplits.ts
@@ -1,4 +1,6 @@
-/** 明細の税込小計（Backend の updateItemSplits と同じ丸め） */
+import type { ItemSplitSavePayload } from '../types/settlement';
+
+/** 明細の税込小計（Backend の calcItemLineTotal と同じ丸め） */
 export function calcItemTotal(item: {
   price?: unknown;
   quantity?: unknown;
@@ -19,7 +21,7 @@ export function buildItemSplitSavePayload(
   activeMembers: SplitSaveMember[],
   amountsByMemberId: Record<number, number>,
   remainderMemberId: number
-): { familyMemberId: number; amount: number }[] {
+): ItemSplitSavePayload[] {
   if (activeMembers.length === 0) return [];
 
   const others = activeMembers.filter((m) => m.id !== remainderMemberId);


### PR DESCRIPTION
## Summary

Issue #87-4（GitHub #260）— #87-2 / #87-3 の横断 Should 対応。

- `frontend/src/types/settlement.ts` … 精算サマリー・割り勘・API レスポンス型
- `apiClient` … `getSettlementStatus` / `getFamilyMembers` / 送金 API の戻り値型
- `SplitEditorScreen` / `SettlementSummaryScreen` … 精算ドメインの `any` 除去
- `backend/src/utils/itemLineTotal.ts` … FE `calcItemTotal` と同式の小計計算
- `docs/reviews/issue-87/results/cross-cutting.md` … 対応・見送り一覧

## スコープ外（記録のみ）

- SplitEditor コンポーネント分割（R-F005）
- 送金の取消・訂正 → Issue #88 (#265)
- `HistoryScreen` の receipt `any`

## Test plan

- [ ] `cd frontend && npx tsc --noEmit`
- [ ] 割り勘保存 → 精算サマリー金額一致（挙動不変）
- [ ] 精算サマリー: 月切替・送金モーダル
- [ ] Web / スマホで上記の退行なし

Closes #260

Made with [Cursor](https://cursor.com)