### PR TITLE
fix: stable デプロイ時の Prisma generate と auth.ts 型エラー

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,20 +75,22 @@ jobs:
           echo "EXPO_PUBLIC_API_URL=http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_BACKEND_PORT }}/api" >> ./frontend/.env
           echo "EXPO_PUBLIC_API_TOKEN=${{ secrets.EXPO_PUBLIC_API_TOKEN }}" >> ./frontend/.env
 
-      - name: Install dependencies
+      - name: Install dependencies and Prisma Client
         run: |
           cd ~/stable/receipt-ai-app/backend && npm install
-          cd ../frontend && npm install
+          cd ~/stable/receipt-ai-app/backend && npx prisma generate
+          cd ~/stable/receipt-ai-app/frontend && npm install
+
+      - name: Prisma Migrate (Stable DB)
+        run: |
+          cd ~/stable/receipt-ai-app
+          docker compose up -d db redis
+          sleep 5
+          docker compose run --rm --no-deps backend npx prisma migrate deploy
 
       - name: Docker Deploy
         run: |
           cd ~/stable/receipt-ai-app
           docker compose up -d --build --remove-orphans
-
-      - name: Prisma Migrate (Stable DB)
-        run: |
-          cd ~/stable/receipt-ai-app
-          docker compose exec -T backend npx prisma migrate deploy
-          
       - name: Cleanup
         run: docker image prune -f

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,15 +1,17 @@
 import jwt from 'jsonwebtoken';
 import logger from './logger';
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const rawJwtSecret = process.env.JWT_SECRET;
 const EXPIRES_IN = process.env.JWT_EXPIRES_IN || '30d';
 const PENDING_EXPIRES_IN = '10m';
 
-if (!JWT_SECRET) {
+if (!rawJwtSecret) {
   const errorMsg = 'FATAL: JWT_SECRET is not defined in environment variables.';
   logger.error(`[AUTH] ${errorMsg}`);
   throw new Error(errorMsg);
 }
+
+const JWT_SECRET: string = rawJwtSecret;
 
 export type TokenPurpose = 'access' | 'totp_pending' | 'totp_setup';
 
@@ -67,13 +69,17 @@ export function verifyToken(
   allowedPurposes: TokenPurpose[] = ['access']
 ): JWTPayload | null {
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload;
-    const purpose = getTokenPurpose(decoded);
+    const decoded = jwt.verify(token, JWT_SECRET);
+    if (typeof decoded === 'string') {
+      return null;
+    }
+    const payload = decoded as JWTPayload;
+    const purpose = getTokenPurpose(payload);
     if (!allowedPurposes.includes(purpose)) {
       logger.warn(`[AUTH] Token purpose mismatch: expected ${allowedPurposes.join('|')}, got ${purpose}`);
       return null;
     }
-    return decoded;
+    return payload;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`[AUTH] トークン検証失敗: ${message}`);


### PR DESCRIPTION
## Summary
- stable CD で `npx prisma generate` を `npm install` 直後に実行（Prisma Client 未更新による起動失敗を防止）
- migration を backend 起動**前**に `docker compose run --rm` で実行（クラッシュループ中の `exec` 失敗を防止）
- `auth.ts` の `JWT_SECRET` 型を ts-node 起動時に通るよう修正

## 背景
main マージ後の stable で backend が起動せず:
1. `familyGroupId does not exist in CategoryWhereInput`（Prisma Client 未 generate）
2. `JWT_SECRET` の TypeScript コンパイルエラー（ts-node）

## Test plan
- [ ] develop マージ → main マージ後、T320 CD Pipeline が成功する
- [ ] `receipt-stable-backend` が起動し `TSError` が出ない
- [ ] stable Web で Admin ログイン可能


Made with [Cursor](https://cursor.com)