### PR TITLE
fix(backend): [Issue #93-1] テナント分離の強化と認証付き画像配信

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -11,6 +11,7 @@ async function main() {
 
   // 0. 既存データのクリーンアップ
   await prisma.item.deleteMany();
+  await prisma.settlementTransfer.deleteMany();
   await prisma.productMaster.deleteMany();
   await prisma.receipt.deleteMany();
   await prisma.familyMember.deleteMany();
@@ -41,7 +42,24 @@ async function main() {
   for (const m of familyMembers) {
     await prisma.familyMember.create({ data: m });
   }
-  console.log('👥 FamilyMembers created.');
+  console.log('👥 FamilyMembers created (山本家).');
+
+  // 1b. 第2世帯（テナント分離テスト用 — Issue #93-1）
+  const familyGroup2 = await prisma.familyGroup.create({
+    data: {
+      id: 2,
+      name: '佐藤家',
+      inviteCode: 'SATO-2026',
+    },
+  });
+  const family2Members = [
+    { id: 4, name: '佐藤（管理者）', familyGroupId: familyGroup2.id, role: 'ADMIN' as const },
+    { id: 5, name: '佐藤（配偶者）', familyGroupId: familyGroup2.id, role: 'USER' as const },
+  ];
+  for (const m of family2Members) {
+    await prisma.familyMember.create({ data: m });
+  }
+  console.log(`👥 FamilyMembers created (${familyGroup2.name}).`);
 
   // 3. 費目カテゴリー
   const categories = [
@@ -61,8 +79,26 @@ async function main() {
     await prisma.category.create({ data: c });
   }
 
-  // 明示 id 投入後は PostgreSQL の serial を同期（未同期だと Category 追加で id 重複）
-  await syncAllSeedTableSequences(prisma);
+  // 第2世帯のテナント分離 fixture（Category 投入後）
+  await prisma.receipt.create({
+    data: {
+      familyGroupId: familyGroup2.id,
+      memberId: 4,
+      storeName: '佐藤家テスト店',
+      date: new Date('2026-01-15T12:00:00.000Z'),
+      totalAmount: 500,
+      imagePath: 'uploads/tenant-isolation-fixture.webp',
+      items: {
+        create: {
+          name: '他世帯テスト商品',
+          price: 500,
+          quantity: 1,
+          categoryId: 1,
+        },
+      },
+    },
+  });
+  console.log('🧾 Tenant isolation fixture receipt created (佐藤家).');
 
   // 4. 店舗正規化マスタ
   const stores = [
@@ -161,6 +197,8 @@ async function main() {
     });
   }
   console.log('🤖 PromptTemplates seeded.');
+
+  await syncAllSeedTableSequences(prisma);
 
   console.log('✅ Seeding Completed.');
 }

--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -1,13 +1,19 @@
 import './test/mockReceiptQueue';
 
+import fs from 'fs';
+import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import { createApp } from './app';
 import {
   ensureTestMemberPassword,
+  getTenantBItemId,
+  getTenantBReceiptWithImage,
   loginAsTestMember,
   shouldRunDbIntegration,
+  TENANT_B_ADMIN_MEMBER_ID,
 } from './test/integrationHelpers';
+import { clearMockReceiptJobs, registerMockReceiptJob } from './test/mockJobStore';
 import { prisma } from './utils/prismaClient';
 
 const app = createApp();
@@ -29,14 +35,27 @@ describe('API integration (no DB)', () => {
     const res = await request(app).post('/api/auth/login').send({});
     expect(res.status).toBe(400);
   });
+
+  it('GET /uploads without auth is not publicly served', async () => {
+    const res = await request(app).get('/uploads/tenant-isolation-fixture.webp');
+    expect(res.status).toBe(404);
+  });
 });
 
 describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () => {
   beforeAll(async () => {
     await ensureTestMemberPassword(1);
+    await ensureTestMemberPassword(TENANT_B_ADMIN_MEMBER_ID);
+
+    const fixturePath = path.join(process.cwd(), 'uploads', 'tenant-isolation-fixture.webp');
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    if (!fs.existsSync(fixturePath)) {
+      fs.writeFileSync(fixturePath, Buffer.from('tenant-isolation-test-image'));
+    }
   });
 
   afterAll(async () => {
+    clearMockReceiptJobs();
     await prisma.$disconnect();
   });
 
@@ -71,5 +90,87 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});
+
+describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {
+  beforeAll(async () => {
+    await ensureTestMemberPassword(1);
+    await ensureTestMemberPassword(TENANT_B_ADMIN_MEMBER_ID);
+
+    const fixturePath = path.join(process.cwd(), 'uploads', 'tenant-isolation-fixture.webp');
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    if (!fs.existsSync(fixturePath)) {
+      fs.writeFileSync(fixturePath, Buffer.from('tenant-isolation-test-image'));
+    }
+  });
+
+  afterAll(async () => {
+    clearMockReceiptJobs();
+  });
+
+  it('rejects cross-tenant updateItemCategory', async () => {
+    const tokenA = await loginAsTestMember(app, 1);
+    const tenantBItemId = await getTenantBItemId();
+
+    const res = await request(app)
+      .patch(`/api/receipts/items/${tenantBItemId}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ categoryId: 2 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects cross-tenant getJobStatus', async () => {
+    registerMockReceiptJob('cross-tenant-job', {
+      memberId: TENANT_B_ADMIN_MEMBER_ID,
+      familyGroupId: 2,
+    });
+
+    const tokenA = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get('/api/receipts/status/cross-tenant-job')
+      .set('Authorization', `Bearer ${tokenA}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('allows same-tenant getJobStatus', async () => {
+    registerMockReceiptJob('same-tenant-job', {
+      memberId: 1,
+      familyGroupId: 1,
+    });
+
+    const tokenA = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get('/api/receipts/status/same-tenant-job')
+      .set('Authorization', `Bearer ${tokenA}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.state).toBe('completed');
+  });
+
+  it('rejects unauthenticated upload image access', async () => {
+    const res = await request(app).get('/api/uploads/tenant-isolation-fixture.webp');
+    expect(res.status).toBe(401);
+  });
+
+  it('allows same-tenant authenticated upload image access', async () => {
+    const tokenA = await loginAsTestMember(app, 1);
+    const { imagePath } = await getTenantBReceiptWithImage();
+    const filename = path.basename(imagePath);
+
+    // 山本家トークンでは佐藤家の画像は 404
+    const denied = await request(app)
+      .get(`/api/uploads/${filename}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(denied.status).toBe(404);
+
+    const tokenB = await loginAsTestMember(app, TENANT_B_ADMIN_MEMBER_ID);
+    const allowed = await request(app)
+      .get(`/api/uploads/${filename}`)
+      .set('Authorization', `Bearer ${tokenB}`);
+    expect(allowed.status).toBe(200);
   });
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -53,7 +53,6 @@ export function createApp() {
   if (!fs.existsSync(uploadDir)) {
     fs.mkdirSync(uploadDir, { recursive: true });
   }
-  app.use('/uploads', express.static(uploadDir));
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -15,8 +15,14 @@ import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
  */
 export const getJobStatus = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
+    const familyGroupId = getFamilyGroupId();
     const job = await receiptQueue.getJob(req.params.jobId!);
     if (!job) throw new AppError('ジョブが見つかりません。', 404);
+
+    const jobFamilyGroupId = Number(job.data?.familyGroupId);
+    if (!jobFamilyGroupId || jobFamilyGroupId !== familyGroupId) {
+      throw new AppError('ジョブが見つかりません。', 404);
+    }
 
     const state = await job.getState();
     res.status(200).json({
@@ -247,7 +253,9 @@ export const updateItemCategory = async (req: Request, res: Response, next: Next
         include: { receipt: true }
       });
 
-      if (!currentItem) throw new AppError('ItemNotFound', 404);
+      if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
+        throw new AppError('ItemNotFound', 404);
+      }
 
       const updatedItem = await tx.item.update({
         where: { id: Number(id) },

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { prisma } from '../utils/prismaClient';
+import { AppError } from '../utils/appError';
+import { getFamilyGroupId } from '../utils/context';
+
+/**
+ * [Issue #93-1 / G3] レシート画像の認証付き配信。
+ * 自世帯の Receipt に紐づく imagePath のみ返す（他世帯・未登録ファイルは 404）。
+ */
+export const serveReceiptImage = async (
+  req: Request<{ filename: string }>,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const familyGroupId = getFamilyGroupId();
+    const rawFilename = req.params.filename;
+    const filename = path.basename(rawFilename);
+
+    if (!filename || filename !== rawFilename || filename.includes('..')) {
+      throw new AppError('Invalid filename', 400);
+    }
+
+    const imagePath = path.join('uploads', filename).replace(/\\/g, '/');
+    const receipt = await prisma.receipt.findFirst({
+      where: { familyGroupId, imagePath },
+      select: { id: true },
+    });
+
+    if (!receipt) {
+      throw new AppError('Not Found', 404);
+    }
+
+    const fullPath = path.join(process.cwd(), imagePath);
+    if (!fs.existsSync(fullPath)) {
+      throw new AppError('Not Found', 404);
+    }
+
+    res.sendFile(fullPath);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -25,6 +25,7 @@ import {
   getFamilyMembers,
   updateItemSplits // ★ Issue #78: 按分保存関数をインポート
 } from '../controllers/receiptController';
+import { serveReceiptImage } from '../controllers/uploadController';
 
 const router = express.Router();
 
@@ -89,6 +90,9 @@ router.use(authMiddleware, tenantMiddleware);
 
 // 所属世帯のメンバー一覧を取得するエンドポイント
 router.get('/family-groups/members', getFamilyMembers);
+
+// [Issue #93-1 / G3] 認証・テナント検証付き画像配信（公開 /uploads は廃止）
+router.get('/uploads/:filename', serveReceiptImage);
 
 router.get('/receipts', getReceipts);
 router.get('/receipts/latest', getLatestReceipt);

--- a/backend/src/test/integrationHelpers.ts
+++ b/backend/src/test/integrationHelpers.ts
@@ -36,3 +36,30 @@ export async function loginAsTestMember(app: Express, memberId = 1): Promise<str
   }
   return res.body.data.token as string;
 }
+
+/** 第2世帯（佐藤家）のテスト用メンバー ID */
+export const TENANT_B_ADMIN_MEMBER_ID = 4;
+
+/** 他世帯の Item ID を DB から取得（seed 済み前提） */
+export async function getTenantBItemId(): Promise<number> {
+  const item = await prisma.item.findFirst({
+    where: { receipt: { familyGroupId: 2 } },
+    select: { id: true },
+  });
+  if (!item) {
+    throw new Error('Tenant B fixture item not found. Run prisma seed.');
+  }
+  return item.id;
+}
+
+/** 他世帯の Receipt ID（画像 fixture 用） */
+export async function getTenantBReceiptWithImage(): Promise<{ id: number; imagePath: string }> {
+  const receipt = await prisma.receipt.findFirst({
+    where: { familyGroupId: 2, imagePath: { not: null } },
+    select: { id: true, imagePath: true },
+  });
+  if (!receipt?.imagePath) {
+    throw new Error('Tenant B fixture receipt not found. Run prisma seed.');
+  }
+  return { id: receipt.id, imagePath: receipt.imagePath };
+}

--- a/backend/src/test/mockJobStore.ts
+++ b/backend/src/test/mockJobStore.ts
@@ -1,0 +1,26 @@
+export type MockReceiptJob = {
+  id: string;
+  data: { memberId?: number; familyGroupId?: number; imagePath?: string };
+  returnvalue: unknown;
+  failedReason: string | null;
+  getState: () => Promise<string>;
+};
+
+export const mockReceiptJobs = new Map<string, MockReceiptJob>();
+
+export function registerMockReceiptJob(
+  id: string,
+  data: { memberId: number; familyGroupId: number; imagePath?: string }
+): void {
+  mockReceiptJobs.set(id, {
+    id,
+    data,
+    returnvalue: null,
+    failedReason: null,
+    getState: async () => 'completed',
+  });
+}
+
+export function clearMockReceiptJobs(): void {
+  mockReceiptJobs.clear();
+}

--- a/backend/src/test/mockReceiptQueue.ts
+++ b/backend/src/test/mockReceiptQueue.ts
@@ -1,4 +1,9 @@
 import { vi } from 'vitest';
+import { mockReceiptJobs, registerMockReceiptJob } from './mockJobStore';
+
+export { registerMockReceiptJob, clearMockReceiptJobs } from './mockJobStore';
+
+let jobCounter = 0;
 
 /**
  * receiptRoutes が import する BullMQ Queue をテスト時に Redis へ接続させない。
@@ -7,6 +12,15 @@ import { vi } from 'vitest';
 vi.mock('../queues/receiptQueue', () => ({
   RECEIPT_QUEUE_NAME: 'receipt-analysis',
   receiptQueue: {
-    add: vi.fn().mockResolvedValue({ id: 'test-job' }),
+    add: vi.fn().mockImplementation(async (_name: string, data: { memberId?: number; familyGroupId?: number; imagePath?: string }) => {
+      const id = `mock-job-${++jobCounter}`;
+      registerMockReceiptJob(id, {
+        memberId: data.memberId!,
+        familyGroupId: data.familyGroupId!,
+        imagePath: data.imagePath,
+      });
+      return { id };
+    }),
+    getJob: vi.fn().mockImplementation(async (id: string) => mockReceiptJobs.get(id) ?? null),
   },
 }));

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -12,6 +12,7 @@ import { AppButton, AppSelect, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme, BREAKPOINTS } from '../theme';
 import apiClient from '../utils/apiClient';
+import { useReceiptImageSource } from '../utils/receiptImageSource';
 
 interface ReceiptDetailComponentProps {
   receipt: any;
@@ -44,6 +45,11 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   const [editData, setEditData] = useState<any>(null);
 
   const cacheKey = useMemo(() => Date.now(), []);
+  const imageSource = useReceiptImageSource(receipt?.imagePath);
+  const imageSourceWithCache = useMemo(() => {
+    if (!imageSource) return null;
+    return { ...imageSource, uri: `${imageSource.uri}?v=${cacheKey}` };
+  }, [imageSource, cacheKey]);
 
   const categorySelectOptions = useMemo(
     () => categories.map((c) => ({ label: c.name, value: c.id as number })),
@@ -80,11 +86,6 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
       </View>
     );
   }
-
-  const getImageUrl = (imagePath: string) => {
-    if (!imagePath) return null;
-    return `${baseUrl}/${imagePath}?v=${cacheKey}`;
-  };
 
   const updateEditField = (key: string, value: any) => {
     setEditData({ ...editData, [key]: value });
@@ -132,9 +133,9 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
       {/* 左側：画像エリア */}
       <View style={isWide ? styles.wideImageColumn : styles.mobileImageArea}>
         <View style={[styles.imageWrapper, !isWide && { height: 350 }]}>
-          {receipt.imagePath ? (
+          {receipt.imagePath && imageSourceWithCache ? (
             <Image 
-              source={{ uri: getImageUrl(receipt.imagePath) as string }}
+              source={imageSourceWithCache}
               style={styles.receiptImage}
               resizeMode="contain"
             />

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -17,6 +17,7 @@ import { AppBackButton, AppButton, AppFormField, AppSelect, AppTextInput } from 
 import { modalStyles } from '../theme';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
+import { useReceiptImageSource } from '../utils/receiptImageSource';
 
 const c = theme.colors;
 const s = theme.colors.semantic.scan;
@@ -74,12 +75,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
     [categories]
   );
 
-  const imageUri = useMemo(() => {
-    if (!initialData.imagePath) return null;
-    const baseUrl = apiClient.defaults.baseURL?.replace('/api', '') || '';
-    const path = initialData.imagePath.startsWith('/') ? initialData.imagePath : `/${initialData.imagePath}`;
-    return `${baseUrl}${path}`;
-  }, [initialData.imagePath]);
+  const imageSource = useReceiptImageSource(initialData.imagePath);
 
   // 合計金額の計算（明細合計 + 外税）
   const calculatedTotal = useMemo(() => {
@@ -171,9 +167,9 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
         </View>
 
         <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-          {imageUri && (
+          {imageSource && (
             <View style={styles.imageContainer}>
-              <Image source={{ uri: imageUri }} style={styles.receiptImage} resizeMode="contain" />
+              <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
               <View style={styles.imageLabel}><Text style={styles.imageLabelText}>加工済みプレビュー</Text></View>
             </View>
           )}

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -26,6 +26,7 @@ import type {
   ReceiptForSplitEditor,
   ReceiptItemForSplit,
 } from '../types/settlement';
+import { useReceiptImageSource } from '../utils/receiptImageSource';
 
 interface SplitEditorScreenProps {
   receipt: ReceiptForSplitEditor;
@@ -46,8 +47,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
   // { itemId: { memberId: 500 } }
   const [editSplits, setEditSplits] = useState<Record<number, Record<number, number>>>({});
 
-  const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
-  const BASE_URL = API_URL.replace(/\/api\/?$/, '');
+  const imageSource = useReceiptImageSource(receipt?.imagePath);
 
   useEffect(() => {
     const init = async () => {
@@ -318,8 +318,6 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
     );
   }
 
-  const getImageUrl = () => receipt.imagePath ? `${BASE_URL}/${receipt.imagePath}` : null;
-
   // レシート全体の合計額を算出
   const receiptTotalAmount = receipt.items.reduce(
     (sum, item) => sum + calcItemTotal(item),
@@ -391,8 +389,8 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, o
       <View style={[styles.mainLayout, isWide ? styles.rowLayout : styles.colLayout]}>
         <View style={[styles.imagePane, isWide && { width: 350 }]}>
           <View style={styles.imageBox}>
-            {getImageUrl() ? (
-              <Image source={{ uri: getImageUrl()! }} style={styles.receiptImage} resizeMode="contain" />
+            {imageSource ? (
+              <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
             ) : (
               <Text style={styles.noImageText}>画像がありません</Text>
             )}

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -18,6 +18,7 @@ import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from 
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
+import { useReceiptImageSource } from '../utils/receiptImageSource';
 
 // --- interface 定義 ---
 interface Category { id: number; name: string; color: string; }
@@ -73,6 +74,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
   const BASE_URL = API_URL.replace(/\/api\/?$/, '');
+  const latestReceiptImageSource = useReceiptImageSource(data?.latestReceipt?.imagePath);
 
   const monthOptions = useMemo(() => getRecentYearMonths(12), []);
 
@@ -211,9 +213,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
               <View style={styles.section}>
                 <Text style={styles.sectionTitle}>最新の解析レシート</Text>
-                {data?.latestReceipt?.imagePath ? (
+                {data?.latestReceipt?.imagePath && latestReceiptImageSource ? (
                   <TouchableOpacity style={styles.receiptPreviewCard} onPress={() => setMainModalVisible(true)}>
-                    <Image source={{ uri: `${BASE_URL}/${data.latestReceipt.imagePath}` }} style={styles.receiptImage} resizeMode="cover" />
+                    <Image source={latestReceiptImageSource} style={styles.receiptImage} resizeMode="cover" />
                     <View style={styles.receiptInfoOverlay}>
                       <View style={{ flex: 1, marginRight: 10 }}>
                         <Text style={styles.receiptStoreName} numberOfLines={1}>

--- a/frontend/src/utils/receiptImageSource.ts
+++ b/frontend/src/utils/receiptImageSource.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import apiClient from './apiClient';
+
+export type ReceiptImageSource = {
+  uri: string;
+  headers: Record<string, string>;
+};
+
+const TOKEN_KEY = 'userToken';
+
+async function getAuthToken(): Promise<string | null> {
+  try {
+    return Platform.OS === 'web'
+      ? await AsyncStorage.getItem(TOKEN_KEY)
+      : await SecureStore.getItemAsync(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** imagePath (uploads/xxx.webp) を認証付き API URL に変換 */
+export function getReceiptImageApiUrl(imagePath: string): string {
+  const normalized = imagePath.replace(/^\//, '');
+  const filename = normalized.startsWith('uploads/')
+    ? normalized.slice('uploads/'.length)
+    : normalized;
+  const base = (apiClient.defaults.baseURL || 'http://localhost:3000/api').replace(/\/$/, '');
+  return `${base}/uploads/${encodeURIComponent(filename)}`;
+}
+
+export async function buildReceiptImageSource(
+  imagePath: string | null | undefined
+): Promise<ReceiptImageSource | null> {
+  if (!imagePath) return null;
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return {
+    uri: getReceiptImageApiUrl(imagePath),
+    headers,
+  };
+}
+
+/** React Native Image 用 — Authorization ヘッダ付き source */
+export function useReceiptImageSource(imagePath: string | null | undefined) {
+  const [source, setSource] = useState<ReceiptImageSource | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    buildReceiptImageSource(imagePath).then((next) => {
+      if (!cancelled) setSource(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [imagePath]);
+
+  return source;
+}


### PR DESCRIPTION
## Summary

- **G1** `updateItemCategory`: 他世帯 Item の更新を `receipt.familyGroupId` 検証で拒否（404）
- **G2** `getJobStatus`: ジョブ payload の `familyGroupId` と現在テナントの一致を検証
- **G3** 公開 `/uploads` 静的配信を廃止し、`GET /api/uploads/:filename`（auth + tenant）に移行
- seed に第2世帯（佐藤家）と fixture レシートを追加
- クロステナント拒否の結合テストを追加
- Frontend: レシート画像を Bearer 付き `/api/uploads/...` で表示

## Test plan

- [x] `backend npm test`（unit + no-DB integration）
- [x] Docker dev コンテナ内 `npx prisma db seed && RUN_API_INTEGRATION=1 npm run test:integration`（12 tests Pass）
- [ ] seed 再投入後、手動でレシート画像が表示されること（Web / Native）
- [ ] 手動回帰 §0 認証（#303/#304 完了後に本格実施）

Closes #302

Made with [Cursor](https://cursor.com)