### PR TITLE
fix(infra): stable Web ログイン CORS（:80 省略 Origin 対応）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
           GEMINI_MODEL="${{ vars.GEMINI_MODEL || 'gemini-flash-latest' }}"
           GEMINI_RETRY_COUNT=3
           GEMINI_RETRY_DELAY=2000
-          CORS_ORIGIN="http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_WEB_PORT }}"
+          CORS_ORIGIN="http://${{ secrets.HOST_IP }},http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_WEB_PORT }}"
           LOG_LEVEL=info
           EOF
 

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -55,7 +55,8 @@ else
     DB_PORT=5432
     REDIS_PORT=6379
     BACKEND_COMMAND="npm run start"
-    CORS_ORIGIN="http://$HOST_IP:$WEB_PORT"
+    # ブラウザ Origin は :80 省略のことがあるため両方許可（Issue #89 ログイン CORS）
+    CORS_ORIGIN="http://$HOST_IP,http://$HOST_IP:$WEB_PORT"
     GEMINI_MODEL="gemini-flash-latest"
     CRON_SCHEDULE="0 4 * * *" # stable環境は毎日午前4時に実行
 fi


### PR DESCRIPTION
## Summary

stable Web（`http://192.168.1.32`）から API（`:3000`）へログインするとき、
`Access-Control-Allow-Origin: http://192.168.1.32:80` とブラウザ Origin
`http://192.168.1.32` が一致せず CORS でブロックされていた。

`CORS_ORIGIN` に `http://HOST` と `http://HOST:WEB_PORT` の両方を設定。

## マージ前の暫定（T320）

```bash
cd ~/stable/receipt-ai-app
sed -i 's|^CORS_ORIGIN=.*|CORS_ORIGIN="http://192.168.1.32,http://192.168.1.32:80"|' backend/.env
docker compose restart backend
```

## Test plan

- [ ] `http://192.168.1.32/` でログイン成功
- [ ] ブラウザコンソールに CORS エラーなし

Made with [Cursor](https://cursor.com)