### PR TITLE
fix(infra): [Issue #94-1] stable CORS + Expo dev 運用ドキュメント

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
           GEMINI_MODEL="${{ vars.GEMINI_MODEL || 'gemini-flash-latest' }}"
           GEMINI_RETRY_COUNT=3
           GEMINI_RETRY_DELAY=2000
-          CORS_ORIGIN="http://${{ secrets.HOST_IP }},http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_WEB_PORT }}"
+          CORS_ORIGIN="http://${{ secrets.HOST_IP }},http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_WEB_PORT }},http://${{ secrets.HOST_IP }}:${{ secrets.STABLE_DEV_PORT || '8082' }},exp://${{ secrets.HOST_IP }}:${{ secrets.STABLE_DEV_PORT || '8082' }}"
           LOG_LEVEL=info
           EOF
 

--- a/docs/mobile-access.md
+++ b/docs/mobile-access.md
@@ -1,0 +1,49 @@
+# モバイル・Web アクセスガイド（Issue #94）
+
+RecAlpt（読み：レシート）の **本番入口** と **開発用 Expo** の使い分け。
+
+## URL 一覧（stable 環境の例）
+
+`HOST_IP` は T320 の LAN IP（例: `192.168.1.32`）。`grep '^HOST_IP=' ~/stable/receipt-ai-app/.env` で確認。
+
+| 用途 | URL | 対象 |
+|------|-----|------|
+| **本番 Web** | `http://HOST_IP` | 家族の日常利用（iPhone / Android / PC） |
+| **開発 Expo Web** | `http://HOST_IP:8082` | QR 表示・ブラウザでの dev 確認 |
+| **API** | `http://HOST_IP:3000/health` | ヘルスチェック（直接は開かない） |
+
+dev 環境は Web `:8080`、Expo dev `:8081`、API `:3001`。
+
+## 本番 Web（家族向け）
+
+1. スマホの Safari / Chrome で `http://HOST_IP` を開く
+2. 招待コードでログイン
+3. **ホーム画面に追加**（任意）— アイコンから起動できる
+   - iPhone: Safari → 共有 → 「ホーム画面に追加」
+   - Android: Chrome → メニュー → 「ホーム画面に追加」
+
+Expo Go は不要。`:8082` も不要。
+
+## 開発・動確（Expo Go）
+
+ネイティブ挙動（カメラ切り取り・生体認証等）の検証用。**本番運用の入口ではない。**
+
+1. T320 で `frontend-dev` コンテナが Up であること
+2. PC で `http://HOST_IP:8082` を開き QR を表示
+3. スマホに **Expo Go** をインストール、同一 Wi-Fi で QR をスキャン
+4. 招待コードでログイン
+
+stable の backend は `:80` に加え `:8082` / `exp://` を CORS 許可している（Issue #94-1）。
+
+## トラブルシュート
+
+| 症状 | 確認 |
+|------|------|
+| `:8082` で招待コードが通らない | backend の `CORS_ORIGIN` に `:8082` と `exp://` が含まれるか、`docker compose restart backend` |
+| Expo Go が繋がらない | 同一 Wi-Fi、`HOST_IP` が QR の URL と一致するか |
+| iPhone でカメラが起動しない | HTTP 制限の可能性 — ギャラリーから選択、または Web 切り取り UI（#94-4）を利用 |
+
+## 関連 Issue
+
+- Epic: [#322](https://github.com/yama180sx/receipt-ai-app/issues/322)（#94）
+- 認証手動動確: [#314](https://github.com/yama180sx/receipt-ai-app/issues/314)（#93-6）

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -56,7 +56,8 @@ else
     REDIS_PORT=6379
     BACKEND_COMMAND="npm run start"
     # ブラウザ Origin は :80 省略のことがあるため両方許可（Issue #89 ログイン CORS）
-    CORS_ORIGIN="http://$HOST_IP,http://$HOST_IP:$WEB_PORT"
+    # Expo dev（:8082）と Expo Go（exp://）も許可
+    CORS_ORIGIN="http://$HOST_IP,http://$HOST_IP:$WEB_PORT,http://$HOST_IP:$DEV_PORT,exp://$HOST_IP:$DEV_PORT"
     GEMINI_MODEL="gemini-flash-latest"
     CRON_SCHEDULE="0 4 * * *" # stable環境は毎日午前4時に実行
 fi


### PR DESCRIPTION
## Summary
- stable / dev の `CORS_ORIGIN` に Expo dev ポート（`:8082` 等）と `exp://` を追加
- `docs/mobile-access.md` で本番 Web（`:80`）と開発 Expo（`:8082`）の使い分けを明記

## 背景
Expo Go / `:8082` から API 呼び出し時に CORS でブロックされていた。家族本番は `:80` のまま、開発動確経路のみ許可を拡張。

## Test plan
- [ ] `setup-env.sh stable` 実行後の `CORS_ORIGIN` に DEV_PORT / exp:// が含まれる
- [ ] stable デプロイ後、`http://HOST:8082` から招待コードログインが成功する
- [ ] `http://HOST`（:80）のログインに影響がない

Closes #323

Made with [Cursor](https://cursor.com)