### PR TITLE
test: [Issue #91-3] app 分離 + Supertest API 結合テスト

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "prisma db seed",
     "prisma:sync-sequences": "npx tsx prisma/run-sync-sequences.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "RUN_API_INTEGRATION=1 vitest run src/app.integration.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -1,0 +1,75 @@
+import './test/mockReceiptQueue';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app';
+import {
+  ensureTestMemberPassword,
+  loginAsTestMember,
+  shouldRunDbIntegration,
+} from './test/integrationHelpers';
+import { prisma } from './utils/prismaClient';
+
+const app = createApp();
+
+describe('API integration (no DB)', () => {
+  it('GET /health returns ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('GET /api/receipts without auth returns 401', async () => {
+    const res = await request(app).get('/api/receipts');
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('POST /api/auth/login without body returns 400', async () => {
+    const res = await request(app).post('/api/auth/login').send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () => {
+  beforeAll(async () => {
+    await ensureTestMemberPassword(1);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('POST /api/auth/login succeeds with test password', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ memberId: 1, password: 'integration-test-password' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.token).toBeDefined();
+    expect(res.body.data.member.familyGroupId).toBeDefined();
+  });
+
+  it('GET /api/receipts with token returns success envelope', async () => {
+    const token = await loginAsTestMember(app);
+    const res = await request(app)
+      .get('/api/receipts')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('GET /api/categories with token returns categories', async () => {
+    const token = await loginAsTestMember(app);
+    const res = await request(app)
+      .get('/api/categories')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,89 @@
+import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import path from 'path';
+import fs from 'fs';
+
+import { authMiddleware } from './middleware/authMiddleware';
+import { tenantMiddleware } from './middleware/tenantMiddleware';
+import authRoutes from './routes/authRoutes';
+import receiptRoutes from './routes/receiptRoutes';
+import productMasterRoutes from './routes/productMasterRoutes';
+import categoryRoutes from './routes/categoryRoutes';
+import adminRoutes from './routes/adminRoutes';
+import statsRoutes from './routes/statsRoutes';
+import { AppError } from './utils/appError';
+import { errorHandler } from './middleware/errorHandler';
+import logger from './utils/logger';
+
+/**
+ * Express アプリ本体（Supertest / 本番起動で共有）。
+ * BullMQ Worker の起動は server.ts の責務。
+ */
+export function createApp() {
+  const app = express();
+  const nodeEnv = process.env.NODE_ENV || 'development';
+
+  const getAllowedOrigins = () => {
+    const rawOrigins = process.env.CORS_ORIGIN || '';
+    if (rawOrigins.includes(',')) {
+      return rawOrigins.split(',').map((o) => o.trim());
+    }
+    if (rawOrigins) return rawOrigins;
+    if (nodeEnv === 'production') {
+      logger.warn('[CORS] CORS_ORIGIN is not defined in production!');
+      return false;
+    }
+    return true;
+  };
+
+  const allowedOrigins = getAllowedOrigins();
+
+  app.use(
+    cors({
+      origin: allowedOrigins,
+      methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'x-member-id'],
+      credentials: true,
+    })
+  );
+
+  app.use(express.json());
+
+  const uploadDir = path.join(process.cwd(), 'uploads');
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+  app.use('/uploads', express.static(uploadDir));
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({
+      status: 'ok',
+      env: nodeEnv,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  app.use('/api/auth', authRoutes);
+  app.use('/api/admin', authMiddleware, adminRoutes);
+  app.use('/api/admin', (req: Request, _res: Response, next: NextFunction) => {
+    next(new AppError(`Admin Route Not Found - ${req.method} ${req.originalUrl}`, 404));
+  });
+
+  const protectedApi = express.Router();
+  protectedApi.use(authMiddleware);
+  protectedApi.use(tenantMiddleware);
+  protectedApi.use('/', receiptRoutes);
+  protectedApi.use('/categories', categoryRoutes);
+  protectedApi.use('/product-master', productMasterRoutes);
+  protectedApi.use('/stats', statsRoutes);
+
+  app.use('/api', protectedApi);
+
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    next(new AppError(`Not Found - ${req.originalUrl}`, 404));
+  });
+
+  app.use(errorHandler);
+
+  return app;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,123 +1,22 @@
-import express, { Request, Response, NextFunction } from 'express';
-import cors from 'cors';
-import path from 'path';
-import fs from 'fs';
 import dotenv from 'dotenv';
-
-// --- [Issue #43] BullMQ & Redis Worker ---
-import './workers/receiptWorker'; 
-
-// --- ユーティリティ & ミドルウェア ---
-import logger from './utils/logger';
-import { authMiddleware } from './middleware/authMiddleware'; 
-import { tenantMiddleware } from './middleware/tenantMiddleware';
-
-// --- ルーター ---
-import authRoutes from './routes/authRoutes'; 
-import receiptRoutes from './routes/receiptRoutes';
-import productMasterRoutes from './routes/productMasterRoutes'; 
-import categoryRoutes from './routes/categoryRoutes';
-import adminRoutes from './routes/adminRoutes'; // [Issue #72] 追加
-import statsRoutes from './routes/statsRoutes'; // ★ [Issue #78] 追加
-
-// --- エラーハンドリング ---
-import { AppError } from './utils/appError';
-import { errorHandler } from './middleware/errorHandler';
 
 dotenv.config();
 
-const app = express();
+// Worker は本番・開発サーバー起動時のみ（テストでは import しない）
+import './workers/receiptWorker';
+
+import { createApp } from './app';
+import logger from './utils/logger';
+
+const app = createApp();
 const port = process.env.PORT || 3000;
-const host = process.env.HOST || '0.0.0.0'; 
+const host = process.env.HOST || '0.0.0.0';
 const nodeEnv = process.env.NODE_ENV || 'development';
 
-// --- 1. 基本ミドルウェア設定 ---
-
-/**
- * [Issue #49-5] CORS設定の堅牢化
- */
-const getAllowedOrigins = () => {
-  const rawOrigins = process.env.CORS_ORIGIN || '';
-  if (rawOrigins.includes(',')) {
-    return rawOrigins.split(',').map(o => o.trim());
-  }
-  if (rawOrigins) return rawOrigins;
-  
-  if (nodeEnv === 'production') {
-    logger.warn('[CORS] CORS_ORIGIN is not defined in production!');
-    return false;
-  }
-  return true;
-};
-
-const allowedOrigins = getAllowedOrigins();
-
-app.use(cors({
-  origin: allowedOrigins,
-  methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-member-id'],
-  credentials: true
-}));
-
-app.use(express.json());
-
-// 静的ファイルの提供
-const uploadDir = path.join(process.cwd(), 'uploads');
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true });
-}
-app.use('/uploads', express.static(uploadDir));
-
-// --- 2. ルート登録 ---
-
-// ヘルスチェック
-app.get('/health', (req: Request, res: Response) => {
-  res.json({ 
-    status: 'ok', 
-    env: nodeEnv,
-    timestamp: new Date().toISOString() 
-  });
-});
-
-// 2-1. 認証なしルート
-app.use('/api/auth', authRoutes);
-
-// 2-2. 管理者向けルート [Issue #72]
-/**
- * プロンプト管理等のシステム設定は、個別の世帯(Tenant)に依存しないグローバル設定のため、
- * tenantMiddleware を介さず、authMiddleware のみで保護します。
- */
-app.use('/api/admin', authMiddleware, adminRoutes);
-
-// ★流出ガードミドルウェアを追加
-// adminRoutes 内でマッチしなかった /api/admin 配下のリクエストは、下の一般ルートに流さずここで確実に遮断する
-app.use('/api/admin', (req: Request, res: Response, next: NextFunction) => {
-  next(new AppError(`Admin Route Not Found - ${req.method} ${req.originalUrl}`, 404));
-});
-
-// 2-3. 認証・テナント必須ルート (業務データアクセス)
-const protectedApi = express.Router();
-protectedApi.use(authMiddleware);
-protectedApi.use(tenantMiddleware);
-
-protectedApi.use('/', receiptRoutes); 
-protectedApi.use('/categories', categoryRoutes);
-protectedApi.use('/product-master', productMasterRoutes);
-protectedApi.use('/stats', statsRoutes); // ★ [Issue #78] 統計・精算系ルートの追加
-
-app.use('/api', protectedApi);
-
-// --- 3. エラーハンドリング ---
-
-// 404 Handler
-app.use((req: Request, res: Response, next: NextFunction) => {
-  next(new AppError(`Not Found - ${req.originalUrl}`, 404));
-});
-
-// Global Error Handler
-app.use(errorHandler);
-
-// --- 4. サーバー起動 ---
+const rawOrigins = process.env.CORS_ORIGIN || '';
+const allowedOrigins = rawOrigins.includes(',')
+  ? rawOrigins.split(',').map((o) => o.trim())
+  : rawOrigins || (nodeEnv === 'production' ? false : true);
 
 app.listen(Number(port), host, () => {
   logger.info(`🚀 API Server running on [${nodeEnv}] mode`);

--- a/backend/src/test/integrationHelpers.ts
+++ b/backend/src/test/integrationHelpers.ts
@@ -1,0 +1,38 @@
+import bcrypt from 'bcrypt';
+import request from 'supertest';
+import type { Express } from 'express';
+import { prisma } from '../utils/prismaClient';
+
+export const TEST_MEMBER_PASSWORD = 'integration-test-password';
+
+/** `RUN_API_INTEGRATION=1` 時のみ DB 結合テストを実行（compose 内や CI 向け） */
+export function shouldRunDbIntegration(): boolean {
+  return (
+    process.env.RUN_API_INTEGRATION === '1' &&
+    Boolean(process.env.DATABASE_URL && process.env.JWT_SECRET)
+  );
+}
+
+/** 既存 DB の member にテスト用パスワードを設定（seed 済み環境向け） */
+export async function ensureTestMemberPassword(memberId = 1): Promise<void> {
+  const hash = await bcrypt.hash(TEST_MEMBER_PASSWORD, 4);
+  const member = await prisma.familyMember.findUnique({ where: { id: memberId } });
+  if (!member) {
+    throw new Error(`Test member id=${memberId} not found. Run prisma seed first.`);
+  }
+  await prisma.familyMember.update({
+    where: { id: memberId },
+    data: { password_hash: hash },
+  });
+}
+
+export async function loginAsTestMember(app: Express, memberId = 1): Promise<string> {
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ memberId, password: TEST_MEMBER_PASSWORD });
+
+  if (res.status !== 200 || !res.body?.success || !res.body?.data?.token) {
+    throw new Error(`Login failed: status=${res.status} body=${JSON.stringify(res.body)}`);
+  }
+  return res.body.data.token as string;
+}

--- a/backend/src/test/mockReceiptQueue.ts
+++ b/backend/src/test/mockReceiptQueue.ts
@@ -1,0 +1,12 @@
+import { vi } from 'vitest';
+
+/**
+ * receiptRoutes が import する BullMQ Queue をテスト時に Redis へ接続させない。
+ * integration テストファイルの先頭で import すること。
+ */
+vi.mock('../queues/receiptQueue', () => ({
+  RECEIPT_QUEUE_NAME: 'receipt-analysis',
+  receiptQueue: {
+    add: vi.fn().mockResolvedValue({ id: 'test-job' }),
+  },
+}));

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    testTimeout: 30000,
   },
 });

--- a/backend/vitest.setup.ts
+++ b/backend/vitest.setup.ts
@@ -1,0 +1,7 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = 'vitest-local-secret';
+}

--- a/docs/testing/plan.md
+++ b/docs/testing/plan.md
@@ -77,6 +77,11 @@ Epic: [#277 Issue #91](https://github.com/yama180sx/receipt-ai-app/issues/277)
 
 **対策:** `app.ts`（Express 定義のみ）+ `server.ts`（listen + worker 起動）に分離。テスト時は worker を起動しない。
 
+**実行:**
+
+- 通常: `cd backend && npm test`（DB 不要の結合テスト 3 件 + 単体 25 件）
+- DB 結合: `docker compose exec -e RUN_API_INTEGRATION=1 backend npm run test:integration`
+
 ### テスト DB
 
 - Docker Compose の Postgres を利用（`DATABASE_URL` をテスト用に切替）


### PR DESCRIPTION
## Summary

- `createApp()` を `backend/src/app.ts` に分離（Supertest / 本番で共有）
- `server.ts` は Worker 起動 + `listen` のみ
- `app.integration.test.ts`: health、401、login バリデーション（DB 不要）
- DB 結合: login / receipts / categories（`RUN_API_INTEGRATION=1` 時）
- BullMQ Queue をテスト時モック（Redis 不要）
- `npm run test:integration` を追加

Closes #280

## Test plan

- [x] `cd backend && npm test` — 28 passed, 3 skipped
- [x] `docker compose exec -e RUN_API_INTEGRATION=1 backend npm run test:integration` — 6 passed
- [ ] マージ後、既存 `npm run dev` / Docker 起動に退行なし（手動確認推奨）

## 補足

- 通常の `npm test` では DB 結合 3 件は **skip**（ホストから `db:5432` に届かないため）
- CI（#91-6）では Postgres service + `RUN_API_INTEGRATION=1` を想定


Made with [Cursor](https://cursor.com)