### PR TITLE
feat: [Issue #93-5] TOTP 2FA + 生体認証完了（Closes #306）

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.0.2",
+        "otplib": "^12.0.1",
         "sharp": "^0.34.5",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0",
@@ -1124,6 +1125,56 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -4058,6 +4109,17 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4771,6 +4833,14 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.0.2",
+    "otplib": "^12.0.1",
     "sharp": "^0.34.5",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",

--- a/backend/prisma/migrations/20260608140000_add_totp_to_family_member/migration.sql
+++ b/backend/prisma/migrations/20260608140000_add_totp_to_family_member/migration.sql
@@ -1,0 +1,4 @@
+-- [Issue #93-5] TOTP 2FA
+ALTER TABLE "FamilyMember" ADD COLUMN "totpSecret" TEXT;
+ALTER TABLE "FamilyMember" ADD COLUMN "totpEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "FamilyMember" ADD COLUMN "totpVerifiedAt" TIMESTAMPTZ(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,6 +35,9 @@ model FamilyMember {
   password_hash String?
   familyGroupId Int           // ★ 所属世帯
   role          Role          @default(USER) // [Issue #73] デフォルトは一般ユーザー
+  totpSecret    String?       // [Issue #93-5] TOTP シークレット（暗号化保存）
+  totpEnabled   Boolean       @default(false)
+  totpVerifiedAt DateTime?    @db.Timestamptz(3)
   familyGroup   FamilyGroup   @relation(fields: [familyGroupId], references: [id])
   receipts      Receipt[]
   apiUsageLogs  ApiUsageLog[] // [Issue #59] トークンログとのリレーション

--- a/backend/prisma/seeds/prompt_templates.json
+++ b/backend/prisma/seeds/prompt_templates.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 13,
+    "id": 9,
     "familyGroupId": 1,
     "key": "RECEIPT_ANALYSIS",
     "name": "システム標準プロンプト",
@@ -13,7 +13,7 @@
     },
     "isActive": true,
     "version": 1,
-    "createdAt": "2026-06-08T13:21:55.037Z",
-    "updatedAt": "2026-06-08T13:21:55.037Z"
+    "createdAt": "2026-06-07T20:55:48.904Z",
+    "updatedAt": "2026-06-07T20:55:48.904Z"
   }
 ]

--- a/backend/prisma/seeds/prompt_templates.json
+++ b/backend/prisma/seeds/prompt_templates.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 9,
+    "id": 13,
     "familyGroupId": 1,
     "key": "RECEIPT_ANALYSIS",
     "name": "システム標準プロンプト",
@@ -13,7 +13,7 @@
     },
     "isActive": true,
     "version": 1,
-    "createdAt": "2026-06-07T20:55:48.904Z",
-    "updatedAt": "2026-06-07T20:55:48.904Z"
+    "createdAt": "2026-06-08T13:21:55.037Z",
+    "updatedAt": "2026-06-08T13:21:55.037Z"
   }
 ]

--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -6,7 +6,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import { createApp } from './app';
 import {
+  ensureTestAdminTotp,
   ensureTestMemberPassword,
+  getTestTotpCode,
   getTenantBItemId,
   getTenantBCategoryId,
   getTenantBReceiptWithImage,
@@ -48,6 +50,8 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
     await ensureTestMemberPassword(1);
     await ensureTestMemberPassword(2);
     await ensureTestMemberPassword(TENANT_B_ADMIN_MEMBER_ID);
+    await ensureTestAdminTotp(1);
+    await ensureTestAdminTotp(TENANT_B_ADMIN_MEMBER_ID);
 
     const fixturePath = path.join(process.cwd(), 'uploads', 'tenant-isolation-fixture.webp');
     fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
@@ -61,8 +65,8 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
     await prisma.$disconnect();
   });
 
-  it('POST /api/auth/login succeeds with test password', async () => {
-    const res = await request(app)
+  it('POST /api/auth/login succeeds with test password (admin TOTP verify)', async () => {
+    const loginRes = await request(app)
       .post('/api/auth/login')
       .send({
         familyGroupId: 1,
@@ -70,11 +74,18 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
         password: 'integration-test-password',
       });
 
-    expect(res.status).toBe(200);
-    expect(res.body.success).toBe(true);
-    expect(res.body.data.token).toBeDefined();
-    expect(res.body.data.member.familyGroupId).toBe(1);
-    expect(res.body.data.requiresTwoFactor).toBe(true);
+    expect(loginRes.status).toBe(200);
+    expect(loginRes.body.data.requiresTotpVerification).toBe(true);
+    expect(loginRes.body.data.pendingToken).toBeDefined();
+
+    const verifyRes = await request(app)
+      .post('/api/auth/verify-totp')
+      .set('Authorization', `Bearer ${loginRes.body.data.pendingToken}`)
+      .send({ code: getTestTotpCode() });
+
+    expect(verifyRes.status).toBe(200);
+    expect(verifyRes.body.data.token).toBeDefined();
+    expect(verifyRes.body.data.member.familyGroupId).toBe(1);
   });
 
   describe('Auth API (#93-2)', () => {
@@ -144,9 +155,16 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
         });
 
       expect(loginRes.status).toBe(200);
-      expect(loginRes.body.data.token).toBeDefined();
-      expect(loginRes.body.data.member.familyGroupId).toBe(2);
-      expect(loginRes.body.data.requiresTwoFactor).toBe(true);
+      expect(loginRes.body.data.requiresTotpVerification).toBe(true);
+
+      const verifyRes = await request(app)
+        .post('/api/auth/verify-totp')
+        .set('Authorization', `Bearer ${loginRes.body.data.pendingToken}`)
+        .send({ code: getTestTotpCode() });
+
+      expect(verifyRes.status).toBe(200);
+      expect(verifyRes.body.data.token).toBeDefined();
+      expect(verifyRes.body.data.member.familyGroupId).toBe(2);
     });
 
     it('POST /api/auth/login rejects member from another family', async () => {
@@ -161,7 +179,7 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
       expect(res.status).toBe(401);
     });
 
