### PR TITLE
feat(frontend): [Issue #92] ログイン UI — 世帯・メンバー選択と端末保持

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,7 +3,7 @@ import bcrypt from 'bcrypt';
 import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { syncAllSeedTableSequences } from './syncSequences';
+import { syncAllSeedTableSequences, syncPostgresIdSequence } from './syncSequences';
 
 const prisma = new PrismaClient();
 
@@ -122,6 +122,8 @@ async function main() {
   console.log('👥 FamilyMembers created (山本家).');
 
   await seedMastersForFamily(familyGroup.id, { useExplicitCategoryIds: true });
+  // 明示 id 投入後はシーケンスを進めないと第2世帯の auto-increment が id=1 で衝突する
+  await syncPostgresIdSequence(prisma, 'Category');
   console.log('📂 Masters seeded (山本家).');
 
   await prisma.productMaster.create({

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
 import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -90,6 +91,9 @@ async function seedMastersForFamily(
 async function main() {
   console.log('--- 🚀 Seeding Start (Multi-Tenancy Architecture) ---');
 
+  const devPassword = process.env.SEED_MEMBER_PASSWORD ?? 'dev-password';
+  const password_hash = await bcrypt.hash(devPassword, 10);
+
   await prisma.item.deleteMany();
   await prisma.settlementTransfer.deleteMany();
   await prisma.productMaster.deleteMany();
@@ -113,7 +117,7 @@ async function main() {
     { id: 3, name: '息子（高校生）', familyGroupId: familyGroup.id, role: 'USER' as const },
   ];
   for (const m of familyMembers) {
-    await prisma.familyMember.create({ data: m });
+    await prisma.familyMember.create({ data: { ...m, password_hash } });
   }
   console.log('👥 FamilyMembers created (山本家).');
 
@@ -150,7 +154,7 @@ async function main() {
     { id: 5, name: '佐藤（配偶者）', familyGroupId: familyGroup2.id, role: 'USER' as const },
   ];
   for (const m of family2Members) {
-    await prisma.familyMember.create({ data: m });
+    await prisma.familyMember.create({ data: { ...m, password_hash } });
   }
   console.log(`👥 FamilyMembers created (${familyGroup2.name}).`);
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,37 +1,36 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { StyleSheet, View, Alert, ActivityIndicator, Platform, TextInput, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, Alert, ActivityIndicator, Text, TouchableOpacity } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
-import * as SplashScreen from 'expo-splash-screen'; 
+import * as SplashScreen from 'expo-splash-screen';
 
 import apiClient, { setOnUnauthorized } from './src/utils/apiClient';
-import { authService } from './src/services/authService'; 
+import { authService } from './src/services/authService';
 
 import { HomeScreen } from './src/screens/HomeScreen';
 import HistoryScreen from './src/screens/HistoryScreen';
-import { StatisticsScreen } from './src/screens/StatisticsScreen'; 
-import { CategoryManagementScreen } from './src/screens/CategoryManagementScreen'; 
-import { ProductMasterScreen } from './src/screens/ProductMasterScreen'; 
-import { ReceiptScanScreen } from './src/screens/ReceiptScanScreen'; 
+import { StatisticsScreen } from './src/screens/StatisticsScreen';
+import { CategoryManagementScreen } from './src/screens/CategoryManagementScreen';
+import { ProductMasterScreen } from './src/screens/ProductMasterScreen';
+import { ReceiptScanScreen } from './src/screens/ReceiptScanScreen';
 import { PromptEditorScreen } from './src/screens/PromptEditorScreen';
 import { AdminStatsScreen } from './src/screens/AdminStatsScreen';
 import { AdminMenuScreen } from './src/screens/AdminMenuScreen';
-import { SplitEditorScreen } from './src/screens/SplitEditorScreen'; 
-import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen'; // ★ [Issue #80] 追加
+import { SplitEditorScreen } from './src/screens/SplitEditorScreen';
+import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen';
+import { LoginScreen } from './src/screens/LoginScreen';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
+import type { LoginResult } from './src/types/auth';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-// ★ 'settlement_summary' を追加
 type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
   RESULT: '@app_result',
-  MEMBER_ID: 'currentMemberId',
 };
 
 export default function App() {
@@ -39,31 +38,26 @@ export default function App() {
   const [userToken, setUserToken] = useState<string | null>(null);
   const [currentMemberId, setCurrentMemberId] = useState<number | null>(null);
   const [currentUserRole, setCurrentUserRole] = useState<string | null>(null);
-  const [loginPassword, setLoginPassword] = useState('');
 
-  const [resultData, setResultData] = useState<any>(null); 
+  const [resultData, setResultData] = useState<any>(null);
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
-  
+
   const [targetReceipt, setTargetReceipt] = useState<any>(null);
 
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        const [token, midStr, role, v, res] = await Promise.all([
-          authService.getToken(),
-          Platform.OS === 'web'
-            ? AsyncStorage.getItem(STORAGE_KEYS.MEMBER_ID)
-            : SecureStore.getItemAsync(STORAGE_KEYS.MEMBER_ID),
-          authService.getRole(),
+        const [session, v, res] = await Promise.all([
+          authService.loadSession(),
           AsyncStorage.getItem(STORAGE_KEYS.VIEW),
           AsyncStorage.getItem(STORAGE_KEYS.RESULT),
         ]);
 
-        if (token) {
-          setUserToken(token);
-          setCurrentMemberId(midStr ? parseInt(midStr, 10) : 1);
-          setCurrentUserRole(role);
+        if (session) {
+          setUserToken(session.token);
+          setCurrentMemberId(session.memberId);
+          setCurrentUserRole(session.role);
 
           try {
             const catRes = await apiClient.get('/categories');
@@ -77,7 +71,6 @@ export default function App() {
 
         if (v) setCurrentView(v as ViewType);
         if (res) setResultData(JSON.parse(res));
-
       } catch (e) {
         console.error('初期化失敗', e);
       } finally {
@@ -91,55 +84,28 @@ export default function App() {
   useEffect(() => {
     setOnUnauthorized(() => {
       handleLogout();
-      Alert.alert("セッション切れ", "有効期限が切れたため、再度ログインしてください。");
+      Alert.alert('セッション切れ', '有効期限が切れたため、再度ログインしてください。');
     });
   }, []);
 
-  const handleLogin = async (memberId: number) => {
-    if (!loginPassword) {
-      Alert.alert("入力エラー", "パスワードを入力してください。");
-      return;
-    }
+  const handleLoginSuccess = async (
+    result: LoginResult,
+    context: { familyName: string; inviteCode: string }
+  ) => {
+    await authService.saveSession({
+      token: result.token,
+      member: result.member,
+      familyGroupName: context.familyName,
+      inviteCode: context.inviteCode,
+    });
 
-    try {
-      const response = await apiClient.post('/auth/login', { 
-        memberId, 
-        password: loginPassword 
-      });
-      
-      if (response.data && response.data.success) {
-        const { token, member } = response.data.data;
-        
-        await authService.saveToken(token);
-        if (member.role) {
-          await authService.saveRole(member.role);
-          setCurrentUserRole(member.role);
-        }
-
-        if (Platform.OS === 'web') {
-          await AsyncStorage.setItem(STORAGE_KEYS.MEMBER_ID, member.id.toString());
-        } else {
-          await SecureStore.setItemAsync(STORAGE_KEYS.MEMBER_ID, member.id.toString());
-        }
-        
-        setUserToken(token);
-        setCurrentMemberId(member.id);
-        setLoginPassword('');
-        fetchCategories();
-      }
-    } catch (e: any) {
-      Alert.alert("認証エラー", "ログインに失敗しました。");
-      setLoginPassword('');
-    }
+    setUserToken(result.token);
+    setCurrentMemberId(result.member.id);
+    setCurrentUserRole(result.member.role);
   };
 
   const handleLogout = async () => {
     await authService.logout();
-    if (Platform.OS === 'web') {
-      await AsyncStorage.removeItem(STORAGE_KEYS.MEMBER_ID);
-    } else {
-      await SecureStore.deleteItemAsync(STORAGE_KEYS.MEMBER_ID);
-    }
 
     setUserToken(null);
     setCurrentMemberId(null);
@@ -147,7 +113,6 @@ export default function App() {
     setCurrentView('main');
     setResultData(null);
     setTargetReceipt(null);
-    setLoginPassword('');
   };
 
   const fetchCategories = useCallback(async () => {
@@ -198,34 +163,12 @@ export default function App() {
     );
   }
 
-  // ★ isFullWidth に 'settlement_summary' を追加
   const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary'].includes(currentView);
 
   if (!userToken) {
     return (
       <ResponsiveContainer fullWidth={false}>
-        <View style={styles.loginContainer}>
-          <Text style={styles.loginTitle}>家計簿アプリ</Text>
-          <Text style={styles.loginSub}>パスワードを入力して開始</Text>
-          <View style={styles.inputWrapper}>
-            <TextInput
-              style={styles.passwordInput}
-              placeholder="パスワードを入力"
-              placeholderTextColor="rgba(255,255,255,0.6)"
-              secureTextEntry={true}
-              value={loginPassword}
-              onChangeText={setLoginPassword}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-          </View>
-          <TouchableOpacity style={styles.loginButton} onPress={() => handleLogin(1)}>
-            <Text style={styles.loginButtonText}>自分 (ID: 1) でログイン</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.loginButton} onPress={() => handleLogin(2)}>
-            <Text style={styles.loginButtonText}>その他 (ID: 2) でログイン</Text>
-          </TouchableOpacity>
-        </View>
+        <LoginScreen onLoginSuccess={handleLoginSuccess} />
       </ResponsiveContainer>
     );
   }
@@ -234,10 +177,10 @@ export default function App() {
     const memberId = currentMemberId!;
 
     switch (currentView) {
-      case 'history': 
+      case 'history':
         return (
-          <HistoryScreen 
-            onBack={() => setCurrentView('main')} 
+          <HistoryScreen
+            onBack={() => setCurrentView('main')}
             currentMemberId={memberId}
             onGoToSplitEditor={(receipt) => {
               setTargetReceipt(receipt);
@@ -245,32 +188,32 @@ export default function App() {
             }}
           />
         );
-      case 'split_editor': 
+      case 'split_editor':
         return (
           <SplitEditorScreen
             receipt={targetReceipt}
             onBack={() => {
               setTargetReceipt(null);
-              setCurrentView('history'); 
+              setCurrentView('history');
             }}
           />
         );
-      case 'settlement_summary': // ★ [Issue #80] 精算サマリー画面のルーティング追加
+      case 'settlement_summary':
         return (
           <SettlementSummaryScreen
             onBack={() => setCurrentView('main')}
           />
         );
-      case 'stats': 
+      case 'stats':
         return <StatisticsScreen currentMemberId={memberId} onBack={() => setCurrentView('main')} />;
-      case 'category_mgr': 
+      case 'category_mgr':
         return <CategoryManagementScreen onBack={() => { fetchCategories(); setCurrentView('admin_menu'); }} currentMemberId={memberId} />;
-      case 'product_master': 
+      case 'product_master':
         return <ProductMasterScreen onBack={() => setCurrentView('admin_menu')} currentMemberId={memberId} />;
-      case 'receipt_scan': 
+      case 'receipt_scan':
         return (
-          <ReceiptScanScreen 
-            initialData={resultData} 
+          <ReceiptScanScreen
+            initialData={resultData}
             categories={categories}
             onSuccess={() => {
               setResultData(null);
@@ -282,13 +225,13 @@ export default function App() {
             }}
           />
         );
-      case 'prompt_editor': 
+      case 'prompt_editor':
         return <PromptEditorScreen onBack={() => setCurrentView('admin_menu')} />;
       case 'admin_stats':
         return <AdminStatsScreen onBack={() => setCurrentView('admin_menu')} />;
       case 'admin_menu':
         return (
-          <AdminMenuScreen 
+          <AdminMenuScreen
             onBack={() => setCurrentView('main')}
             onGoToCategories={() => setCurrentView('category_mgr')}
             onGoToProductMaster={() => setCurrentView('product_master')}
@@ -303,13 +246,12 @@ export default function App() {
               <Text style={styles.logoutText}>ログアウト</Text>
             </TouchableOpacity>
 
-            <HomeScreen 
-              onAnalysisReady={handleAnalysisReady} 
+            <HomeScreen
+              onAnalysisReady={handleAnalysisReady}
               onGoToHistory={() => setCurrentView('history')}
               onGoToStats={() => setCurrentView('stats')}
-              // ★ [Issue #80] ハンドラを注入
               onGoToSettlement={() => setCurrentView('settlement_summary')}
-              onGoToAdminMenu={() => setCurrentView('admin_menu')} 
+              onGoToAdminMenu={() => setCurrentView('admin_menu')}
               currentMemberId={memberId}
               userRole={currentUserRole}
             />
@@ -331,21 +273,6 @@ export default function App() {
 
 const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
-  loginContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.primary, padding: 40 },
-  loginTitle: { fontSize: 32, fontWeight: 'bold', color: 'white', marginBottom: 10 },
-  loginSub: { fontSize: 16, color: 'rgba(255,255,255,0.8)', marginBottom: 30 },
-  inputWrapper: { width: '100%', marginBottom: 20 },
-  passwordInput: {
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    borderRadius: 12,
-    padding: 15,
-    color: 'white',
-    fontSize: 18,
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.3)',
-  },
-  loginButton: { backgroundColor: 'white', width: '100%', padding: 18, borderRadius: 15, marginBottom: 15, alignItems: 'center' },
-  loginButtonText: { color: theme.colors.primary, fontWeight: 'bold', fontSize: 16 },
   logoutTrigger: { position: 'absolute', top: 60, right: 20, zIndex: 10, backgroundColor: 'rgba(0,0,0,0.05)', padding: 8, borderRadius: 10 },
   logoutText: { color: theme.colors.text.muted, fontSize: 12, fontWeight: 'bold' },
 });

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -1,0 +1,297 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { loginService } from '../services/loginService';
+import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../types/auth';
+import { theme } from '../theme';
+
+type LoginStep = 'invite' | 'member' | 'password';
+
+type Props = {
+  onLoginSuccess: (result: LoginResult, context: { familyName: string; inviteCode: string }) => void;
+};
+
+export function LoginScreen({ onLoginSuccess }: Props) {
+  const [step, setStep] = useState<LoginStep>('invite');
+  const [inviteCode, setInviteCode] = useState('');
+  const [family, setFamily] = useState<ResolvedFamily | null>(null);
+  const [members, setMembers] = useState<AuthFamilyMember[]>([]);
+  const [selectedMember, setSelectedMember] = useState<AuthFamilyMember | null>(null);
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const resetToInvite = () => {
+    setStep('invite');
+    setFamily(null);
+    setMembers([]);
+    setSelectedMember(null);
+    setPassword('');
+  };
+
+  const handleResolveFamily = async () => {
+    if (!inviteCode.trim()) {
+      Alert.alert('入力エラー', '招待コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const resolved = await loginService.resolveFamily(inviteCode);
+      const memberList = await loginService.getFamilyMembers(
+        resolved.familyGroupId,
+        inviteCode
+      );
+      setFamily(resolved);
+      setMembers(memberList);
+      setStep('member');
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : '招待コードの確認に失敗しました。';
+      Alert.alert('エラー', message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectMember = (member: AuthFamilyMember) => {
+    setSelectedMember(member);
+    setPassword('');
+    setStep('password');
+  };
+
+  const handleLogin = async () => {
+    if (!family || !selectedMember) return;
+    if (!password) {
+      Alert.alert('入力エラー', 'パスワードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await loginService.login(
+        family.familyGroupId,
+        selectedMember.id,
+        password
+      );
+      onLoginSuccess(result, { familyName: family.name, inviteCode: inviteCode.trim() });
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : 'ログインに失敗しました。';
+      Alert.alert('認証エラー', message);
+      setPassword('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderInviteStep = () => (
+    <>
+      <Text style={styles.subtitle}>招待コードを入力してください</Text>
+      <View style={styles.inputWrapper}>
+        <TextInput
+          style={styles.input}
+          placeholder="例: YAMAMOTO-2026"
+          placeholderTextColor="rgba(255,255,255,0.6)"
+          value={inviteCode}
+          onChangeText={setInviteCode}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          editable={!loading}
+        />
+      </View>
+      <TouchableOpacity
+        style={[styles.primaryButton, loading && styles.buttonDisabled]}
+        onPress={handleResolveFamily}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={theme.colors.primary} />
+        ) : (
+          <Text style={styles.primaryButtonText}>次へ</Text>
+        )}
+      </TouchableOpacity>
+    </>
+  );
+
+  const renderMemberStep = () => (
+    <>
+      <Text style={styles.familyLabel}>{family?.name}</Text>
+      <Text style={styles.subtitle}>ログインするメンバーを選択</Text>
+      <ScrollView style={styles.memberList} contentContainerStyle={styles.memberListContent}>
+        {members.map((member) => (
+          <TouchableOpacity
+            key={member.id}
+            style={styles.memberButton}
+            onPress={() => handleSelectMember(member)}
+            disabled={loading}
+          >
+            <Text style={styles.memberButtonText}>{member.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+      <TouchableOpacity style={styles.linkButton} onPress={resetToInvite} disabled={loading}>
+        <Text style={styles.linkButtonText}>別の世帯でログイン</Text>
+      </TouchableOpacity>
+    </>
+  );
+
+  const renderPasswordStep = () => (
+    <>
+      <Text style={styles.familyLabel}>{family?.name}</Text>
+      <Text style={styles.subtitle}>{selectedMember?.name} としてログイン</Text>
+      <View style={styles.inputWrapper}>
+        <TextInput
+          style={styles.input}
+          placeholder="パスワードを入力"
+          placeholderTextColor="rgba(255,255,255,0.6)"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!loading}
+          onSubmitEditing={handleLogin}
+        />
+      </View>
+      <TouchableOpacity
+        style={[styles.primaryButton, loading && styles.buttonDisabled]}
+        onPress={handleLogin}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={theme.colors.primary} />
+        ) : (
+          <Text style={styles.primaryButtonText}>ログイン</Text>
+        )}
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.secondaryButton}
+        onPress={() => {
+          setSelectedMember(null);
+          setPassword('');
+          setStep('member');
+        }}
+        disabled={loading}
+      >
+        <Text style={styles.secondaryButtonText}>メンバー選択に戻る</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.linkButton} onPress={resetToInvite} disabled={loading}>
+        <Text style={styles.linkButtonText}>別の世帯でログイン</Text>
+      </TouchableOpacity>
+    </>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>家計簿アプリ</Text>
+      {step === 'invite' && renderInviteStep()}
+      {step === 'member' && renderMemberStep()}
+      {step === 'password' && renderPasswordStep()}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: theme.colors.primary,
+    padding: 40,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: 'white',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  familyLabel: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: 'white',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: 'rgba(255,255,255,0.8)',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  inputWrapper: {
+    width: '100%',
+    marginBottom: 20,
+  },
+  input: {
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    borderRadius: 12,
+    padding: 15,
+    color: 'white',
+    fontSize: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+  },
+  primaryButton: {
+    backgroundColor: 'white',
+    width: '100%',
+    padding: 18,
+    borderRadius: 15,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: theme.colors.primary,
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  secondaryButton: {
+    width: '100%',
+    padding: 14,
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  secondaryButtonText: {
+    color: 'rgba(255,255,255,0.9)',
+    fontSize: 15,
+  },
+  linkButton: {
+    width: '100%',
+    padding: 12,
+    alignItems: 'center',
+  },
+  linkButtonText: {
+    color: 'rgba(255,255,255,0.75)',
+    fontSize: 14,
+    textDecorationLine: 'underline',
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  memberList: {
+    maxHeight: 280,
+    width: '100%',
+    marginBottom: 16,
+  },
+  memberListContent: {
+    gap: 12,
+  },
+  memberButton: {
+    backgroundColor: 'white',
+    padding: 18,
+    borderRadius: 15,
+    alignItems: 'center',
+  },
+  memberButtonText: {
+    color: theme.colors.primary,
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,52 +1,157 @@
 import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
+import type { StoredSession } from '../types/auth';
 
-const TOKEN_KEY = 'userToken';
-// [Issue #73] Role保存用のキー
-const ROLE_KEY = 'currentUserRole';
+export const AUTH_STORAGE_KEYS = {
+  TOKEN: 'userToken',
+  ROLE: 'currentUserRole',
+  MEMBER_ID: 'currentMemberId',
+  MEMBER_NAME: 'currentMemberName',
+  FAMILY_GROUP_ID: 'currentFamilyGroupId',
+  FAMILY_GROUP_NAME: 'currentFamilyGroupName',
+  INVITE_CODE: 'savedInviteCode',
+} as const;
+
+async function setItem(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(key, value);
+  } else {
+    await SecureStore.setItemAsync(key, value);
+  }
+}
+
+async function getItem(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    return AsyncStorage.getItem(key);
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function removeItem(key: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(key);
+  } else {
+    await SecureStore.deleteItemAsync(key);
+  }
+}
 
 export const authService = {
-  // トークンを保存する
   async saveToken(token: string) {
-    if (Platform.OS === 'web') {
-      await AsyncStorage.setItem(TOKEN_KEY, token);
-    } else {
-      await SecureStore.setItemAsync(TOKEN_KEY, token);
-    }
+    await setItem(AUTH_STORAGE_KEYS.TOKEN, token);
   },
-  // 保存されているトークンを読み出す
+
   async getToken() {
-    if (Platform.OS === 'web') {
-      return await AsyncStorage.getItem(TOKEN_KEY);
-    } else {
-      return await SecureStore.getItemAsync(TOKEN_KEY);
-    }
+    return getItem(AUTH_STORAGE_KEYS.TOKEN);
   },
-  // [Issue #73] Roleを保存する
+
   async saveRole(role: string) {
-    if (Platform.OS === 'web') {
-      await AsyncStorage.setItem(ROLE_KEY, role);
-    } else {
-      await SecureStore.setItemAsync(ROLE_KEY, role);
-    }
+    await setItem(AUTH_STORAGE_KEYS.ROLE, role);
   },
-  // [Issue #73] 保存されているRoleを読み出す
+
   async getRole() {
-    if (Platform.OS === 'web') {
-      return await AsyncStorage.getItem(ROLE_KEY);
-    } else {
-      return await SecureStore.getItemAsync(ROLE_KEY);
+    return getItem(AUTH_STORAGE_KEYS.ROLE);
+  },
+
+  async saveMemberId(memberId: number) {
+    await setItem(AUTH_STORAGE_KEYS.MEMBER_ID, String(memberId));
+  },
+
+  async getMemberId(): Promise<number | null> {
+    const value = await getItem(AUTH_STORAGE_KEYS.MEMBER_ID);
+    if (!value) return null;
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  },
+
+  async saveMemberName(name: string) {
+    await setItem(AUTH_STORAGE_KEYS.MEMBER_NAME, name);
+  },
+
+  async getMemberName() {
+    return getItem(AUTH_STORAGE_KEYS.MEMBER_NAME);
+  },
+
+  async saveFamilyGroupId(familyGroupId: number) {
+    await setItem(AUTH_STORAGE_KEYS.FAMILY_GROUP_ID, String(familyGroupId));
+  },
+
+  async getFamilyGroupId(): Promise<number | null> {
+    const value = await getItem(AUTH_STORAGE_KEYS.FAMILY_GROUP_ID);
+    if (!value) return null;
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  },
+
+  async saveFamilyGroupName(name: string) {
+    await setItem(AUTH_STORAGE_KEYS.FAMILY_GROUP_NAME, name);
+  },
+
+  async getFamilyGroupName() {
+    return getItem(AUTH_STORAGE_KEYS.FAMILY_GROUP_NAME);
+  },
+
+  /** 端末保持用（メンバー選択の再表示には使わない） */
+  async saveInviteCode(inviteCode: string) {
+    await setItem(AUTH_STORAGE_KEYS.INVITE_CODE, inviteCode);
+  },
+
+  async getInviteCode() {
+    return getItem(AUTH_STORAGE_KEYS.INVITE_CODE);
+  },
+
+  async saveSession(session: {
+    token: string;
+    member: { id: number; name: string; familyGroupId: number; role: string };
+    familyGroupName: string;
+    inviteCode?: string;
+  }) {
+    await this.saveToken(session.token);
+    await this.saveMemberId(session.member.id);
+    await this.saveMemberName(session.member.name);
+    await this.saveFamilyGroupId(session.member.familyGroupId);
+    await this.saveFamilyGroupName(session.familyGroupName);
+    if (session.member.role) {
+      await this.saveRole(session.member.role);
+    }
+    if (session.inviteCode) {
+      await this.saveInviteCode(session.inviteCode);
     }
   },
-  // ログアウト時にトークンとRoleを消去する
-  async logout() {
-    if (Platform.OS === 'web') {
-      await AsyncStorage.removeItem(TOKEN_KEY);
-      await AsyncStorage.removeItem(ROLE_KEY);
-    } else {
-      await SecureStore.deleteItemAsync(TOKEN_KEY);
-      await SecureStore.deleteItemAsync(ROLE_KEY);
+
+  async loadSession(): Promise<StoredSession | null> {
+    const [token, memberId, memberName, familyGroupId, familyGroupName, role] =
+      await Promise.all([
+        this.getToken(),
+        this.getMemberId(),
+        this.getMemberName(),
+        this.getFamilyGroupId(),
+        this.getFamilyGroupName(),
+        this.getRole(),
+      ]);
+
+    if (!token || memberId == null || familyGroupId == null) {
+      return null;
     }
-  }
+
+    return {
+      token,
+      memberId,
+      memberName: memberName ?? '',
+      familyGroupId,
+      familyGroupName: familyGroupName ?? '',
+      role,
+    };
+  },
+
+  async logout() {
+    await Promise.all(
+      Object.values(AUTH_STORAGE_KEYS).map((key) => removeItem(key))
+    );
+  },
+
+  /** [#306 連携用] 生体認証 ON/OFF — 現時点は空実装 */
+  async isBiometricEnabled(): Promise<boolean> {
+    return false;
+  },
 };

--- a/frontend/src/services/loginService.ts
+++ b/frontend/src/services/loginService.ts
@@ -1,0 +1,37 @@
+import apiClient from '../utils/apiClient';
+import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../types/auth';
+
+type SuccessEnvelope<T> = { success: true; data: T };
+
+export const loginService = {
+  async resolveFamily(inviteCode: string): Promise<ResolvedFamily> {
+    const res = await apiClient.post<SuccessEnvelope<ResolvedFamily>>('/auth/resolve-family', {
+      inviteCode: inviteCode.trim(),
+    });
+    return res.data.data;
+  },
+
+  async getFamilyMembers(
+    familyGroupId: number,
+    inviteCode: string
+  ): Promise<AuthFamilyMember[]> {
+    const res = await apiClient.get<SuccessEnvelope<AuthFamilyMember[]>>(
+      `/auth/families/${familyGroupId}/members`,
+      { params: { inviteCode: inviteCode.trim() } }
+    );
+    return res.data.data;
+  },
+
+  async login(
+    familyGroupId: number,
+    memberId: number,
+    password: string
+  ): Promise<LoginResult> {
+    const res = await apiClient.post<SuccessEnvelope<LoginResult>>('/auth/login', {
+      familyGroupId,
+      memberId,
+      password,
+    });
+    return res.data.data;
+  },
+};

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,31 @@
+export type ResolvedFamily = {
+  familyGroupId: number;
+  name: string;
+};
+
+export type AuthFamilyMember = {
+  id: number;
+  name: string;
+};
+
+export type LoginMember = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: string;
+};
+
+export type LoginResult = {
+  token: string;
+  member: LoginMember;
+  requiresTwoFactor: boolean;
+};
+
+export type StoredSession = {
+  token: string;
+  memberId: number;
+  memberName: string;
+  familyGroupId: number;
+  familyGroupName: string;
+  role: string | null;
+};

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -2,13 +2,7 @@ import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform, Alert } from 'react-native';
-
-// --- 定数定義 ---
-const STORAGE_KEYS = {
-  TOKEN: 'userToken',
-  MEMBER_ID: 'currentMemberId',
-  USER_ROLE: 'currentUserRole', 
-} as const;
+import { AUTH_STORAGE_KEYS } from '../services/authService';
 
 /**
  * [Issue #52] 401エラー時に App.tsx 等の UI 側でログアウト処理を発火させるためのハンドラ
@@ -49,17 +43,17 @@ const getStorageItem = async (key: string): Promise<string | null> => {
  * [Issue #73] 現在ログイン中のユーザーの Role を取得するユーティリティ
  */
 export const getUserRole = async (): Promise<string | null> => {
-  return await getStorageItem(STORAGE_KEYS.USER_ROLE);
+  return await getStorageItem(AUTH_STORAGE_KEYS.ROLE);
 };
 
 // --- リクエストインターセプター：送信前に認証情報を自動注入 ---
 apiClient.interceptors.request.use(async (config) => {
-  const token = await getStorageItem(STORAGE_KEYS.TOKEN);
+  const token = await getStorageItem(AUTH_STORAGE_KEYS.TOKEN);
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
 
-  const memberId = await getStorageItem(STORAGE_KEYS.MEMBER_ID);
+  const memberId = await getStorageItem(AUTH_STORAGE_KEYS.MEMBER_ID);
   if (memberId) {
     config.headers['x-member-id'] = memberId;
   }


### PR DESCRIPTION
## Summary

内部 **#92** / GitHub **#304** — 招待コードベースのログインフローを Frontend に実装しました。

| Step | UI | API |
|------|-----|-----|
| 1 | 招待コード入力 | `POST /api/auth/resolve-family` |
| 2 | メンバー選択 | `GET /api/auth/families/:id/members?inviteCode=` |
| 3 | パスワード | `POST /api/auth/login`（`familyGroupId` + `memberId`） |

### 主な変更

- **`LoginScreen`**: 3ステップ UI、「別の世帯でログイン」対応
- **`authService`**: `familyGroupId` / `memberId` / 表示名 / JWT の端末保持・起動時復元
- **`loginService`**: 認証 API ラッパー
- **`App.tsx`**: 固定 ID 1/2 UI 廃止、`LoginScreen` に置き換え
- **`seed.ts`**: 全メンバーに dev 用パスワード（デフォルト `dev-password`）を設定

### dev ログイン手順

1. 招待コード: `YAMAMOTO-2026`（山本家 3名）/ `SATO-2026`（佐藤家）
2. メンバーを選択
3. パスワード: `dev-password`（`SEED_MEMBER_PASSWORD` で変更可）

## Test plan

- [x] `frontend npm test` / `tsc --noEmit`
- [ ] dev Docker: seed 後、3名すべてログイン可能
- [ ] 再起動後にセッション復元（ログイン画面をスキップ）
- [ ] ログアウト → 再ログイン
- [ ] 手動回帰 §0

## main マージ

#92 + Backend 一式（#93-1 / #93-4 / #93-2）を **同時デプロイ** 推奨。
#93-4 マージ時: `prisma migrate deploy` 必須。stable では `prisma db seed` 禁止。

Closes #304

Made with [Cursor](https://cursor.com)