### PR TITLE
feat(frontend): [Issue #93-5] 起動時生体認証ロック（Native）

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,11 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { StyleSheet, View, Alert, ActivityIndicator, Text, TouchableOpacity } from 'react-native';
+import {
+  StyleSheet,
+  View,
+  Alert,
+  ActivityIndicator,
+  Text,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SplashScreen from 'expo-splash-screen';
 
 import apiClient, { setOnUnauthorized } from './src/utils/apiClient';
 import { authService } from './src/services/authService';
+import { canUseBiometric } from './src/services/biometricService';
 
 import { HomeScreen } from './src/screens/HomeScreen';
 import HistoryScreen from './src/screens/HistoryScreen';
@@ -19,10 +28,11 @@ import { AdminMenuScreen } from './src/screens/AdminMenuScreen';
 import { SplitEditorScreen } from './src/screens/SplitEditorScreen';
 import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen';
 import { LoginScreen } from './src/screens/LoginScreen';
+import { BiometricLockScreen } from './src/screens/BiometricLockScreen';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
-import type { LoginResult } from './src/types/auth';
+import type { LoginResult, StoredSession } from './src/types/auth';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
@@ -38,6 +48,9 @@ export default function App() {
   const [userToken, setUserToken] = useState<string | null>(null);
   const [currentMemberId, setCurrentMemberId] = useState<number | null>(null);
   const [currentUserRole, setCurrentUserRole] = useState<string | null>(null);
+  const [pendingSession, setPendingSession] = useState<StoredSession | null>(null);
+  const [biometricLockActive, setBiometricLockActive] = useState(false);
+  const [biometricEnabled, setBiometricEnabled] = useState(false);
 
   const [resultData, setResultData] = useState<any>(null);
   const [categories, setCategories] = useState<any[]>([]);
@@ -45,27 +58,43 @@ export default function App() {
 
   const [targetReceipt, setTargetReceipt] = useState<any>(null);
 
+  const applySession = useCallback((session: StoredSession) => {
+    setUserToken(session.token);
+    setCurrentMemberId(session.memberId);
+    setCurrentUserRole(session.role);
+  }, []);
+
+  const fetchCategoriesForSession = useCallback(async () => {
+    try {
+      const catRes = await apiClient.get('/categories');
+      if (catRes.data?.success) {
+        setCategories(catRes.data.data);
+      }
+    } catch (catErr) {
+      console.error('起動時のカテゴリマスタ先行取得失敗:', catErr);
+    }
+  }, []);
+
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        const [session, v, res] = await Promise.all([
+        const [session, bioEnabled, v, res] = await Promise.all([
           authService.loadSession(),
+          authService.isBiometricEnabled(),
           AsyncStorage.getItem(STORAGE_KEYS.VIEW),
           AsyncStorage.getItem(STORAGE_KEYS.RESULT),
         ]);
 
-        if (session) {
-          setUserToken(session.token);
-          setCurrentMemberId(session.memberId);
-          setCurrentUserRole(session.role);
+        setBiometricEnabled(bioEnabled);
 
-          try {
-            const catRes = await apiClient.get('/categories');
-            if (catRes.data?.success) {
-              setCategories(catRes.data.data);
-            }
-          } catch (catErr) {
-            console.error('起動時のカテゴリマスタ先行取得失敗:', catErr);
+        if (session) {
+          const needsBiometricLock = bioEnabled && Platform.OS !== 'web';
+          if (needsBiometricLock) {
+            setPendingSession(session);
+            setBiometricLockActive(true);
+          } else {
+            applySession(session);
+            await fetchCategoriesForSession();
           }
         }
 
@@ -79,13 +108,34 @@ export default function App() {
       }
     };
     initializeApp();
-  }, []);
+  }, [applySession, fetchCategoriesForSession]);
 
   useEffect(() => {
     setOnUnauthorized(() => {
-      handleLogout();
+      void handleLogout();
       Alert.alert('セッション切れ', '有効期限が切れたため、再度ログインしてください。');
     });
+  }, []);
+
+  const promptEnableBiometric = useCallback(async () => {
+    if (Platform.OS === 'web') return;
+    const available = await canUseBiometric();
+    if (!available) return;
+
+    Alert.alert(
+      '生体認証',
+      '次回起動時に生体認証でロック解除しますか？',
+      [
+        { text: 'あとで', style: 'cancel' },
+        {
+          text: '有効にする',
+          onPress: async () => {
+            await authService.setBiometricEnabled(true);
+            setBiometricEnabled(true);
+          },
+        },
+      ]
+    );
   }, []);
 
   const handleLoginSuccess = async (
@@ -99,10 +149,47 @@ export default function App() {
       inviteCode: context.inviteCode,
     });
 
-    setUserToken(result.token);
-    setCurrentMemberId(result.member.id);
-    setCurrentUserRole(result.member.role);
+    applySession({
+      token: result.token,
+      memberId: result.member.id,
+      memberName: result.member.name,
+      familyGroupId: result.member.familyGroupId,
+      familyGroupName: context.familyName,
+      role: result.member.role,
+    });
+    setBiometricLockActive(false);
+    setPendingSession(null);
+    await fetchCategoriesForSession();
+    await promptEnableBiometric();
   };
+
+  const handleBiometricUnlock = useCallback(async () => {
+    if (!pendingSession) return;
+    applySession(pendingSession);
+    setBiometricLockActive(false);
+    setPendingSession(null);
+    await fetchCategoriesForSession();
+  }, [applySession, fetchCategoriesForSession, pendingSession]);
+
+  const handleUsePasswordFromLock = useCallback(async () => {
+    await authService.logout();
+    setPendingSession(null);
+    setBiometricLockActive(false);
+    setBiometricEnabled(false);
+    setUserToken(null);
+    setCurrentMemberId(null);
+    setCurrentUserRole(null);
+    setCurrentView('main');
+    setResultData(null);
+    setTargetReceipt(null);
+    setCategories([]);
+  }, []);
+
+  const handleDisableBiometric = useCallback(async () => {
+    await authService.setBiometricEnabled(false);
+    setBiometricEnabled(false);
+    Alert.alert('生体認証', '生体認証によるロック解除をオフにしました。');
+  }, []);
 
   const handleLogout = async () => {
     await authService.logout();
@@ -110,9 +197,13 @@ export default function App() {
     setUserToken(null);
     setCurrentMemberId(null);
     setCurrentUserRole(null);
+    setPendingSession(null);
+    setBiometricLockActive(false);
+    setBiometricEnabled(false);
     setCurrentView('main');
     setResultData(null);
     setTargetReceipt(null);
+    setCategories([]);
   };
 
   const fetchCategories = useCallback(async () => {
@@ -164,6 +255,18 @@ export default function App() {
   }
 
   const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary'].includes(currentView);
+
+  if (biometricLockActive && pendingSession) {
+    return (
+      <ResponsiveContainer fullWidth={false}>
+        <BiometricLockScreen
+          memberName={pendingSession.memberName}
+          onUnlocked={handleBiometricUnlock}
+          onUsePassword={handleUsePasswordFromLock}
+        />
+      </ResponsiveContainer>
+    );
+  }
 
   if (!userToken) {
     return (
@@ -242,9 +345,16 @@ export default function App() {
       default:
         return (
           <View style={{ flex: 1 }}>
-            <TouchableOpacity style={styles.logoutTrigger} onPress={handleLogout}>
-              <Text style={styles.logoutText}>ログアウト</Text>
-            </TouchableOpacity>
+            <View style={styles.topActions}>
+              {biometricEnabled && Platform.OS !== 'web' ? (
+                <TouchableOpacity style={styles.topActionButton} onPress={handleDisableBiometric}>
+                  <Text style={styles.topActionText}>生体認証オフ</Text>
+                </TouchableOpacity>
+              ) : null}
+              <TouchableOpacity style={styles.topActionButton} onPress={handleLogout}>
+                <Text style={styles.topActionText}>ログアウト</Text>
+              </TouchableOpacity>
+            </View>
 
             <HomeScreen
               onAnalysisReady={handleAnalysisReady}
@@ -273,6 +383,18 @@ export default function App() {
 
 const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
-  logoutTrigger: { position: 'absolute', top: 60, right: 20, zIndex: 10, backgroundColor: 'rgba(0,0,0,0.05)', padding: 8, borderRadius: 10 },
-  logoutText: { color: theme.colors.text.muted, fontSize: 12, fontWeight: 'bold' },
+  topActions: {
+    position: 'absolute',
+    top: 60,
+    right: 20,
+    zIndex: 10,
+    flexDirection: 'row',
+    gap: 8,
+  },
+  topActionButton: {
+    backgroundColor: 'rgba(0,0,0,0.05)',
+    padding: 8,
+    borderRadius: 10,
+  },
+  topActionText: { color: theme.colors.text.muted, fontSize: 12, fontWeight: 'bold' },
 });

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -13,7 +13,10 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSFaceIDUsageDescription": "家計簿アプリのロック解除に Face ID を使用します。"
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -27,7 +30,13 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-secure-store"
+      "expo-secure-store",
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "家計簿アプリのロック解除に Face ID を使用します。"
+        }
+      ]
     ]
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "expo-file-system": "~19.0.21",
         "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "~17.0.10",
+        "expo-local-authentication": "~17.0.8",
         "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
@@ -5779,6 +5780,18 @@
       "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "expo": "*"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "expo-file-system": "~19.0.21",
     "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "~17.0.10",
+    "expo-local-authentication": "~17.0.8",
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/frontend/src/screens/BiometricLockScreen.tsx
+++ b/frontend/src/screens/BiometricLockScreen.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { authenticateWithBiometric } from '../services/biometricService';
+import { theme } from '../theme';
+
+type Props = {
+  memberName?: string;
+  onUnlocked: () => void;
+  onUsePassword: () => void;
+};
+
+export function BiometricLockScreen({ memberName, onUnlocked, onUsePassword }: Props) {
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const tryUnlock = useCallback(async () => {
+    setIsAuthenticating(true);
+    setErrorMessage(null);
+    try {
+      const success = await authenticateWithBiometric();
+      if (success) {
+        onUnlocked();
+      } else {
+        setErrorMessage('生体認証に失敗しました。もう一度お試しください。');
+      }
+    } catch {
+      setErrorMessage('生体認証を利用できませんでした。');
+    } finally {
+      setIsAuthenticating(false);
+    }
+  }, [onUnlocked]);
+
+  useEffect(() => {
+    void tryUnlock();
+  }, [tryUnlock]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>ロック中</Text>
+      {memberName ? (
+        <Text style={styles.subtitle}>{memberName} としてログイン済み</Text>
+      ) : (
+        <Text style={styles.subtitle}>生体認証でロックを解除してください</Text>
+      )}
+
+      {isAuthenticating ? (
+        <ActivityIndicator size="large" color="white" style={styles.spinner} />
+      ) : (
+        <TouchableOpacity style={styles.primaryButton} onPress={tryUnlock}>
+          <Text style={styles.primaryButtonText}>生体認証で解除</Text>
+        </TouchableOpacity>
+      )}
+
+      {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+
+      <TouchableOpacity style={styles.linkButton} onPress={onUsePassword} disabled={isAuthenticating}>
+        <Text style={styles.linkButtonText}>パスワードでログイン</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.primary,
+    padding: 40,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: 'white',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: 'rgba(255,255,255,0.85)',
+    marginBottom: 32,
+    textAlign: 'center',
+  },
+  spinner: {
+    marginVertical: 24,
+  },
+  primaryButton: {
+    backgroundColor: 'white',
+    width: '100%',
+    padding: 18,
+    borderRadius: 15,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  primaryButtonText: {
+    color: theme.colors.primary,
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  error: {
+    color: '#ffcccc',
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  linkButton: {
+    padding: 12,
+  },
+  linkButtonText: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 14,
+    textDecorationLine: 'underline',
+  },
+});

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -11,6 +11,7 @@ export const AUTH_STORAGE_KEYS = {
   FAMILY_GROUP_ID: 'currentFamilyGroupId',
   FAMILY_GROUP_NAME: 'currentFamilyGroupName',
   INVITE_CODE: 'savedInviteCode',
+  BIOMETRIC_ENABLED: 'biometricEnabled',
 } as const;
 
 async function setItem(key: string, value: string): Promise<void> {
@@ -150,8 +151,18 @@ export const authService = {
     );
   },
 
-  /** [#306 連携用] 生体認証 ON/OFF — 現時点は空実装 */
+  async setBiometricEnabled(enabled: boolean): Promise<void> {
+    if (Platform.OS === 'web') return;
+    if (enabled) {
+      await setItem(AUTH_STORAGE_KEYS.BIOMETRIC_ENABLED, 'true');
+    } else {
+      await removeItem(AUTH_STORAGE_KEYS.BIOMETRIC_ENABLED);
+    }
+  },
+
   async isBiometricEnabled(): Promise<boolean> {
-    return false;
+    if (Platform.OS === 'web') return false;
+    const value = await getItem(AUTH_STORAGE_KEYS.BIOMETRIC_ENABLED);
+    return value === 'true';
   },
 };

--- a/frontend/src/services/biometricService.ts
+++ b/frontend/src/services/biometricService.ts
@@ -1,0 +1,30 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+import { Platform } from 'react-native';
+
+/** Web は Later。Native のみ生体ロック対象 */
+export function isBiometricPlatform(): boolean {
+  return Platform.OS === 'ios' || Platform.OS === 'android';
+}
+
+export async function canUseBiometric(): Promise<boolean> {
+  if (!isBiometricPlatform()) return false;
+
+  const [hasHardware, isEnrolled] = await Promise.all([
+    LocalAuthentication.hasHardwareAsync(),
+    LocalAuthentication.isEnrolledAsync(),
+  ]);
+  return hasHardware && isEnrolled;
+}
+
+export async function authenticateWithBiometric(
+  promptMessage = 'アプリのロックを解除してください'
+): Promise<boolean> {
+  if (!isBiometricPlatform()) return false;
+
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage,
+    cancelLabel: 'キャンセル',
+    disableDeviceFallback: false,
+  });
+  return result.success;
+}


### PR DESCRIPTION
## Summary

内部 **#93-5** / GitHub **#306** の **第1部（生体認証 Must）** です。TOTP 2FA は本 PR には含めません。

### 生体認証（Native のみ）

| 項目 | 内容 |
|------|------|
| 初回 | パスワードログイン成功後、「生体で次回からロック解除」を任意で ON |
| 2回目以降 | 起動時 `BiometricLockScreen` → 成功後 SecureStore から JWT 復元 |
| JWT 期限切れ | 既存の 401 ハンドラでログアウト → パスワード再入力 |
| Web | 対象外（従来どおりパスワードログインのみ） |
| OFF | ログアウト、またはホーム画面の「生体認証オフ」 |

### 変更ファイル

- `expo-local-authentication` 追加
- `app.json` — Face ID 権限・プラグイン
- `biometricService.ts` / `BiometricLockScreen.tsx`
- `authService` — `biometricEnabled` フラグ
- `App.tsx` — 起動フロー分岐

### dev build について

**Expo Go では Face ID / 指紋が使えない場合があります。** 実機確認は `npx expo run:ios` / `run:android` の dev build を推奨します。

## Test plan

- [x] `frontend npm test` / `tsc --noEmit`
- [ ] Web: 従来どおりログイン・再起動でセッション復元（生体プロンプトなし）
- [ ] iOS/Android dev build: ログイン → 生体 ON → アプリ再起動 → ロック画面
- [ ] 「パスワードでログイン」でフル再認証
- [ ] ログアウトで生体 OFF

## 残タスク（#306 継続）

- [ ] TOTP 2FA（Backend + Frontend）
- [ ] Admin 必須 / USER 任意のセットアップ UI

Part of #306

Made with [Cursor](https://cursor.com)