-    it('POST /api/auth/login sets requiresTwoFactor false for USER role', async () => {
+    it('POST /api/auth/login issues token directly for USER without TOTP', async () => {
       const res = await request(app)
         .post('/api/auth/login')
         .send({
@@ -171,7 +189,106 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
         });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.requiresTwoFactor).toBe(false);
+      expect(res.body.data.token).toBeDefined();
+      expect(res.body.data.requiresTotpSetup).toBe(false);
+      expect(res.body.data.requiresTotpVerification).toBe(false);
+    });
+  });
+
+  describe('TOTP 2FA (#93-5)', () => {
+    it('admin without TOTP gets requiresTotpSetup on login', async () => {
+      await prisma.familyMember.update({
+        where: { id: 1 },
+        data: { totpSecret: null, totpEnabled: false, totpVerifiedAt: null },
+      });
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId: 1,
+          memberId: 1,
+          password: 'integration-test-password',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.requiresTotpSetup).toBe(true);
+      expect(res.body.data.pendingToken).toBeDefined();
+      expect(res.body.data.token).toBeNull();
+
+      await ensureTestAdminTotp(1);
+    });
+
+    it('admin setup flow issues access token', async () => {
+      await prisma.familyMember.update({
+        where: { id: 1 },
+        data: { totpSecret: null, totpEnabled: false, totpVerifiedAt: null },
+      });
+
+      const loginRes = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId: 1,
+          memberId: 1,
+          password: 'integration-test-password',
+        });
+      const pendingToken = loginRes.body.data.pendingToken;
+
+      const setupRes = await request(app)
+        .post('/api/auth/totp/setup')
+        .set('Authorization', `Bearer ${pendingToken}`);
+      expect(setupRes.status).toBe(200);
+      const { secret } = setupRes.body.data;
+
+      const { authenticator } = await import('otplib');
+      const confirmRes = await request(app)
+        .post('/api/auth/totp/confirm')
+        .set('Authorization', `Bearer ${pendingToken}`)
+        .send({ code: authenticator.generate(secret) });
+
+      expect(confirmRes.status).toBe(200);
+      expect(confirmRes.body.data.token).toBeDefined();
+
+      await ensureTestAdminTotp(1);
+    });
+
+    it('blocks admin API when TOTP not enabled', async () => {
+      await prisma.familyMember.update({
+        where: { id: 1 },
+        data: { totpSecret: null, totpEnabled: false, totpVerifiedAt: null },
+      });
+
+      const loginRes = await request(app)
+        .post('/api/auth/login')
+        .send({
+          familyGroupId: 1,
+          memberId: 1,
+          password: 'integration-test-password',
+        });
+
+      const setupRes = await request(app)
+        .post('/api/auth/totp/setup')
+        .set('Authorization', `Bearer ${loginRes.body.data.pendingToken}`);
+      const { secret } = setupRes.body.data;
+      const { authenticator } = await import('otplib');
+      const confirmRes = await request(app)
+        .post('/api/auth/totp/confirm')
+        .set('Authorization', `Bearer ${loginRes.body.data.pendingToken}`)
+        .send({ code: authenticator.generate(secret) });
+      const token = confirmRes.body.data.token;
+
+      await prisma.familyMember.update({
+        where: { id: 1 },
+        data: { totpEnabled: false },
+      });
+
+      const adminRes = await request(app)
+        .get('/api/admin/prompts')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(adminRes.status).toBe(403);
+      expect(adminRes.body.code).toBe('TOTP_REQUIRED');
+
+      await ensureTestAdminTotp(1);
     });
   });
 

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,13 +1,62 @@
 import { Request, Response, NextFunction } from 'express';
 import bcrypt from 'bcrypt';
 import { Role } from '@prisma/client';
-import { generateToken } from '../utils/auth';
+import {
+  generateAccessToken,
+  generatePendingToken,
+  JWTPayload,
+} from '../utils/auth';
 import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
+import {
+  buildOtpauthUrl,
+  decryptSecretFromStorage,
+  encryptSecretForStorage,
+  generateTotpSecret,
+  isTotpRequiredForRole,
+  verifyTotpCode,
+} from '../services/totpService';
 
-/**
- * [Issue #93-2] Step 1: 招待コードから世帯を特定
- */
+type AuthUser = JWTPayload;
+
+function formatMember(member: {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
+}) {
+  return {
+    id: member.id,
+    name: member.name,
+    familyGroupId: member.familyGroupId,
+    role: member.role,
+    totpEnabled: member.totpEnabled,
+  };
+}
+
+function buildAccessResponse(member: {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
+}) {
+  const memberDto = formatMember(member);
+  return {
+    token: generateAccessToken({
+      id: member.id,
+      name: member.name,
+      familyGroupId: member.familyGroupId,
+      role: member.role,
+    }),
+    pendingToken: null,
+    member: memberDto,
+    requiresTotpVerification: false,
+    requiresTotpSetup: false,
+  };
+}
+
 export const resolveFamily = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { inviteCode } = req.body;
@@ -37,9 +86,6 @@ export const resolveFamily = async (req: Request, res: Response, next: NextFunct
   }
 };
 
-/**
- * [Issue #93-2] Step 2: 世帯メンバー一覧（inviteCode で世帯アクセスを検証）
- */
 export const getFamilyMembers = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const familyGroupId = parseInt(req.params.familyGroupId, 10);
@@ -77,14 +123,6 @@ export const getFamilyMembers = async (req: Request, res: Response, next: NextFu
   }
 };
 
-/** [#306 連携用] Admin は 2FA 必須、USER は任意 */
-function requiresTwoFactor(role: Role): boolean {
-  return role === Role.ADMIN;
-}
-
-/**
- * [Issue #54 / #73 / #93-2] Step 4: ログイン（familyGroupId 必須）
- */
 export const login = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { familyGroupId, memberId, password } = req.body;
@@ -122,26 +160,196 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
       throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
     }
 
