### PR TITLE
ci: [Issue #91-6] PR テストゲート（GitHub Actions）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         run: npm test
         env:
           JWT_SECRET: ci-test-jwt-secret
+          # app.integration.test.ts が createApp 経由で Prisma を import するため必須（DB 結合は skip）
+          DATABASE_URL: postgresql://vitest:vitest@127.0.0.1:5432/vitest?schema=public
 
   frontend-unit:
     name: Frontend unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,101 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  backend-unit:
+    name: Backend unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Run tests
+        run: npm test
+        env:
+          JWT_SECRET: ci-test-jwt-secret
+
+  frontend-unit:
+    name: Frontend unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  backend-integration:
+    name: Backend API integration (Postgres)
+    runs-on: ubuntu-latest
+    needs: [backend-unit]
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: cntadm
+          POSTGRES_PASSWORD: ci-test-db-password
+          POSTGRES_DB: receipt_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cntadm -d receipt_db"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://cntadm:ci-test-db-password@localhost:5432/receipt_db?schema=public
+      JWT_SECRET: ci-test-jwt-secret
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Apply migrations
+        run: npx prisma migrate deploy
+
+      - name: Seed database
+        run: npx prisma db seed
+
+      - name: Run API integration tests
+        run: npm run test:integration

--- a/backend/vitest.setup.ts
+++ b/backend/vitest.setup.ts
@@ -5,3 +5,9 @@ dotenv.config();
 if (!process.env.JWT_SECRET) {
   process.env.JWT_SECRET = 'vitest-local-secret';
 }
+
+// PrismaClient 生成時に必須（CI 等 .env なし環境向け。DB 未使用テストは接続しない）
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL =
+    'postgresql://vitest:vitest@127.0.0.1:5432/vitest?schema=public';
+}

--- a/docs/testing/plan.md
+++ b/docs/testing/plan.md
@@ -96,8 +96,8 @@ Epic: [#277 Issue #91](https://github.com/yama180sx/receipt-ai-app/issues/277)
 
 | トリガー | 内容 | ランナー |
 |----------|------|----------|
-| PR → `develop` | `npm test`（backend + frontend unit） | `ubuntu-latest` |
-| PR → `develop` | API 結合（#91-3 完了後） | `ubuntu-latest` + Postgres service |
+| PR → `develop` | `npm test`（backend + frontend unit） | `ubuntu-latest` — `.github/workflows/test.yml` |
+| PR → `develop` | API 結合（`npm run test:integration`） | 同上ジョブ `backend-integration`（Postgres service） |
 | push → `main` | 既存 deploy workflow（変更なし） | self-hosted (T320) |
 
 **スコープ外:** ESLint / Prettier（未導入のため別 Issue）


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml` を新規追加
- トリガー: `pull_request` → `develop`
- ジョブ:
  - **backend-unit** — `npm test`（単体 + DB 不要の結合 3 件）
  - **frontend-unit** — `npm test`
  - **backend-integration** — Postgres 16 + migrate + seed + `npm run test:integration`

Closes #283

## Test plan

- [ ] 本 PR マージ後、別 PR で Actions が green になること
- [ ] 既存 `deploy.yml`（self-hosted / main push）に影響がないこと

## 補足

- deploy 用 self-hosted ランナーとは独立（`ubuntu-latest` のみ）
- `JWT_SECRET` は CI 用の固定値（リポジトリ Secrets 不要）


Made with [Cursor](https://cursor.com)