### PR TITLE
feat(backend): [Issue #93-2] 認証 API・ログインフロー

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -46,6 +46,7 @@ describe('API integration (no DB)', () => {
 describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () => {
   beforeAll(async () => {
     await ensureTestMemberPassword(1);
+    await ensureTestMemberPassword(2);
     await ensureTestMemberPassword(TENANT_B_ADMIN_MEMBER_ID);
 
     const fixturePath = path.join(process.cwd(), 'uploads', 'tenant-isolation-fixture.webp');
@@ -63,12 +64,115 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
   it('POST /api/auth/login succeeds with test password', async () => {
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ memberId: 1, password: 'integration-test-password' });
+      .send({
+        familyGroupId: 1,
+        memberId: 1,
+        password: 'integration-test-password',
+      });
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data.token).toBeDefined();
-    expect(res.body.data.member.familyGroupId).toBeDefined();
+    expect(res.body.data.member.familyGroupId).toBe(1);
+    expect(res.body.data.requiresTwoFactor).toBe(true);
+  });
+
+  describe('Auth API (#93-2)', () => {
+    const YAMAMOTO_INVITE = 'YAMAMOTO-2026';
+    const SATO_INVITE = 'SATO-2026';
+
+    it('POST /api/auth/resolve-family returns family for valid invite code', async () => {
+      const res = await request(app)
+        .post('/api/auth/resolve-family')
+        .send({ inviteCode: YAMAMOTO_INVITE });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual({ familyGroupId: 1, name: '山本家' });
+    });
+
+    it('POST /api/auth/resolve-family rejects unknown invite code', async () => {
+      const res = await request(app)
+        .post('/api/auth/resolve-family')
+        .send({ inviteCode: 'INVALID-CODE' });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('GET members returns list when inviteCode matches family', async () => {
+      const res = await request(app)
+        .get('/api/auth/families/1/members')
+        .query({ inviteCode: YAMAMOTO_INVITE });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.length).toBeGreaterThanOrEqual(3);
+      expect(res.body.data[0]).toMatchObject({ id: expect.any(Number), name: expect.any(String) });
+      expect(res.body.data.some((m: { id: number }) => m.id === 1)).toBe(true);
+    });
+
+    it('GET members rejects mismatched inviteCode', async () => {
+      const res = await request(app)
+        .get('/api/auth/families/1/members')
+        .query({ inviteCode: SATO_INVITE });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('full login flow: resolve → members → login', async () => {
+      const resolved = await request(app)
+        .post('/api/auth/resolve-family')
+        .send({ inviteCode: SATO_INVITE });
+      expect(resolved.status).toBe(200);
+      const { familyGroupId } = resolved.body.data;
+
+      const members = await request(app)
+        .get(`/api/auth/families/${familyGroupId}/members`)
+        .query({ inviteCode: SATO_INVITE });
+      expect(members.status).toBe(200);
+      const adminMember = members.body.data.find(
+        (m: { id: number }) => m.id === TENANT_B_ADMIN_MEMBER_ID
+      );
+      expect(adminMember).toBeDefined();
+
+      const loginRes = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId,
+          memberId: adminMember.id,
+          password: 'integration-test-password',
+        });
+
+      expect(loginRes.status).toBe(200);
+      expect(loginRes.body.data.token).toBeDefined();
+      expect(loginRes.body.data.member.familyGroupId).toBe(2);
+      expect(loginRes.body.data.requiresTwoFactor).toBe(true);
+    });
+
+    it('POST /api/auth/login rejects member from another family', async () => {
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId: 1,
+          memberId: TENANT_B_ADMIN_MEMBER_ID,
+          password: 'integration-test-password',
+        });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /api/auth/login sets requiresTwoFactor false for USER role', async () => {
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId: 1,
+          memberId: 2,
+          password: 'integration-test-password',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.requiresTwoFactor).toBe(false);
+    });
   });
 
   it('GET /api/receipts with token returns success envelope', async () => {

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,52 +1,133 @@
 import { Request, Response, NextFunction } from 'express';
 import bcrypt from 'bcrypt';
+import { Role } from '@prisma/client';
 import { generateToken } from '../utils/auth';
 import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
 
 /**
- * [Issue #54 / #73] ログイン処理 (bcrypt照合版)
- * メンバーIDとパスワードを受け取り、照合後にJWTを発行します。
+ * [Issue #93-2] Step 1: 招待コードから世帯を特定
+ */
+export const resolveFamily = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { inviteCode } = req.body;
+
+    if (!inviteCode || typeof inviteCode !== 'string' || !inviteCode.trim()) {
+      throw new AppError('招待コードを入力してください。', 400);
+    }
+
+    const familyGroup = await prisma.familyGroup.findUnique({
+      where: { inviteCode: inviteCode.trim() },
+      select: { id: true, name: true },
+    });
+
+    if (!familyGroup) {
+      throw new AppError('招待コードが正しくありません。', 404);
+    }
+
+    res.status(200).json({
+      success: true,
+      data: {
+        familyGroupId: familyGroup.id,
+        name: familyGroup.name,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * [Issue #93-2] Step 2: 世帯メンバー一覧（inviteCode で世帯アクセスを検証）
+ */
+export const getFamilyMembers = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const familyGroupId = parseInt(req.params.familyGroupId, 10);
+    const inviteCode = typeof req.query.inviteCode === 'string' ? req.query.inviteCode.trim() : '';
+
+    if (Number.isNaN(familyGroupId)) {
+      throw new AppError('世帯IDが不正です。', 400);
+    }
+
+    if (!inviteCode) {
+      throw new AppError('招待コードを指定してください。', 400);
+    }
+
+    const familyGroup = await prisma.familyGroup.findFirst({
+      where: { id: familyGroupId, inviteCode },
+      select: { id: true },
+    });
+
+    if (!familyGroup) {
+      throw new AppError('世帯が見つからないか、招待コードが一致しません。', 404);
+    }
+
+    const members = await prisma.familyMember.findMany({
+      where: { familyGroupId },
+      select: { id: true, name: true },
+      orderBy: { id: 'asc' },
+    });
+
+    res.status(200).json({
+      success: true,
+      data: members,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** [#306 連携用] Admin は 2FA 必須、USER は任意 */
+function requiresTwoFactor(role: Role): boolean {
+  return role === Role.ADMIN;
+}
+
+/**
+ * [Issue #54 / #73 / #93-2] Step 4: ログイン（familyGroupId 必須）
  */
 export const login = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { memberId, password } = req.body;
+    const { familyGroupId, memberId, password } = req.body;
 
-    if (!memberId || !password) {
-      throw new AppError('メンバーIDとパスワードを入力してください。', 400);
+    if (!familyGroupId || !memberId || !password) {
+      throw new AppError('世帯ID、メンバーID、パスワードを入力してください。', 400);
     }
 
-    const parsedId = parseInt(memberId, 10);
+    const parsedFamilyGroupId = parseInt(familyGroupId, 10);
+    const parsedMemberId = parseInt(memberId, 10);
 
-    // 1. メンバーと所属世帯の取得
+    if (Number.isNaN(parsedFamilyGroupId) || Number.isNaN(parsedMemberId)) {
+      throw new AppError('世帯IDまたはメンバーIDが不正です。', 400);
+    }
+
     const member = await prisma.familyMember.findUnique({
-      where: { id: parsedId },
-      include: { familyGroup: true }
+      where: { id: parsedMemberId },
+      include: { familyGroup: true },
     });
 
     if (!member || !member.familyGroup) {
       throw new AppError('指定されたメンバーまたは世帯が見つかりません。', 404);
     }
 
-    // 2. パスワード未設定のチェック
+    if (member.familyGroupId !== parsedFamilyGroupId) {
+      throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
+    }
+
     if (!member.password_hash) {
       throw new AppError('パスワードが設定されていません。管理者に連絡してください。', 403);
     }
 
-    // 3. bcryptによるパスワード照合
     const isMatch = await bcrypt.compare(password, member.password_hash);
     if (!isMatch) {
       throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
     }
 
-    // 4. JWTの発行
-    // [Issue #73] authMiddleware (isAdmin) で検証できるよう id を追加し、roleも含める
     const token = generateToken({
-      id: member.id, // ← req.user.id 用に追加
+      id: member.id,
       memberId: member.id,
       familyGroupId: member.familyGroup.id,
       name: member.name,
-      role: member.role 
+      role: member.role,
     });
 
     res.status(200).json({
@@ -57,9 +138,10 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
           id: member.id,
           name: member.name,
           familyGroupId: member.familyGroupId,
-          role: member.role // ★フロントへ渡すための修正
-        }
-      }
+          role: member.role,
+        },
+        requiresTwoFactor: requiresTwoFactor(member.role),
+      },
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,9 +1,15 @@
 import { Router } from 'express';
-import { login } from '../controllers/authController';
+import { getFamilyMembers, login, resolveFamily } from '../controllers/authController';
 
 const router = Router();
 
-// POST /api/auth/login
+// [Issue #93-2] Step 1: 招待コード → 世帯特定
+router.post('/resolve-family', resolveFamily);
+
+// [Issue #93-2] Step 2: 世帯メンバー一覧（?inviteCode= 必須）
+router.get('/families/:familyGroupId/members', getFamilyMembers);
+
+// [Issue #93-2] Step 4: ログイン
 router.post('/login', login);
 
 export default router;

--- a/backend/src/test/integrationHelpers.ts
+++ b/backend/src/test/integrationHelpers.ts
@@ -27,9 +27,21 @@ export async function ensureTestMemberPassword(memberId = 1): Promise<void> {
 }
 
 export async function loginAsTestMember(app: Express, memberId = 1): Promise<string> {
+  const member = await prisma.familyMember.findUnique({
+    where: { id: memberId },
+    select: { familyGroupId: true },
+  });
+  if (!member) {
+    throw new Error(`Test member id=${memberId} not found. Run prisma seed first.`);
+  }
+
   const res = await request(app)
     .post('/api/auth/login')
-    .send({ memberId, password: TEST_MEMBER_PASSWORD });
+    .send({
+      familyGroupId: member.familyGroupId,
+      memberId,
+      password: TEST_MEMBER_PASSWORD,
+    });
 
   if (res.status !== 200 || !res.body?.success || !res.body?.data?.token) {
     throw new Error(`Login failed: status=${res.status} body=${JSON.stringify(res.body)}`);


### PR DESCRIPTION
## Summary

Epic #93 の Backend 認証フローを実装しました（内部 **#93-2** / GitHub **#303**）。

| Step | Endpoint | 内容 |
|------|----------|------|
| 1 | `POST /api/auth/resolve-family` | `{ inviteCode }` → `{ familyGroupId, name }` |
| 2 | `GET /api/auth/families/:familyGroupId/members?inviteCode=` | メンバー一覧 `[{ id, name }]`（inviteCode で世帯検証） |
| 4 | `POST /api/auth/login` | `{ familyGroupId, memberId, password }` 必須、`memberId ∈ familyGroupId` を検証 |

### その他

- login レスポンスに `requiresTwoFactor`（ADMIN=true / USER=false）— **#93-5 (#306)** 連携用
- `loginAsTestMember` ヘルパーを `familyGroupId` 付き login に更新
- 結合テスト 7 件追加（正しいフロー + クロステナント拒否）

## Breaking change

- **`POST /api/auth/login` のリクエスト body に `familyGroupId` が必須**（Frontend #92 対応前は旧 login 不可）

## Test plan

- [x] `backend npm test`
- [x] Docker dev: `RUN_API_INTEGRATION=1 npm run test:integration`（19 tests Pass）
- [ ] Frontend #92 マージ後、手動で招待コードログインフローを確認

Closes #303

Made with [Cursor](https://cursor.com)