-    const token = generateToken({
+    const tokenInput = {
       id: member.id,
-      memberId: member.id,
-      familyGroupId: member.familyGroup.id,
       name: member.name,
+      familyGroupId: member.familyGroupId,
       role: member.role,
+    };
+    const memberDto = formatMember(member);
+
+    if (member.totpEnabled) {
+      res.status(200).json({
+        success: true,
+        data: {
+          token: null,
+          pendingToken: generatePendingToken(tokenInput, 'totp_pending'),
+          member: memberDto,
+          requiresTotpVerification: true,
+          requiresTotpSetup: false,
+        },
+      });
+      return;
+    }
+
+    if (isTotpRequiredForRole(member.role)) {
+      res.status(200).json({
+        success: true,
+        data: {
+          token: null,
+          pendingToken: generatePendingToken(tokenInput, 'totp_setup'),
+          member: memberDto,
+          requiresTotpVerification: false,
+          requiresTotpSetup: true,
+        },
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      data: buildAccessResponse(member),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** TOTP セットアップ開始（pending setup またはログイン済み USER） */
+export const startTotpSetup = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = (req as Request & { user: AuthUser }).user;
+    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
+    if (!member) {
+      throw new AppError('メンバーが見つかりません。', 404);
+    }
+    if (member.totpEnabled) {
+      throw new AppError('二要素認証は既に有効です。', 400);
+    }
+
+    const secret = generateTotpSecret();
+    await prisma.familyMember.update({
+      where: { id: member.id },
+      data: {
+        totpSecret: encryptSecretForStorage(secret),
+        totpEnabled: false,
+        totpVerifiedAt: null,
+      },
     });
 
     res.status(200).json({
       success: true,
       data: {
-        token,
-        member: {
-          id: member.id,
-          name: member.name,
-          familyGroupId: member.familyGroupId,
-          role: member.role,
-        },
-        requiresTwoFactor: requiresTwoFactor(member.role),
+        secret,
+        otpauthUrl: buildOtpauthUrl(member.name, secret),
       },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** TOTP セットアップ完了 → フル JWT 発行（setup 時）または有効化のみ */
+export const confirmTotpSetup = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = (req as Request & { user: AuthUser }).user;
+    const { code } = req.body;
+    if (!code || typeof code !== 'string') {
+      throw new AppError('認証コードを入力してください。', 400);
+    }
+
+    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
+    if (!member?.totpSecret) {
+      throw new AppError('二要素認証のセットアップが開始されていません。', 400);
+    }
+    if (member.totpEnabled) {
+      throw new AppError('二要素認証は既に有効です。', 400);
+    }
+
+    const secret = decryptSecretFromStorage(member.totpSecret);
+    if (!verifyTotpCode(secret, code.trim())) {
+      throw new AppError('認証コードが正しくありません。', 401);
+    }
+
+    const updated = await prisma.familyMember.update({
+      where: { id: member.id },
+      data: {
+        totpEnabled: true,
+        totpVerifiedAt: new Date(),
+      },
+    });
+
+    const memberDto = formatMember(updated);
+    const isSetupFlow = user.purpose === 'totp_setup';
+
+    res.status(200).json({
+      success: true,
+      data: isSetupFlow
+        ? buildAccessResponse(updated)
+        : { member: memberDto, totpEnabled: true },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** ログイン時 TOTP 検証 */
+export const verifyTotp = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = (req as Request & { user: AuthUser }).user;
+    const { code } = req.body;
+    if (!code || typeof code !== 'string') {
+      throw new AppError('認証コードを入力してください。', 400);
+    }
+
+    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
+    if (!member?.totpEnabled || !member.totpSecret) {
+      throw new AppError('二要素認証が有効ではありません。', 400);
+    }
+
+    const secret = decryptSecretFromStorage(member.totpSecret);
+    if (!verifyTotpCode(secret, code.trim())) {
+      throw new AppError('認証コードが正しくありません。', 401);
+    }
+
+    res.status(200).json({
+      success: true,
+      data: buildAccessResponse(member),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** USER 任意: 二要素認証を無効化 */
+export const disableTotp = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = (req as Request & { user: AuthUser }).user;
+    const { password, code } = req.body;
+    if (!password || !code) {
+      throw new AppError('パスワードと認証コードを入力してください。', 400);
+    }
+
+    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
+    if (!member?.password_hash || !member.totpEnabled || !member.totpSecret) {
+      throw new AppError('二要素認証が有効ではありません。', 400);
+    }
+    if (isTotpRequiredForRole(member.role)) {
+      throw new AppError('管理者は二要素認証を無効にできません。', 403);
+    }
+
+    const passwordOk = await bcrypt.compare(password, member.password_hash);
+    if (!passwordOk) {
+      throw new AppError('パスワードが正しくありません。', 401);
+    }
+
+    const secret = decryptSecretFromStorage(member.totpSecret);
+    if (!verifyTotpCode(secret, String(code).trim())) {
+      throw new AppError('認証コードが正しくありません。', 401);
+    }
+
+    await prisma.familyMember.update({
+      where: { id: member.id },
+      data: {
+        totpSecret: null,
+        totpEnabled: false,
+        totpVerifiedAt: null,
+      },
+    });
+
+    res.status(200).json({
+      success: true,
+      data: { totpEnabled: false },
     });
   } catch (error) {
     next(error);

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -22,7 +22,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   }
 
   const token = authHeader.split(' ')[1];
-  const decoded = verifyToken(token);
+  const decoded = verifyToken(token, ['access']);
 
   if (!decoded) {
     logger.warn(`[AUTH] Invalid or Expired Token: ${req.path}`);
@@ -54,8 +54,17 @@ export const isAdmin = async (req: Request, res: Response, next: NextFunction) =
 
     const user = await prisma.familyMember.findUnique({
       where: { id: userId },
-      select: { role: true }
+      select: { role: true, totpEnabled: true },
     });
+
+    if (user?.role === 'ADMIN' && !user.totpEnabled) {
+      logger.warn(`[AUTH] Admin without TOTP attempted access: User ID ${userId}`);
+      return res.status(403).json({
+        success: false,
+        code: 'TOTP_REQUIRED',
+        message: '管理者機能を利用するには二要素認証の設定が必要です',
+      });
+    }
 
     if (user?.role !== 'ADMIN') {
       logger.warn(`[AUTH] Forbidden Admin Access Attempt by User ID: ${userId}`);

--- a/backend/src/middleware/pendingAuthMiddleware.ts
+++ b/backend/src/middleware/pendingAuthMiddleware.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express';
+import { TokenPurpose, verifyToken } from '../utils/auth';
+import logger from '../utils/logger';
+
+export function pendingAuthMiddleware(...allowedPurposes: TokenPurpose[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return res.status(401).json({ success: false, message: '認証が必要です' });
+    }
+
+    const token = authHeader.split(' ')[1];
+    const decoded = verifyToken(token, allowedPurposes);
+    if (!decoded) {
+      logger.warn(`[AUTH] Invalid pending token: ${req.path}`);
+      return res.status(401).json({ success: false, message: 'セッションが無効です。再度ログインしてください。' });
+    }
+
+    (req as Request & { user: typeof decoded }).user = decoded;
+    next();
+  };
+}

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,15 +1,34 @@
 import { Router } from 'express';
-import { getFamilyMembers, login, resolveFamily } from '../controllers/authController';
+import {
+  confirmTotpSetup,
+  disableTotp,
+  getFamilyMembers,
+  login,
+  resolveFamily,
+  startTotpSetup,
+  verifyTotp,
+} from '../controllers/authController';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { pendingAuthMiddleware } from '../middleware/pendingAuthMiddleware';
 
 const router = Router();
 
-// [Issue #93-2] Step 1: 招待コード → 世帯特定
 router.post('/resolve-family', resolveFamily);
-
-// [Issue #93-2] Step 2: 世帯メンバー一覧（?inviteCode= 必須）
 router.get('/families/:familyGroupId/members', getFamilyMembers);
-
-// [Issue #93-2] Step 4: ログイン
 router.post('/login', login);
+
+router.post(
+  '/totp/setup',
+  pendingAuthMiddleware('totp_setup', 'access'),
+  startTotpSetup
+);
+router.post(
+  '/totp/confirm',
+  pendingAuthMiddleware('totp_setup', 'access'),
+  confirmTotpSetup
+);
+router.post('/verify-totp', pendingAuthMiddleware('totp_pending'), verifyTotp);
+
+router.post('/totp/disable', authMiddleware, disableTotp);
 
 export default router;

--- a/backend/src/services/totpService.ts
+++ b/backend/src/services/totpService.ts
@@ -1,0 +1,32 @@
+import { authenticator } from 'otplib';
+import { Role } from '@prisma/client';
+import { encryptTotpSecret, decryptTotpSecret } from '../utils/totpCrypto';
+
+const APP_NAME = 'ReceiptAI';
+
+authenticator.options = { window: 1 };
+
+export function generateTotpSecret(): string {
+  return authenticator.generateSecret();
+}
+
+export function buildOtpauthUrl(memberName: string, secret: string): string {
+  return authenticator.keyuri(memberName, APP_NAME, secret);
+}
+
+export function verifyTotpCode(secret: string, code: string): boolean {
+  return authenticator.verify({ token: code, secret });
+}
+
+export function encryptSecretForStorage(secret: string): string {
+  return encryptTotpSecret(secret);
+}
+
+export function decryptSecretFromStorage(encrypted: string): string {
+  return decryptTotpSecret(encrypted);
+}
+
+/** Admin は 2FA 必須、USER は任意 */
+export function isTotpRequiredForRole(role: Role): boolean {
+  return role === Role.ADMIN;
+}

--- a/backend/src/test/integrationHelpers.ts
+++ b/backend/src/test/integrationHelpers.ts
@@ -1,11 +1,19 @@
 import bcrypt from 'bcrypt';
+import { authenticator } from 'otplib';
 import request from 'supertest';
 import type { Express } from 'express';
 import { prisma } from '../utils/prismaClient';
+import { encryptSecretForStorage } from '../services/totpService';
+import { Role } from '@prisma/client';
 
 export const TEST_MEMBER_PASSWORD = 'integration-test-password';
+/** 結合テスト用固定 TOTP シークレット（base32） */
+export const TEST_TOTP_SECRET = 'JBSWY3DPEHPK3PXP';
 
-/** `RUN_API_INTEGRATION=1` 時のみ DB 結合テストを実行（compose 内や CI 向け） */
+export function getTestTotpCode(): string {
+  return authenticator.generate(TEST_TOTP_SECRET);
+}
+
 export function shouldRunDbIntegration(): boolean {
   return (
     process.env.RUN_API_INTEGRATION === '1' &&
@@ -13,7 +21,6 @@ export function shouldRunDbIntegration(): boolean {
   );
 }
 
-/** 既存 DB の member にテスト用パスワードを設定（seed 済み環境向け） */
 export async function ensureTestMemberPassword(memberId = 1): Promise<void> {
   const hash = await bcrypt.hash(TEST_MEMBER_PASSWORD, 4);
   const member = await prisma.familyMember.findUnique({ where: { id: memberId } });
@@ -26,33 +33,88 @@ export async function ensureTestMemberPassword(memberId = 1): Promise<void> {
   });
 }
 
+/** Admin 結合テスト用: 既知シークレットで TOTP を有効化 */
+export async function ensureTestAdminTotp(memberId: number): Promise<void> {
+  const member = await prisma.familyMember.findUnique({ where: { id: memberId } });
+  if (!member) {
+    throw new Error(`Test member id=${memberId} not found.`);
+  }
+  if (member.role !== Role.ADMIN) return;
+  if (member.totpEnabled) return;
+
+  await prisma.familyMember.update({
+    where: { id: memberId },
+    data: {
+      totpSecret: encryptSecretForStorage(TEST_TOTP_SECRET),
+      totpEnabled: true,
+      totpVerifiedAt: new Date(),
+    },
+  });
+}
+
+async function completeTotpLogin(app: Express, loginBody: Record<string, unknown>): Promise<string> {
+  const loginRes = await request(app).post('/api/auth/login').send(loginBody);
+  if (loginRes.status !== 200 || !loginRes.body?.success) {
+    throw new Error(`Login failed: ${JSON.stringify(loginRes.body)}`);
+  }
+
+  const data = loginRes.body.data;
+  if (data.token) {
+    return data.token as string;
+  }
+
+  const pendingToken = data.pendingToken as string;
+
+  if (data.requiresTotpSetup) {
+    await request(app)
+      .post('/api/auth/totp/setup')
+      .set('Authorization', `Bearer ${pendingToken}`);
+    const confirmRes = await request(app)
+      .post('/api/auth/totp/confirm')
+      .set('Authorization', `Bearer ${pendingToken}`)
+      .send({ code: getTestTotpCode() });
+    if (confirmRes.status !== 200 || !confirmRes.body?.data?.token) {
+      throw new Error(`TOTP setup failed: ${JSON.stringify(confirmRes.body)}`);
+    }
+    return confirmRes.body.data.token as string;
+  }
+
+  if (data.requiresTotpVerification) {
+    const verifyRes = await request(app)
+      .post('/api/auth/verify-totp')
+      .set('Authorization', `Bearer ${pendingToken}`)
+      .send({ code: getTestTotpCode() });
+    if (verifyRes.status !== 200 || !verifyRes.body?.data?.token) {
+      throw new Error(`TOTP verify failed: ${JSON.stringify(verifyRes.body)}`);
+    }
+    return verifyRes.body.data.token as string;
+  }
+
+  throw new Error(`Unexpected login response: ${JSON.stringify(data)}`);
+}
+
 export async function loginAsTestMember(app: Express, memberId = 1): Promise<string> {
   const member = await prisma.familyMember.findUnique({
     where: { id: memberId },
-    select: { familyGroupId: true },
+    select: { familyGroupId: true, role: true },
   });
   if (!member) {
     throw new Error(`Test member id=${memberId} not found. Run prisma seed first.`);
   }
 
-  const res = await request(app)
-    .post('/api/auth/login')
-    .send({
-      familyGroupId: member.familyGroupId,
-      memberId,
-      password: TEST_MEMBER_PASSWORD,
-    });
-
-  if (res.status !== 200 || !res.body?.success || !res.body?.data?.token) {
-    throw new Error(`Login failed: status=${res.status} body=${JSON.stringify(res.body)}`);
+  if (member.role === Role.ADMIN) {
+    await ensureTestAdminTotp(memberId);
   }
-  return res.body.data.token as string;
+
+  return completeTotpLogin(app, {
+    familyGroupId: member.familyGroupId,
+    memberId,
+    password: TEST_MEMBER_PASSWORD,
+  });
 }
 
-/** 第2世帯（佐藤家）のテスト用メンバー ID */
 export const TENANT_B_ADMIN_MEMBER_ID = 4;
 
-/** 他世帯の Item ID を DB から取得（seed 済み前提） */
 export async function getTenantBItemId(): Promise<number> {
   const item = await prisma.item.findFirst({
     where: { receipt: { familyGroupId: 2 } },
@@ -64,7 +126,6 @@ export async function getTenantBItemId(): Promise<number> {
   return item.id;
 }
 
-/** 他世帯の Category ID を DB から取得（seed 済み前提） */
 export async function getTenantBCategoryId(name = '食費'): Promise<number> {
   const category = await prisma.category.findFirst({
     where: { familyGroupId: 2, name },
@@ -76,12 +137,10 @@ export async function getTenantBCategoryId(name = '食費'): Promise<number> {
   return category.id;
 }
 
-/** 自世帯の Category 件数 */
 export async function countCategoriesForFamily(familyGroupId: number): Promise<number> {
   return prisma.category.count({ where: { familyGroupId } });
 }
 
-/** 他世帯の Receipt ID（画像 fixture 用） */
 export async function getTenantBReceiptWithImage(): Promise<{ id: number; imagePath: string }> {
   const receipt = await prisma.receipt.findFirst({
     where: { familyGroupId: 2, imagePath: { not: null } },

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,50 +1,82 @@
 import jwt from 'jsonwebtoken';
 import logger from './logger';
 
-// [Issue #69] 環境変数の必須化と安全性の向上
 const JWT_SECRET = process.env.JWT_SECRET;
 const EXPIRES_IN = process.env.JWT_EXPIRES_IN || '30d';
+const PENDING_EXPIRES_IN = '10m';
 
-// 起動時に秘密鍵の存在を保証する
 if (!JWT_SECRET) {
   const errorMsg = 'FATAL: JWT_SECRET is not defined in environment variables.';
   logger.error(`[AUTH] ${errorMsg}`);
   throw new Error(errorMsg);
 }
 
-/**
- * [Issue #52 / #73] トークンのペイロード定義
- * familyGroupId を含み、マルチテナント対応の基盤となります。
- * 権限管理(isAdmin)のために id と role を追加しました。
- */
+export type TokenPurpose = 'access' | 'totp_pending' | 'totp_setup';
+
 export interface JWTPayload {
-  id: number;           // [Issue #73] authMiddleware (req.user.id) 用
-  memberId: number;     // 互換性維持
+  id: number;
+  memberId: number;
   familyGroupId: number;
   name: string;
-  role?: string;        // [Issue #73] 権限 (例: 'ADMIN')
+  role?: string;
+  purpose?: TokenPurpose;
 }
 
-/**
- * トークンの生成
- */
-export const generateToken = (payload: JWTPayload): string => {
-  // ペイロードを展開して署名
-  return jwt.sign({ ...payload }, JWT_SECRET, { 
-    expiresIn: EXPIRES_IN as any 
-  });
+type MemberTokenInput = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: string;
 };
 
-/**
- * トークンの検証
- */
-export const verifyToken = (token: string): JWTPayload | null => {
+function toPayload(member: MemberTokenInput, purpose: TokenPurpose): JWTPayload {
+  return {
+    id: member.id,
+    memberId: member.id,
+    familyGroupId: member.familyGroupId,
+    name: member.name,
+    role: member.role,
+    purpose,
+  };
+}
+
+export function generateAccessToken(member: MemberTokenInput): string {
+  return jwt.sign(toPayload(member, 'access'), JWT_SECRET, {
+    expiresIn: EXPIRES_IN as jwt.SignOptions['expiresIn'],
+  });
+}
+
+export function generatePendingToken(
+  member: MemberTokenInput,
+  purpose: 'totp_pending' | 'totp_setup'
+): string {
+  return jwt.sign(toPayload(member, purpose), JWT_SECRET, {
+    expiresIn: PENDING_EXPIRES_IN,
+  });
+}
+
+/** @deprecated generateAccessToken を使用 */
+export const generateToken = generateAccessToken;
+
+export function getTokenPurpose(payload: JWTPayload): TokenPurpose {
+  return payload.purpose ?? 'access';
+}
+
+export function verifyToken(
+  token: string,
+  allowedPurposes: TokenPurpose[] = ['access']
+): JWTPayload | null {
   try {
-    // 署名の検証
-    return jwt.verify(token, JWT_SECRET) as JWTPayload;
-  } catch (error: any) {
-    // 期限切れや改ざんをログに記録
-    logger.error(`[AUTH] トークン検証失敗: ${error.message}`);
+    const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload;
+    const purpose = getTokenPurpose(decoded);
+    if (!allowedPurposes.includes(purpose)) {
+      logger.warn(`[AUTH] Token purpose mismatch: expected ${allowedPurposes.join('|')}, got ${purpose}`);
+      return null;
+    }
+    return decoded;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`[AUTH] トークン検証失敗: ${message}`);
     return null;
   }
-};
+}

--- a/backend/src/utils/totpCrypto.ts
+++ b/backend/src/utils/totpCrypto.ts
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+
+function getEncryptionKey(): Buffer {
+  const source = process.env.TOTP_ENCRYPTION_KEY || process.env.JWT_SECRET;
+  if (!source) {
+    throw new Error('TOTP encryption requires JWT_SECRET or TOTP_ENCRYPTION_KEY');
+  }
+  return crypto.createHash('sha256').update(`${source}:totp`).digest();
+}
+
+export function encryptTotpSecret(secret: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGORITHM, getEncryptionKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('base64')}:${tag.toString('base64')}:${encrypted.toString('base64')}`;
+}
+
+export function decryptTotpSecret(payload: string): string {
+  const [ivB64, tagB64, dataB64] = payload.split(':');
+  if (!ivB64 || !tagB64 || !dataB64) {
+    throw new Error('Invalid encrypted TOTP secret format');
+  }
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    getEncryptionKey(),
+    Buffer.from(ivB64, 'base64')
+  );
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(dataB64, 'base64')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -29,6 +29,7 @@ import { SplitEditorScreen } from './src/screens/SplitEditorScreen';
 import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen';
 import { LoginScreen } from './src/screens/LoginScreen';
 import { BiometricLockScreen } from './src/screens/BiometricLockScreen';
+import { TotpSettingsScreen } from './src/screens/TotpSettingsScreen';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
@@ -36,7 +37,7 @@ import type { LoginResult, StoredSession } from './src/types/auth';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary';
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary' | 'totp_settings';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -51,6 +52,7 @@ export default function App() {
   const [pendingSession, setPendingSession] = useState<StoredSession | null>(null);
   const [biometricLockActive, setBiometricLockActive] = useState(false);
   const [biometricEnabled, setBiometricEnabled] = useState(false);
+  const [totpEnabled, setTotpEnabled] = useState(false);
 
   const [resultData, setResultData] = useState<any>(null);
   const [categories, setCategories] = useState<any[]>([]);
@@ -159,6 +161,7 @@ export default function App() {
     });
     setBiometricLockActive(false);
     setPendingSession(null);
+    setTotpEnabled(Boolean(result.member.totpEnabled));
     await fetchCategoriesForSession();
     await promptEnableBiometric();
   };
@@ -176,6 +179,7 @@ export default function App() {
     setPendingSession(null);
     setBiometricLockActive(false);
     setBiometricEnabled(false);
+    setTotpEnabled(false);
     setUserToken(null);
     setCurrentMemberId(null);
     setCurrentUserRole(null);
@@ -200,6 +204,7 @@ export default function App() {
     setPendingSession(null);
     setBiometricLockActive(false);
     setBiometricEnabled(false);
+    setTotpEnabled(false);
     setCurrentView('main');
     setResultData(null);
     setTargetReceipt(null);
@@ -254,7 +259,7 @@ export default function App() {
     );
   }
 
-  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary'].includes(currentView);
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary', 'totp_settings'].includes(currentView);
 
   if (biometricLockActive && pendingSession) {
     return (
@@ -342,10 +347,26 @@ export default function App() {
             onGoToAdminStats={() => setCurrentView('admin_stats')}
           />
         );
+      case 'totp_settings':
+        return (
+          <TotpSettingsScreen
+            totpEnabled={totpEnabled}
+            onBack={() => setCurrentView('main')}
+            onChanged={setTotpEnabled}
+          />
+        );
       default:
         return (
           <View style={{ flex: 1 }}>
             <View style={styles.topActions}>
+              {currentUserRole === 'USER' ? (
+                <TouchableOpacity
+                  style={styles.topActionButton}
+                  onPress={() => setCurrentView('totp_settings')}
+                >
+                  <Text style={styles.topActionText}>2FA設定</Text>
+                </TouchableOpacity>
+              ) : null}
               {biometricEnabled && Platform.OS !== 'web' ? (
                 <TouchableOpacity style={styles.topActionButton} onPress={handleDisableBiometric}>
                   <Text style={styles.topActionText}>生体認証オフ</Text>

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -13,7 +13,7 @@ import { loginService } from '../services/loginService';
 import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../types/auth';
 import { theme } from '../theme';
 
-type LoginStep = 'invite' | 'member' | 'password';
+type LoginStep = 'invite' | 'member' | 'password' | 'totp_setup' | 'totp_verify';
 
 type Props = {
   onLoginSuccess: (result: LoginResult, context: { familyName: string; inviteCode: string }) => void;
@@ -26,7 +26,15 @@ export function LoginScreen({ onLoginSuccess }: Props) {
   const [members, setMembers] = useState<AuthFamilyMember[]>([]);
   const [selectedMember, setSelectedMember] = useState<AuthFamilyMember | null>(null);
   const [password, setPassword] = useState('');
+  const [pendingToken, setPendingToken] = useState<string | null>(null);
+  const [totpSecret, setTotpSecret] = useState<string | null>(null);
+  const [totpCode, setTotpCode] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const finishLogin = (result: LoginResult) => {
+    if (!family) return;
+    onLoginSuccess(result, { familyName: family.name, inviteCode: inviteCode.trim() });
+  };
 
   const resetToInvite = () => {
     setStep('invite');
@@ -34,6 +42,9 @@ export function LoginScreen({ onLoginSuccess }: Props) {
     setMembers([]);
     setSelectedMember(null);
     setPassword('');
+    setPendingToken(null);
+    setTotpSecret(null);
+    setTotpCode('');
   };
 
   const handleResolveFamily = async () => {
@@ -76,12 +87,38 @@ export function LoginScreen({ onLoginSuccess }: Props) {
 
     setLoading(true);
     try {
-      const result = await loginService.login(
+      const response = await loginService.login(
         family.familyGroupId,
         selectedMember.id,
         password
       );
-      onLoginSuccess(result, { familyName: family.name, inviteCode: inviteCode.trim() });
+
+      if (response.token) {
+        finishLogin({ token: response.token, member: response.member });
+        return;
+      }
+
+      if (!response.pendingToken) {
+        throw new Error('認証トークンを取得できませんでした。');
+      }
+
+      setPendingToken(response.pendingToken);
+
+      if (response.requiresTotpSetup) {
+        const setup = await loginService.startTotpSetup(response.pendingToken);
+        setTotpSecret(setup.secret);
+        setTotpCode('');
+        setStep('totp_setup');
+        return;
+      }
+
+      if (response.requiresTotpVerification) {
+        setTotpCode('');
+        setStep('totp_verify');
+        return;
+      }
+
+      throw new Error('想定外のログイン応答です。');
     } catch (e: unknown) {
       const message =
         e instanceof Error ? e.message : 'ログインに失敗しました。';
@@ -91,6 +128,86 @@ export function LoginScreen({ onLoginSuccess }: Props) {
       setLoading(false);
     }
   };
+
+  const handleConfirmTotpSetup = async () => {
+    if (!pendingToken || !totpCode.trim()) {
+      Alert.alert('入力エラー', '認証アプリの6桁コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await loginService.confirmTotpSetup(pendingToken, totpCode);
+      finishLogin(result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '認証コードの確認に失敗しました。';
+      Alert.alert('エラー', message);
+      setTotpCode('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyTotp = async () => {
+    if (!pendingToken || !totpCode.trim()) {
+      Alert.alert('入力エラー', '認証アプリの6桁コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await loginService.verifyTotp(pendingToken, totpCode);
+      finishLogin(result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '認証コードが正しくありません。';
+      Alert.alert('認証エラー', message);
+      setTotpCode('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderTotpStep = (isSetup: boolean) => (
+    <>
+      <Text style={styles.familyLabel}>{family?.name}</Text>
+      <Text style={styles.subtitle}>
+        {isSetup
+          ? '二要素認証の設定（管理者必須）'
+          : '二要素認証コードを入力'}
+      </Text>
+      {isSetup && totpSecret ? (
+        <View style={styles.secretBox}>
+          <Text style={styles.secretLabel}>認証アプリに登録するキー</Text>
+          <Text style={styles.secretText} selectable>
+            {totpSecret}
+          </Text>
+        </View>
+      ) : null}
+      <View style={styles.inputWrapper}>
+        <TextInput
+          style={styles.input}
+          placeholder="6桁コード"
+          placeholderTextColor="rgba(255,255,255,0.6)"
+          value={totpCode}
+          onChangeText={setTotpCode}
+          keyboardType="number-pad"
+          maxLength={6}
+          editable={!loading}
+        />
+      </View>
+      <TouchableOpacity
+        style={[styles.primaryButton, loading && styles.buttonDisabled]}
+        onPress={isSetup ? handleConfirmTotpSetup : handleVerifyTotp}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={theme.colors.primary} />
+        ) : (
+          <Text style={styles.primaryButtonText}>{isSetup ? '設定を完了' : '確認'}</Text>
+        )}
+      </TouchableOpacity>
+    </>
+  );
 
   const renderInviteStep = () => (
     <>
@@ -195,6 +312,8 @@ export function LoginScreen({ onLoginSuccess }: Props) {
       {step === 'invite' && renderInviteStep()}
       {step === 'member' && renderMemberStep()}
       {step === 'password' && renderPasswordStep()}
+      {step === 'totp_setup' && renderTotpStep(true)}
+      {step === 'totp_verify' && renderTotpStep(false)}
     </View>
   );
 }
@@ -225,6 +344,23 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.8)',
     marginBottom: 24,
     textAlign: 'center',
+  },
+  secretBox: {
+    width: '100%',
+    backgroundColor: 'rgba(0,0,0,0.2)',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  secretLabel: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  secretText: {
+    color: 'white',
+    fontSize: 14,
+    fontFamily: 'monospace',
   },
   inputWrapper: {
     width: '100%',

--- a/frontend/src/screens/TotpSettingsScreen.tsx
+++ b/frontend/src/screens/TotpSettingsScreen.tsx
@@ -1,0 +1,197 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { loginService } from '../services/loginService';
+import { theme } from '../theme';
+
+type Props = {
+  totpEnabled: boolean;
+  onBack: () => void;
+  onChanged: (enabled: boolean) => void;
+};
+
+export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
+  const [secret, setSecret] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleStartEnable = async () => {
+    setLoading(true);
+    try {
+      const setup = await loginService.startTotpSetupForUser();
+      setSecret(setup.secret);
+      setCode('');
+    } catch (e: unknown) {
+      Alert.alert('エラー', e instanceof Error ? e.message : 'セットアップに失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmEnable = async () => {
+    if (!code.trim()) {
+      Alert.alert('入力エラー', '6桁コードを入力してください。');
+      return;
+    }
+    setLoading(true);
+    try {
+      await loginService.enableTotpForUser(code);
+      setSecret(null);
+      setCode('');
+      onChanged(true);
+      Alert.alert('完了', '二要素認証を有効にしました。');
+    } catch (e: unknown) {
+      Alert.alert('エラー', e instanceof Error ? e.message : '有効化に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDisable = async () => {
+    if (!password || !code.trim()) {
+      Alert.alert('入力エラー', 'パスワードと6桁コードを入力してください。');
+      return;
+    }
+    setLoading(true);
+    try {
+      await loginService.disableTotp(password, code);
+      setPassword('');
+      setCode('');
+      onChanged(false);
+      Alert.alert('完了', '二要素認証を無効にしました。');
+    } catch (e: unknown) {
+      Alert.alert('エラー', e instanceof Error ? e.message : '無効化に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={onBack} style={styles.backButton}>
+        <Text style={styles.backText}>← 戻る</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>二要素認証</Text>
+
+      {totpEnabled ? (
+        <>
+          <Text style={styles.subtitle}>現在: 有効</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="パスワード"
+            secureTextEntry
+            value={password}
+            onChangeText={setPassword}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="6桁コード"
+            keyboardType="number-pad"
+            maxLength={6}
+            value={code}
+            onChangeText={setCode}
+          />
+          <TouchableOpacity
+            style={styles.dangerButton}
+            onPress={handleDisable}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text style={styles.dangerButtonText}>二要素認証を無効にする</Text>
+            )}
+          </TouchableOpacity>
+        </>
+      ) : secret ? (
+        <>
+          <Text style={styles.subtitle}>認証アプリに以下のキーを登録してください</Text>
+          <Text style={styles.secret} selectable>
+            {secret}
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="6桁コード"
+            keyboardType="number-pad"
+            maxLength={6}
+            value={code}
+            onChangeText={setCode}
+          />
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={handleConfirmEnable}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator color={theme.colors.primary} />
+            ) : (
+              <Text style={styles.primaryButtonText}>有効化</Text>
+            )}
+          </TouchableOpacity>
+        </>
+      ) : (
+        <>
+          <Text style={styles.subtitle}>ログイン時に認証コードの入力が必要になります。</Text>
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={handleStartEnable}
+            disabled={loading}
+          >
+            {loading ? (
+              <ActivityIndicator color={theme.colors.primary} />
+            ) : (
+              <Text style={styles.primaryButtonText}>セットアップを開始</Text>
+            )}
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, backgroundColor: theme.colors.background },
+  backButton: { marginBottom: 16 },
+  backText: { color: theme.colors.primary, fontSize: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 8, color: theme.colors.text.main },
+  subtitle: { fontSize: 15, color: theme.colors.text.muted, marginBottom: 20 },
+  secret: {
+    fontFamily: 'monospace',
+    fontSize: 14,
+    backgroundColor: theme.colors.surface,
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 12,
+    fontSize: 16,
+    backgroundColor: theme.colors.surface,
+  },
+  primaryButton: {
+    backgroundColor: theme.colors.primary,
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonText: { color: 'white', fontWeight: 'bold' },
+  dangerButton: {
+    backgroundColor: '#c0392b',
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  dangerButtonText: { color: 'white', fontWeight: 'bold' },
+});

--- a/frontend/src/services/loginService.ts
+++ b/frontend/src/services/loginService.ts
@@ -1,7 +1,23 @@
+import axios from 'axios';
 import apiClient from '../utils/apiClient';
-import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../types/auth';
+import type {
+  AuthFamilyMember,
+  LoginResponse,
+  LoginResult,
+  ResolvedFamily,
+  TotpSetupInfo,
+} from '../types/auth';
 
 type SuccessEnvelope<T> = { success: true; data: T };
+
+const pendingClient = (pendingToken: string) =>
+  axios.create({
+    baseURL: apiClient.defaults.baseURL,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${pendingToken}`,
+    },
+  });
 
 export const loginService = {
   async resolveFamily(inviteCode: string): Promise<ResolvedFamily> {
@@ -26,12 +42,56 @@ export const loginService = {
     familyGroupId: number,
     memberId: number,
     password: string
-  ): Promise<LoginResult> {
-    const res = await apiClient.post<SuccessEnvelope<LoginResult>>('/auth/login', {
+  ): Promise<LoginResponse> {
+    const res = await apiClient.post<SuccessEnvelope<LoginResponse>>('/auth/login', {
       familyGroupId,
       memberId,
       password,
     });
     return res.data.data;
+  },
+
+  async startTotpSetup(pendingToken: string): Promise<TotpSetupInfo> {
+    const res = await pendingClient(pendingToken).post<SuccessEnvelope<TotpSetupInfo>>(
+      '/auth/totp/setup'
+    );
+    return res.data.data;
+  },
+
+  async confirmTotpSetup(pendingToken: string, code: string): Promise<LoginResult> {
+    const res = await pendingClient(pendingToken).post<SuccessEnvelope<LoginResponse>>(
+      '/auth/totp/confirm',
+      { code: code.trim() }
+    );
+    const data = res.data.data;
+    if (!data.token) {
+      throw new Error('トークンを取得できませんでした。');
+    }
+    return { token: data.token, member: data.member };
+  },
+
+  async verifyTotp(pendingToken: string, code: string): Promise<LoginResult> {
+    const res = await pendingClient(pendingToken).post<SuccessEnvelope<LoginResponse>>(
+      '/auth/verify-totp',
+      { code: code.trim() }
+    );
+    const data = res.data.data;
+    if (!data.token) {
+      throw new Error('トークンを取得できませんでした。');
+    }
+    return { token: data.token, member: data.member };
+  },
+
+  async enableTotpForUser(code: string): Promise<void> {
+    await apiClient.post('/auth/totp/confirm', { code: code.trim() });
+  },
+
+  async startTotpSetupForUser(): Promise<TotpSetupInfo> {
+    const res = await apiClient.post<SuccessEnvelope<TotpSetupInfo>>('/auth/totp/setup');
+    return res.data.data;
+  },
+
+  async disableTotp(password: string, code: string): Promise<void> {
+    await apiClient.post('/auth/totp/disable', { password, code: code.trim() });
   },
 };

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -13,12 +13,25 @@ export type LoginMember = {
   name: string;
   familyGroupId: number;
   role: string;
+  totpEnabled?: boolean;
+};
+
+export type LoginResponse = {
+  token: string | null;
+  pendingToken: string | null;
+  member: LoginMember;
+  requiresTotpVerification: boolean;
+  requiresTotpSetup: boolean;
 };
 
 export type LoginResult = {
   token: string;
   member: LoginMember;
-  requiresTwoFactor: boolean;
+};
+
+export type TotpSetupInfo = {
+  secret: string;
+  otpauthUrl: string;
 };
 
 export type StoredSession = {


### PR DESCRIPTION
## Summary

内部 **#93-5** / GitHub **#306** を **完了** します（PR #311 の生体認証に続く TOTP 2FA 部分）。

> 前回 PR #311 は Issue の一部のみでした。今後は完了単位または Issue 分割で PR を出します。

### Backend

- **DB**: `FamilyMember.totpSecret` / `totpEnabled` / `totpVerifiedAt`（migration）
- **API**:
  - `POST /api/auth/login` — TOTP 要否に応じ `pendingToken` または `token` を返却
  - `POST /api/auth/totp/setup` — セットアップ開始（QR 用 secret / otpauthUrl）
  - `POST /api/auth/totp/confirm` — 初回セットアップ完了
  - `POST /api/auth/verify-totp` — ログイン時 6 桁検証
  - `POST /api/auth/totp/disable` — USER 任意で無効化
- **ガード**: `isAdmin` が `totpEnabled=false` の Admin を `403 TOTP_REQUIRED` で拒否

### Frontend

- `LoginScreen` — Admin 初回セットアップ / 2FA 検証ステップ追加
- `TotpSettingsScreen` — USER 向け 2FA ON/OFF（任意）
- PR #311 の生体認証ロックはそのまま維持

### ロール別仕様

| ロール | 2FA |
|--------|-----|
| ADMIN | **必須** — 初回ログインでセットアップ、未設定時は Admin API 不可 |
| USER | **任意** — ホームの「2FA設定」から ON/OFF |

## main マージ時

- `prisma migrate deploy` **必須**（TOTP カラム追加）
- 既存 Admin は **次回ログイン時に TOTP セットアップ** が必要
- Backend + Frontend **同時デプロイ**

## Test plan

- [x] `backend npm test`
- [x] `frontend npm test` / `tsc --noEmit`
- [x] Docker dev: migration + seed + integration **26 tests Pass**
- [ ] Admin 初回ログイン → TOTP 設定 → 管理者メニュー利用可
- [ ] USER ログイン（TOTP なし）→ 任意で 2FA 有効化
- [ ] Web はパスワード + TOTP のみ（生体なし）

Closes #306

Made with [Cursor](https://cursor.com)