### PR TITLE
fix(infra): [Issue #89] バックアップ cron 用 logs ディレクトリの再発防止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,9 @@ jobs:
             --exclude 'pgdata' \
             --exclude 'redisdata' \
             --exclude 'uploads' \
+            --exclude 'logs' \
             ./ ~/stable/receipt-ai-app/
+          mkdir -p ~/stable/receipt-ai-app/logs
 
       - name: Create Stable .env
         run: |

--- a/docs/restore-manual.md
+++ b/docs/restore-manual.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 0. バックアップが増えないとき（cron）
+
+stable の定期バックアップは `crontab`（4:00 / `@reboot`）で `scripts/backup.sh` を実行する。ログは `{プロジェクト}/logs/backup_{env}.log` に追記される。
+
+**`logs/` が無いと cron のリダイレクトが失敗し、バックアップ自体が走らない**（Issue #89）。`main` デプロイ後は次を確認する。
+
+```bash
+mkdir -p ~/stable/receipt-ai-app/logs
+cd ~/stable/receipt-ai-app && ./scripts/backup.sh stable
+tail ~/stable/receipt-ai-app/logs/backup_stable.log
+```
+
+cron 行を直す場合は `setup-env.sh stable` を再実行する（`mkdir -p logs` を含む行に更新される）。
+
+---
+
 ## 1. 事前準備：最新バックアップのタイムスタンプ確認
 
 リストアを実行する前に、まずは復元に使用するバックアップファイルの「タイムスタンプ（日時情報）」を確認する。

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -110,7 +110,8 @@ EOF
 echo "✅ Environment variables created."
 
 # ★ [Issue #41] Cronジョブの自動登録（定期実行 ＆ 起動時実行の多重登録）
-CRON_CMD="${PROJECT_ROOT}/scripts/backup.sh $ENV >> ${PROJECT_ROOT}/logs/backup_${ENV}.log 2>&1"
+# ★ [Issue #89] logs/ が無いとリダイレクトで cron 全体が失敗するため先に mkdir
+CRON_CMD="mkdir -p \"${PROJECT_ROOT}/logs\" && ${PROJECT_ROOT}/scripts/backup.sh $ENV >> ${PROJECT_ROOT}/logs/backup_${ENV}.log 2>&1"
 
 # 現在のcronを一時ファイルに出力 (存在しない場合は空ファイル作成)
 crontab -l > /tmp/current_cron 2>/dev/null || touch /tmp/current_cron


### PR DESCRIPTION
## Summary

Issue #89（#270）— stable で 5/29 以降バックアップが止まっていた原因への対応。

**原因**: `deploy.yml` の `rsync --delete` が `~/stable/receipt-ai-app/logs/` を削除 → cron の `>> logs/backup_stable.log` が失敗し `backup.sh` 未実行。

## 変更

- `.github/workflows/deploy.yml` … `--exclude 'logs'`、`mkdir -p logs`  after rsync
- `setup-env.sh` … cron 行の先頭で `mkdir -p logs`（dev/stable 共通）
- `docs/restore-manual.md` … トラブルシュート節を追加

## マージ後（T320・手動）

1. `develop` → `main` マージで CD 反映（または `deploy.yml` 相当を手動適用）
2. 既存 crontab を更新:
   ```bash
   cd ~/stable/receipt-ai-app && ./setup-env.sh stable
   ```
   （`.env.secret` が必要。上書きが嫌な場合は `crontab -e` で行頭に `mkdir -p .../logs &&` を追加）
3. 即時バックアップ:
   ```bash
   mkdir -p ~/stable/receipt-ai-app/logs
   ~/stable/receipt-ai-app/scripts/backup.sh stable
   ```

Closes #270

Made with [Cursor](https://cursor.com)