### PR TITLE
test: [Issue #91-4] Frontend utils 単体テスト

### DIFF
--- a/frontend/src/utils/parsePositiveYenAmount.test.ts
+++ b/frontend/src/utils/parsePositiveYenAmount.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { hasNegativeAmountSign, parsePositiveYenAmount } from './parsePositiveYenAmount';
+
+describe('hasNegativeAmountSign', () => {
+  it('detects half-width and full-width minus signs', () => {
+    expect(hasNegativeAmountSign('-1000')).toBe(true);
+    expect(hasNegativeAmountSign('－1000')).toBe(true);
+    expect(hasNegativeAmountSign('1000')).toBe(false);
+  });
+});
+
+describe('parsePositiveYenAmount', () => {
+  it('parses positive integer yen from formatted input', () => {
+    expect(parsePositiveYenAmount('5,000円')).toBe(5000);
+  });
+
+  it('rejects negative-looking input without extracting digits', () => {
+    expect(parsePositiveYenAmount('-5000')).toBeNull();
+    expect(parsePositiveYenAmount('－5000')).toBeNull();
+  });
+
+  it('rejects zero and empty input', () => {
+    expect(parsePositiveYenAmount('0')).toBeNull();
+    expect(parsePositiveYenAmount('')).toBeNull();
+    expect(parsePositiveYenAmount('   ')).toBeNull();
+  });
+
+  it('rejects non-numeric input', () => {
+    expect(parsePositiveYenAmount('abc')).toBeNull();
+  });
+});

--- a/frontend/src/utils/splitEditorSplits.test.ts
+++ b/frontend/src/utils/splitEditorSplits.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { buildItemSplitSavePayload, calcItemTotal } from './splitEditorSplits';
 
-describe('splitEditorSplits', () => {
-  it('calculates item total with rounding', () => {
+describe('calcItemTotal', () => {
+  it('matches backend calcItemLineTotal rounding', () => {
     expect(calcItemTotal({ price: 99.5, quantity: 2 })).toBe(199);
   });
 
-  it('places remainder member at end of payload', () => {
+  it('defaults quantity to 1', () => {
+    expect(calcItemTotal({ price: 108 })).toBe(108);
+  });
+
+  it('handles string-like values from API', () => {
+    expect(calcItemTotal({ price: '250', quantity: '2' })).toBe(500);
+  });
+});
+
+describe('buildItemSplitSavePayload', () => {
+  it('places remainder member at end for backend last-element rule', () => {
     const payload = buildItemSplitSavePayload(
       [{ id: 1 }, { id: 2 }, { id: 3 }],
       { 1: 33, 2: 33, 3: 34 },
@@ -15,5 +25,29 @@ describe('splitEditorSplits', () => {
 
     expect(payload.map((p) => p.familyMemberId)).toEqual([2, 3, 1]);
     expect(payload.map((p) => p.amount)).toEqual([33, 34, 33]);
+  });
+
+  it('returns empty array when no active members', () => {
+    expect(buildItemSplitSavePayload([], {}, 1)).toEqual([]);
+  });
+
+  it('keeps member order when remainder id is not found', () => {
+    const payload = buildItemSplitSavePayload(
+      [{ id: 1 }, { id: 2 }],
+      { 1: 60, 2: 40 },
+      99
+    );
+
+    expect(payload.map((p) => p.familyMemberId)).toEqual([1, 2]);
+    expect(payload.map((p) => p.amount)).toEqual([60, 40]);
+  });
+
+  it('defaults missing amounts to zero', () => {
+    const payload = buildItemSplitSavePayload([{ id: 1 }, { id: 2 }], {}, 2);
+
+    expect(payload).toEqual([
+      { familyMemberId: 1, amount: 0 },
+      { familyMemberId: 2, amount: 0 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- `splitEditorSplits` — 小計丸め、端数メンバー末尾配置、空メンバー、欠損 amount
- `parsePositiveYenAmount` — 正の円パース、マイナス記号拒否、ゼロ/空/非数値

Closes #281

## Test plan

- [x] `cd frontend && npm test` — 12 passed（2 files）
- [ ] Backend #91-2 マージ後、按分端数ケースが FE/BE で一致していること

## スコープ外

- Screen コンポーネント（jest-expo + RNTL）
- `alertMessage.ts`（RN モックが必要）


Made with [Cursor](https://cursor.com)