### PR TITLE
fix: Category / PromptTemplate 作成時の familyGroupId 型エラー

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -73,7 +73,16 @@ export const createPrompt = async (req: Request, res: Response) => {
     }
 
     const newPrompt = await prisma.promptTemplate.create({
-      data: { key, name, description, systemPrompt, domainHints, isActive, version: 1 },
+      data: {
+        key,
+        name,
+        description,
+        systemPrompt,
+        domainHints,
+        isActive,
+        version: 1,
+        familyGroupId,
+      },
     });
 
     await syncPromptsToJson(familyGroupId);

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -4,6 +4,7 @@ import { AppError } from '../utils/appError';
 import logger from '../utils/logger';
 import { pickNextCategoryColor } from '../utils/categoryColor';
 import { getRouteParam } from '../utils/routeParams';
+import { getFamilyGroupId } from '../utils/context';
 
 /**
  * 📂 カテゴリー一覧取得
@@ -34,7 +35,11 @@ export const createCategory = async (req: Request, res: Response, next: NextFunc
       return next(new AppError('Name is required', 400));
     }
 
-    const existing = await prisma.category.findMany({ select: { color: true } });
+    const familyGroupId = getFamilyGroupId();
+    const existing = await prisma.category.findMany({
+      where: { familyGroupId },
+      select: { color: true },
+    });
     const existingColors = existing.map((c) => c.color);
     const requested =
       typeof color === 'string' && color.trim() ? color.trim() : '';
@@ -52,6 +57,7 @@ export const createCategory = async (req: Request, res: Response, next: NextFunc
       data: {
         name,
         color: resolvedColor,
+        familyGroupId,
       },
     });
 


### PR DESCRIPTION
## Summary
- `categoryController.createCategory` に `familyGroupId` を明示（色一覧も世帯スコープ）
- `adminController.createPrompt` に `familyGroupId` を明示

## 背景
stable backend が `categoryController.ts` で Prisma `CategoryCreateInput` の型エラー（`familyGroupId` / `familyGroup` 不足）により起動失敗。

## 関連
- #93-4 マスタ世帯分離
- PR #318（routeParams）— develop 済み

## Test plan
- [x] `npm test`（backend）
- [ ] develop → main マージ後、stable CD 成功
- [ ] `docker compose logs backend` で `TSError` なし


Made with [Cursor](https://cursor.com)