### PR TITLE
feat(settlement): [Issue #88] 送金記録の取消と履歴一覧

### DIFF
--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../utils/prismaClient';
 import { getFamilyGroupId } from '../utils/context';
+import { AppError } from '../utils/appError';
 import {
   getCurrentYearMonthLocal,
   getLocalMonthDateRange,
@@ -195,6 +196,46 @@ export const addSettlementTransfer = async (req: Request, res: Response, next: N
       data: newTransfer
     });
 
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * [Issue #88] 送金記録の取消（物理削除）
+ * DELETE /api/stats/settlement/transfers/:id
+ */
+export const deleteSettlementTransfer = async (
+  req: Request<{ id: string }>,
+  res: Response,
+  next: NextFunction
+) => {
+  const familyGroupId = getFamilyGroupId();
+  const transferId = Number(req.params.id);
+
+  if (!Number.isFinite(transferId) || transferId <= 0) {
+    return res.status(400).json({ success: false, message: '送金記録IDが不正です。' });
+  }
+
+  try {
+    const transfer = await prisma.settlementTransfer.findUnique({
+      where: { id: transferId },
+      include: {
+        sender: { select: { familyGroupId: true } },
+      },
+    });
+
+    if (!transfer) {
+      throw new AppError('送金記録が見つかりません。', 404);
+    }
+
+    if (transfer.sender.familyGroupId !== familyGroupId) {
+      throw new AppError('この送金記録を操作する権限がありません。', 403);
+    }
+
+    await prisma.settlementTransfer.delete({ where: { id: transferId } });
+
+    res.status(200).json({ success: true, data: { id: transferId } });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -1,5 +1,9 @@
 import express from 'express';
-import { getSettlementStatus, addSettlementTransfer } from '../controllers/statsController';
+import {
+  getSettlementStatus,
+  addSettlementTransfer,
+  deleteSettlementTransfer,
+} from '../controllers/statsController';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { tenantMiddleware } from '../middleware/tenantMiddleware';
 
@@ -13,5 +17,6 @@ router.get('/settlement', getSettlementStatus);
 
 // ★ [Issue #81] 送金履歴の追加
 router.post('/settlement/transfers', addSettlementTransfer);
+router.delete('/settlement/transfers/:id', deleteSettlementTransfer);
 
 export default router;

--- a/frontend/src/constants/buttonLabels.ts
+++ b/frontend/src/constants/buttonLabels.ts
@@ -10,6 +10,7 @@ export const BUTTON_LABELS = {
   add: '追加',
   create: '新規作成',
   recordTransfer: '送金を記録',
+  cancelTransfer: '取消',
   setDefault: 'デフォルトに設定',
   splitEqual: '均等',
 } as const;

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -21,11 +21,26 @@ import { theme, tableStyles, BREAKPOINTS } from '../theme';
 import { api } from '../utils/apiClient';
 import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 import { showAlert } from '../utils/alertMessage';
+import { showConfirmDialog } from '../utils/confirmDialog';
 import {
   hasNegativeAmountSign,
   parsePositiveYenAmount,
 } from '../utils/parsePositiveYenAmount';
-import type { SettlementMemberSummary } from '../types/settlement';
+import type {
+  SettlementMemberSummary,
+  SettlementTransfer,
+} from '../types/settlement';
+
+function formatTransferDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('ja-JP', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
 
 interface SettlementSummaryScreenProps {
   onBack: () => void;
@@ -38,6 +53,10 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
   const [summaryData, setSummaryData] = useState<SettlementMemberSummary[]>([]);
+  const [transferList, setTransferList] = useState<SettlementTransfer[]>([]);
+  const [cancellingTransferId, setCancellingTransferId] = useState<number | null>(
+    null
+  );
 
   // 送金モーダル用ステート
   const [isTransferModalVisible, setTransferModalVisible] = useState(false);
@@ -64,6 +83,21 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   );
 
   const monthSelectOptions = useMonthSelectOptions(months, isWide);
+
+  const memberNameById = useMemo(() => {
+    const map = new Map<number, string>();
+    summaryData.forEach((m) => map.set(m.memberId, m.name));
+    return map;
+  }, [summaryData]);
+
+  const sortedTransfers = useMemo(
+    () =>
+      [...transferList].sort(
+        (a, b) =>
+          new Date(b.settledAt).getTime() - new Date(a.settledAt).getTime()
+      ),
+    [transferList]
+  );
 
   const openTransferModal = () => {
     setTransferFieldErrors({});
@@ -94,12 +128,15 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
     return Object.keys(errors).length === 0;
   };
 
-  const loadSettlementData = async () => {
+  const loadSettlementData = async (options?: { silent?: boolean }) => {
     try {
-      setLoading(true);
+      if (!options?.silent) {
+        setLoading(true);
+      }
       const res = await api.getSettlementStatus(selectedMonth);
       if (res.success) {
         setSummaryData(res.data?.members ?? []);
+        setTransferList(res.data?.transfers ?? []);
       }
     } catch (err) {
       console.error('精算サマリーの取得失敗:', err);
@@ -146,6 +183,50 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const executeCancelTransfer = async (transfer: SettlementTransfer) => {
+    const fromName =
+      memberNameById.get(transfer.fromMemberId) ?? `ID:${transfer.fromMemberId}`;
+    const toName =
+      memberNameById.get(transfer.toMemberId) ?? `ID:${transfer.toMemberId}`;
+
+    setCancellingTransferId(transfer.id);
+    try {
+      const res = await api.deleteSettlementTransfer(transfer.id);
+      if (res.success) {
+        showAlert('完了', '送金記録を取り消しました。');
+        await loadSettlementData({ silent: true });
+      }
+    } catch (err) {
+      console.error('送金取消エラー', err);
+      showAlert(
+        'エラー',
+        `${fromName} → ${toName} ¥${transfer.amount.toLocaleString()} の取消に失敗しました。`
+      );
+    } finally {
+      setCancellingTransferId(null);
+    }
+  };
+
+  const handleCancelTransfer = (transfer: SettlementTransfer) => {
+    const fromName =
+      memberNameById.get(transfer.fromMemberId) ?? `ID:${transfer.fromMemberId}`;
+    const toName =
+      memberNameById.get(transfer.toMemberId) ?? `ID:${transfer.toMemberId}`;
+
+    showConfirmDialog(
+      '送金記録の取消',
+      `${fromName} → ${toName}\n¥${transfer.amount.toLocaleString()}\n\nこの送金記録を取り消しますか？精算残額が更新されます。`,
+      [
+        { text: BUTTON_LABELS.cancel, style: 'cancel' },
+        {
+          text: BUTTON_LABELS.cancelTransfer,
+          style: 'destructive',
+          onPress: () => executeCancelTransfer(transfer),
+        },
+      ]
+    );
   };
 
   return (
@@ -292,6 +373,44 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
                 );
               })}
             </View>
+          </View>
+
+          <View style={styles.transferHistoryContainer}>
+            <Text style={styles.tableTitle}>💸 送金履歴（{selectedMonth}）</Text>
+            {sortedTransfers.length === 0 ? (
+              <Text style={styles.transferHistoryEmpty}>
+                この月に登録された送金はありません。
+              </Text>
+            ) : (
+              sortedTransfers.map((t) => {
+                const fromName =
+                  memberNameById.get(t.fromMemberId) ?? `ID:${t.fromMemberId}`;
+                const toName =
+                  memberNameById.get(t.toMemberId) ?? `ID:${t.toMemberId}`;
+                const isCancelling = cancellingTransferId === t.id;
+
+                return (
+                  <View key={t.id} style={styles.transferHistoryRow}>
+                    <View style={styles.transferHistoryMain}>
+                      <Text style={styles.transferHistoryLine}>
+                        {fromName} → {toName}
+                      </Text>
+                      <Text style={styles.transferHistoryMeta}>
+                        ¥{t.amount.toLocaleString()} · {formatTransferDate(t.settledAt)}
+                      </Text>
+                    </View>
+                    <AppButton
+                      title={BUTTON_LABELS.cancelTransfer}
+                      onPress={() => handleCancelTransfer(t)}
+                      variant="danger"
+                      size="sm"
+                      loading={isCancelling}
+                      disabled={cancellingTransferId !== null}
+                    />
+                  </View>
+                );
+              })
+            )}
           </View>
 
         </ScrollView>
@@ -444,4 +563,37 @@ const styles = StyleSheet.create({
   tableTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 15, color: theme.colors.text.main },
   cellName: { flex: 1.5, minWidth: 100 },
   cellAmount: { flex: 1, textAlign: 'right' },
+
+  transferHistoryContainer: {
+    marginTop: 24,
+    backgroundColor: theme.colors.surface,
+    padding: 20,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  transferHistoryEmpty: {
+    fontSize: 14,
+    color: theme.colors.text.muted,
+  },
+  transferHistoryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  transferHistoryMain: { flex: 1, minWidth: 0 },
+  transferHistoryLine: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: theme.colors.text.main,
+  },
+  transferHistoryMeta: {
+    fontSize: 13,
+    color: theme.colors.text.muted,
+    marginTop: 4,
+  },
 });

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -133,6 +133,12 @@ export const api = {
     const res = await apiClient.post('/stats/settlement/transfers', payload);
     return res.data;
   },
+  deleteSettlementTransfer: async (
+    id: number
+  ): Promise<ApiSuccessResponse<{ id: number }>> => {
+    const res = await apiClient.delete(`/stats/settlement/transfers/${id}`);
+    return res.data;
+  },
 };
 
 export default apiClient;


### PR DESCRIPTION
## Summary

Issue #88（#265）— 送金記録の訂正・取消（MVP: 取消のみ）。

- Backend: `DELETE /api/stats/settlement/transfers/:id`（世帯テナント検証）
- Frontend: 精算サマリーに当月送金履歴一覧と「取消」操作
- `showConfirmDialog` / `showAlert` で Web・スマホ対応

## スコープ外

- 送金の編集 UI/API（フェーズ2）
- マイナス金額による相殺

## Test plan

- [x] 送金登録 → 履歴表示 → 取消 → 残額が戻る
- [x] 表示月と DB の `month` を一致させた確認
- [x] Web: 確認ダイアログ・完了通知
- [x] `npx tsc --noEmit`

Closes #265

Made with [Cursor](https://cursor.com)