### PR TITLE
test: [Issue #91-2] Backend utils 単体テスト

### DIFF
--- a/backend/src/utils/categoryColor.test.ts
+++ b/backend/src/utils/categoryColor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { CATEGORY_COLOR_PALETTE, pickNextCategoryColor } from './categoryColor';
+
+describe('pickNextCategoryColor', () => {
+  it('returns first palette color when none are used', () => {
+    expect(pickNextCategoryColor([])).toBe(CATEGORY_COLOR_PALETTE[0]);
+  });
+
+  it('skips colors already used (case-insensitive)', () => {
+    const used = CATEGORY_COLOR_PALETTE.slice(0, 3).map((c) => c.toUpperCase());
+    expect(pickNextCategoryColor(used)).toBe(CATEGORY_COLOR_PALETTE[3]);
+  });
+
+  it('ignores empty and null entries', () => {
+    expect(pickNextCategoryColor([null, '', '   '])).toBe(CATEGORY_COLOR_PALETTE[0]);
+  });
+
+  it('generates fallback hex when palette is exhausted', () => {
+    const allUsed = [...CATEGORY_COLOR_PALETTE];
+    const fallback = pickNextCategoryColor(allUsed);
+
+    expect(fallback).toMatch(/^#[0-9a-f]{6}$/);
+    expect(allUsed.map((c) => c.toLowerCase())).not.toContain(fallback.toLowerCase());
+  });
+});

--- a/backend/src/utils/itemLineTotal.test.ts
+++ b/backend/src/utils/itemLineTotal.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { calcItemLineTotal } from './itemLineTotal';
+
+describe('calcItemLineTotal', () => {
+  it('rounds price × quantity to integer yen', () => {
+    expect(calcItemLineTotal(99.5, 2)).toBe(199);
+  });
+
+  it('parses string price and quantity', () => {
+    expect(calcItemLineTotal('108', '3')).toBe(324);
+  });
+
+  it('defaults quantity to 1', () => {
+    expect(calcItemLineTotal(498)).toBe(498);
+  });
+
+  it('treats invalid quantity as 1', () => {
+    expect(calcItemLineTotal(100, 'abc')).toBe(100);
+  });
+
+  it('returns 0 for zero price', () => {
+    expect(calcItemLineTotal(0, 5)).toBe(0);
+  });
+});

--- a/backend/src/utils/itemSplitAllocation.test.ts
+++ b/backend/src/utils/itemSplitAllocation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { AppError } from './appError';
 import { allocateItemSplits } from './itemSplitAllocation';
 
 describe('allocateItemSplits', () => {
@@ -13,7 +14,75 @@ describe('allocateItemSplits', () => {
     expect(result.reduce((sum, s) => sum + s.amount, 0)).toBe(100);
   });
 
+  it('allocates by explicit amounts and remainder on last member', () => {
+    const result = allocateItemSplits(100, [
+      { familyMemberId: 1, amount: 40 },
+      { familyMemberId: 2, amount: 35 },
+      { familyMemberId: 3 },
+    ]);
+
+    expect(result).toEqual([
+      { familyMemberId: 1, amount: 40 },
+      { familyMemberId: 2, amount: 35 },
+      { familyMemberId: 3, amount: 25 },
+    ]);
+  });
+
+  it('handles two-member equal ratio with odd total', () => {
+    const result = allocateItemSplits(101, [
+      { familyMemberId: 10, ratio: 0.5 },
+      { familyMemberId: 20, ratio: 0.5 },
+    ]);
+
+    expect(result.map((s) => s.amount)).toEqual([51, 50]);
+  });
+
   it('returns empty array when no splits', () => {
     expect(allocateItemSplits(100, [])).toEqual([]);
+  });
+
+  it('accepts zero total with zero splits on each member', () => {
+    const result = allocateItemSplits(0, [{ familyMemberId: 1, ratio: 1 }]);
+    expect(result).toEqual([{ familyMemberId: 1, amount: 0 }]);
+  });
+
+  it('throws when total is negative', () => {
+    expect(() => allocateItemSplits(-1, [{ familyMemberId: 1, ratio: 1 }])).toThrow(
+      AppError
+    );
+  });
+
+  it('throws on duplicate familyMemberId', () => {
+    expect(() =>
+      allocateItemSplits(100, [
+        { familyMemberId: 1, ratio: 0.5 },
+        { familyMemberId: 1, ratio: 0.5 },
+      ])
+    ).toThrow(AppError);
+  });
+
+  it('throws on invalid familyMemberId', () => {
+    expect(() =>
+      allocateItemSplits(100, [{ familyMemberId: 0, ratio: 1 }])
+    ).toThrow(AppError);
+  });
+
+  it('throws when non-last split lacks ratio and amount', () => {
+    expect(() =>
+      allocateItemSplits(100, [
+        { familyMemberId: 1 },
+        { familyMemberId: 2, ratio: 1 },
+      ])
+    ).toThrow(AppError);
+  });
+
+  it('throws when explicit amounts exceed total before last member', () => {
+    expect(() =>
+      allocateItemSplits(100, [
+        { familyMemberId: 1, amount: 60 },
+        { familyMemberId: 2, amount: 50 },
+        { familyMemberId: 3 },
+      ])
+    ).toThrow(AppError);
   });
 });

--- a/backend/src/utils/yearMonth.test.ts
+++ b/backend/src/utils/yearMonth.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getCurrentYearMonthLocal,
+  getLocalMonthDateRange,
+  normalizeYearMonth,
+} from './yearMonth';
+
+describe('normalizeYearMonth', () => {
+  it('normalizes single-digit month', () => {
+    expect(normalizeYearMonth('2026-5')).toBe('2026-05');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeYearMonth('  2026-12  ')).toBe('2026-12');
+  });
+
+  it('returns null for invalid format', () => {
+    expect(normalizeYearMonth('2026/05')).toBeNull();
+    expect(normalizeYearMonth('')).toBeNull();
+    expect(normalizeYearMonth(null)).toBeNull();
+  });
+});
+
+describe('getLocalMonthDateRange', () => {
+  it('returns local midnight boundaries for the given month', () => {
+    const { start, end } = getLocalMonthDateRange('2026-05');
+
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(4);
+    expect(start.getDate()).toBe(1);
+    expect(start.getHours()).toBe(0);
+
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(5);
+    expect(end.getDate()).toBe(1);
+  });
+
+  it('falls back to current month when input is invalid', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15, 12, 0, 0)); // 2026-03-15 local
+
+    const { start, end } = getLocalMonthDateRange('invalid');
+
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(2);
+    expect(end.getMonth()).toBe(3);
+
+    vi.useRealTimers();
+  });
+});
+
+describe('getCurrentYearMonthLocal', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns YYYY-MM in local timezone', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 31, 23, 30, 0)); // still January locally
+
+    expect(getCurrentYearMonthLocal()).toBe('2026-01');
+  });
+});


### PR DESCRIPTION
## Summary

- `itemSplitAllocation` — 端数・明示金額・2人按分・異常系（重複 ID、合計不一致等）
- `itemLineTotal` — 丸め・文字列入力・quantity デフォルト
- `yearMonth` — 正規化・ローカル月境界・不正入力フォールバック
- `categoryColor` — パレット選択・大文字小文字・枯渇時フォールバック

Closes #279

## Test plan

- [x] `cd backend && npm test` — 25 passed（4 files）
- [ ] レビュー: 按分端数ケースが #87-2 仕様と一致していること

## スコープ外

- `normalizer.ts`（Prisma 依存）→ #91-7


Made with [Cursor](https://cursor.com)