### PR TITLE
fix: 認証付きレシート画像の Web/Android 表示を修正

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -395,6 +395,26 @@ describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {
       .set('Authorization', `Bearer ${tokenB}`);
     expect(allowed.status).toBe(200);
   });
+
+  it('allows pending job image access before receipt is saved', async () => {
+    const pendingImagePath = 'uploads/pending-preview-fixture.webp';
+    const fixturePath = path.join(process.cwd(), pendingImagePath);
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(fixturePath, Buffer.from('pending-preview-test'));
+
+    registerMockReceiptJob('pending-preview-job', {
+      memberId: 1,
+      familyGroupId: 1,
+      imagePath: pendingImagePath,
+    });
+
+    const token = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get(`/api/uploads/${path.basename(pendingImagePath)}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
 });
 
 describe.skipIf(!shouldRunDbIntegration())('Master tenant isolation (#93-4)', () => {

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,13 +1,13 @@
 import { Request, Response, NextFunction } from 'express';
 import fs from 'fs';
 import path from 'path';
-import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
 import { getFamilyGroupId } from '../utils/context';
+import { canAccessReceiptImage, getImageFullPath } from '../services/imageAccessService';
 
 /**
  * [Issue #93-1 / G3] レシート画像の認証付き配信。
- * 自世帯の Receipt に紐づく imagePath のみ返す（他世帯・未登録ファイルは 404）。
+ * 自世帯の Receipt、または解析ジョブ投入済み imagePath のみ返す。
  */
 export const serveReceiptImage = async (
   req: Request<{ filename: string }>,
@@ -24,16 +24,12 @@ export const serveReceiptImage = async (
     }
 
     const imagePath = path.join('uploads', filename).replace(/\\/g, '/');
-    const receipt = await prisma.receipt.findFirst({
-      where: { familyGroupId, imagePath },
-      select: { id: true },
-    });
 
-    if (!receipt) {
+    if (!(await canAccessReceiptImage(familyGroupId, imagePath))) {
       throw new AppError('Not Found', 404);
     }
 
-    const fullPath = path.join(process.cwd(), imagePath);
+    const fullPath = getImageFullPath(imagePath);
     if (!fs.existsSync(fullPath)) {
       throw new AppError('Not Found', 404);
     }

--- a/backend/src/services/imageAccessService.ts
+++ b/backend/src/services/imageAccessService.ts
@@ -1,0 +1,49 @@
+import path from 'path';
+import { prisma } from '../utils/prismaClient';
+import { receiptQueue } from '../queues/receiptQueue';
+
+function normalizeImagePath(imagePath: string): string {
+  return imagePath.replace(/\\/g, '/');
+}
+
+async function hasQueueJobForImage(
+  familyGroupId: number,
+  imagePath: string
+): Promise<boolean> {
+  const jobs = await receiptQueue.getJobs(
+    ['completed', 'waiting', 'active', 'delayed', 'paused'],
+    0,
+    200,
+    true
+  );
+
+  return jobs.some(
+    (job) =>
+      Number(job.data?.familyGroupId) === familyGroupId &&
+      normalizeImagePath(String(job.data?.imagePath ?? '')) === imagePath
+  );
+}
+
+/**
+ * 自世帯が参照可能なレシート画像か判定する。
+ * - DB に保存済み Receipt
+ * - 解析ジョブ投入済み（保存前プレビュー用）
+ */
+export async function canAccessReceiptImage(
+  familyGroupId: number,
+  imagePath: string
+): Promise<boolean> {
+  const normalized = normalizeImagePath(imagePath);
+
+  const receipt = await prisma.receipt.findFirst({
+    where: { familyGroupId, imagePath: normalized },
+    select: { id: true },
+  });
+  if (receipt) return true;
+
+  return hasQueueJobForImage(familyGroupId, normalized);
+}
+
+export function getImageFullPath(imagePath: string): string {
+  return path.join(process.cwd(), normalizeImagePath(imagePath));
+}

--- a/backend/src/test/mockReceiptQueue.ts
+++ b/backend/src/test/mockReceiptQueue.ts
@@ -22,5 +22,6 @@ vi.mock('../queues/receiptQueue', () => ({
       return { id };
     }),
     getJob: vi.fn().mockImplementation(async (id: string) => mockReceiptJobs.get(id) ?? null),
+    getJobs: vi.fn().mockImplementation(async () => Array.from(mockReceiptJobs.values())),
   },
 }));

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -48,6 +48,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   const imageSource = useReceiptImageSource(receipt?.imagePath);
   const imageSourceWithCache = useMemo(() => {
     if (!imageSource) return null;
+    if (!imageSource.uri.startsWith('http')) return imageSource;
     return { ...imageSource, uri: `${imageSource.uri}?v=${cacheKey}` };
   }, [imageSource, cacheKey]);
 

--- a/frontend/src/utils/receiptImageSource.ts
+++ b/frontend/src/utils/receiptImageSource.ts
@@ -1,24 +1,40 @@
 import { useEffect, useState } from 'react';
 import { Platform } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
+import { File, Paths } from 'expo-file-system';
 import apiClient from './apiClient';
+import { authService } from '../services/authService';
 
 export type ReceiptImageSource = {
   uri: string;
-  headers: Record<string, string>;
+  headers?: Record<string, string>;
 };
 
-const TOKEN_KEY = 'userToken';
+function getUploadApiPath(imagePath: string): string {
+  const normalized = imagePath.replace(/^\//, '');
+  const filename = normalized.startsWith('uploads/')
+    ? normalized.slice('uploads/'.length)
+    : normalized;
+  return `/uploads/${encodeURIComponent(filename)}`;
+}
 
-async function getAuthToken(): Promise<string | null> {
-  try {
-    return Platform.OS === 'web'
-      ? await AsyncStorage.getItem(TOKEN_KEY)
-      : await SecureStore.getItemAsync(TOKEN_KEY);
-  } catch {
-    return null;
+function getCacheFilename(imagePath: string): string {
+  const normalized = imagePath.replace(/^\//, '');
+  return normalized.replace(/\//g, '_');
+}
+
+async function buildAuthHeaders(): Promise<Record<string, string>> {
+  const [token, memberId] = await Promise.all([
+    authService.getToken(),
+    authService.getMemberId(),
+  ]);
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
+  if (memberId != null) {
+    headers['x-member-id'] = String(memberId);
+  }
+  return headers;
 }
 
 /** imagePath (uploads/xxx.webp) を認証付き API URL に変換 */
@@ -35,28 +51,57 @@ export async function buildReceiptImageSource(
   imagePath: string | null | undefined
 ): Promise<ReceiptImageSource | null> {
   if (!imagePath) return null;
-  const token = await getAuthToken();
-  const headers: Record<string, string> = {};
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+
+  try {
+    if (Platform.OS === 'web') {
+      const res = await apiClient.get(getUploadApiPath(imagePath), {
+        responseType: 'blob',
+      });
+      return { uri: URL.createObjectURL(res.data) };
+    }
+
+    const destination = new File(Paths.cache, `receipt-${getCacheFilename(imagePath)}`);
+    const downloaded = await File.downloadFileAsync(
+      getReceiptImageApiUrl(imagePath),
+      destination,
+      {
+        headers: await buildAuthHeaders(),
+        idempotent: true,
+      }
+    );
+    return { uri: downloaded.uri };
+  } catch (error) {
+    console.warn('[ReceiptImage] Failed to load image:', error);
+    return null;
   }
-  return {
-    uri: getReceiptImageApiUrl(imagePath),
-    headers,
-  };
 }
 
-/** React Native Image 用 — Authorization ヘッダ付き source */
+/** 認証付き API から取得したローカル URI（Web: blob / Native: cache file） */
 export function useReceiptImageSource(imagePath: string | null | undefined) {
   const [source, setSource] = useState<ReceiptImageSource | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    let blobUrl: string | null = null;
+
     buildReceiptImageSource(imagePath).then((next) => {
-      if (!cancelled) setSource(next);
+      if (cancelled) {
+        if (next?.uri.startsWith('blob:')) {
+          URL.revokeObjectURL(next.uri);
+        }
+        return;
+      }
+      if (next?.uri.startsWith('blob:')) {
+        blobUrl = next.uri;
+      }
+      setSource(next);
     });
+
     return () => {
       cancelled = true;
+      if (blobUrl) {
+        URL.revokeObjectURL(blobUrl);
+      }
     };
   }, [imagePath]);
 


### PR DESCRIPTION
## Summary
- 保存前の解析確認画面でも、同一世帯の解析ジョブに紐づく imagePath から画像を配信できるようにした（#93-1 認証付き API の穴埋め）
- Web では `apiClient` + blob URL、Android/iOS では Expo SDK 54 の `File.downloadFileAsync` で認証付きダウンロードするよう変更
- 履歴詳細では blob / file URI にキャッシュバスターを付けないよう修正

## Test plan
- [x] Web: 解析確認画面・履歴詳細でレシート画像が表示される
- [x] Android: 解析確認画面・履歴詳細でレシート画像が表示される
- [x] Web / Android で通常操作にエラーなし
- [x] `npm test`（backend）


Made with [Cursor](https://cursor.com)