### PR TITLE
feat(frontend): [Issue #94-2〜4] RecAlpt ブランディングとモバイル Web UX

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -33,6 +33,8 @@ import { TotpSettingsScreen } from './src/screens/TotpSettingsScreen';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
+import { DisplayModeProvider } from './src/contexts/DisplayModeContext';
+import { DisplayModeSettings } from './src/components/DisplayModeSettings';
 import type { LoginResult, StoredSession } from './src/types/auth';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
@@ -359,6 +361,7 @@ export default function App() {
         return (
           <View style={{ flex: 1 }}>
             <View style={styles.topActions}>
+              {Platform.OS === 'web' ? <DisplayModeSettings /> : null}
               {currentUserRole === 'USER' ? (
                 <TouchableOpacity
                   style={styles.topActionButton}
@@ -393,11 +396,13 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <ResponsiveContainer fullWidth={isFullWidth}>
-        <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
-          {renderMainContent()}
-        </View>
-      </ResponsiveContainer>
+      <DisplayModeProvider>
+        <ResponsiveContainer fullWidth={isFullWidth}>
+          <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+            {renderMainContent()}
+          </View>
+        </ResponsiveContainer>
+      </DisplayModeProvider>
     </SafeAreaProvider>
   );
 }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "tmp_project",
-    "slug": "tmp_project",
+    "name": "RecAlpt",
+    "slug": "recalpt",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "NSFaceIDUsageDescription": "家計簿アプリのロック解除に Face ID を使用します。"
+        "NSFaceIDUsageDescription": "RecAlpt のロック解除に Face ID を使用します。"
       }
     },
     "android": {
@@ -27,14 +27,19 @@
       "predictiveBackGestureEnabled": false
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "name": "RecAlpt",
+      "shortName": "RecAlpt",
+      "display": "standalone",
+      "themeColor": "#2563eb",
+      "backgroundColor": "#ffffff"
     },
     "plugins": [
       "expo-secure-store",
       [
         "expo-local-authentication",
         {
-          "faceIDPermission": "家計簿アプリのロック解除に Face ID を使用します。"
+          "faceIDPermission": "RecAlpt のロック解除に Face ID を使用します。"
         }
       ]
     ]

--- a/frontend/src/components/DisplayModeSettings.tsx
+++ b/frontend/src/components/DisplayModeSettings.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { theme } from '../theme';
+import { useDisplayMode } from '../contexts/DisplayModeContext';
+import type { DisplayLayoutMode } from '../services/displayModeService';
+
+const OPTIONS: { value: DisplayLayoutMode; label: string }[] = [
+  { value: 'auto', label: '自動' },
+  { value: 'mobile', label: 'スマホ' },
+  { value: 'web', label: 'Web' },
+];
+
+export function DisplayModeSettings() {
+  const { mode, setMode } = useDisplayMode();
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.label}>表示</Text>
+      <View style={styles.row}>
+        {OPTIONS.map((opt) => {
+          const active = mode === opt.value;
+          return (
+            <TouchableOpacity
+              key={opt.value}
+              style={[styles.chip, active && styles.chipActive]}
+              onPress={() => void setMode(opt.value)}
+            >
+              <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                {opt.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    flexWrap: 'wrap',
+  },
+  label: {
+    fontSize: 11,
+    color: theme.colors.text.muted,
+    marginRight: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  chip: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  chipActive: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primary,
+  },
+  chipText: {
+    fontSize: 11,
+    color: theme.colors.text.main,
+  },
+  chipTextActive: {
+    color: theme.colors.text.inverse,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -10,7 +10,8 @@ import {
 } from 'react-native';
 import { AppButton, AppSelect, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme, BREAKPOINTS } from '../theme';
+import { theme } from '../theme';
+import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import apiClient from '../utils/apiClient';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 
@@ -38,7 +39,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
 }) => {
   const { width: windowWidth } = useWindowDimensions();
   const effectiveWidth = fullWidth ? windowWidth : windowWidth - 350;
-  const isWide = effectiveWidth >= BREAKPOINTS.TABLET;
+  const isWide = useIsWideLayout({ width: effectiveWidth });
 
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/ReceiptImageCropModal.tsx
+++ b/frontend/src/components/ReceiptImageCropModal.tsx
@@ -1,0 +1,225 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Modal,
+  PanResponder,
+  type LayoutChangeEvent,
+  type GestureResponderEvent,
+  type PanResponderGestureState,
+} from 'react-native';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { AppButton } from './ui';
+import { theme } from '../theme';
+
+type Point = { x: number; y: number };
+type Rect = { x: number; y: number; width: number; height: number };
+
+type Props = {
+  visible: boolean;
+  imageUri: string;
+  onConfirm: (uri: string) => void;
+  onCancel: () => void;
+};
+
+function normalizeRect(start: Point, end: Point): Rect {
+  const x = Math.min(start.x, end.x);
+  const y = Math.min(start.y, end.y);
+  const width = Math.abs(end.x - start.x);
+  const height = Math.abs(end.y - start.y);
+  return { x, y, width, height };
+}
+
+/**
+ * Web 向けレシート切り取りモーダル（Issue #94-4）
+ */
+export function ReceiptImageCropModal({
+  visible,
+  imageUri,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [displaySize, setDisplaySize] = useState({ width: 0, height: 0 });
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const [selection, setSelection] = useState<Rect | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const dragStart = useRef<Point | null>(null);
+
+  const resetState = useCallback(() => {
+    setSelection(null);
+    dragStart.current = null;
+    setProcessing(false);
+  }, []);
+
+  const handleLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setDisplaySize({ width, height });
+  };
+
+  const handleImageLoad = (e: { nativeEvent: { source: { width: number; height: number } } }) => {
+    const { width, height } = e.nativeEvent.source;
+    setNaturalSize({ width, height });
+  };
+
+  const updateSelection = (start: Point, current: Point) => {
+    setSelection(normalizeRect(start, current));
+  };
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt: GestureResponderEvent) => {
+        const { locationX, locationY } = evt.nativeEvent;
+        dragStart.current = { x: locationX, y: locationY };
+        setSelection({ x: locationX, y: locationY, width: 0, height: 0 });
+      },
+      onPanResponderMove: (evt: GestureResponderEvent, _gs: PanResponderGestureState) => {
+        if (!dragStart.current) return;
+        const { locationX, locationY } = evt.nativeEvent;
+        updateSelection(dragStart.current, { x: locationX, y: locationY });
+      },
+      onPanResponderRelease: (evt: GestureResponderEvent) => {
+        if (!dragStart.current) return;
+        const { locationX, locationY } = evt.nativeEvent;
+        updateSelection(dragStart.current, { x: locationX, y: locationY });
+        dragStart.current = null;
+      },
+    })
+  ).current;
+
+  const handleConfirm = async () => {
+    if (!selection || selection.width < 8 || selection.height < 8) {
+      onConfirm(imageUri);
+      return;
+    }
+    if (!displaySize.width || !naturalSize.width) {
+      onConfirm(imageUri);
+      return;
+    }
+
+    setProcessing(true);
+    try {
+      const scaleX = naturalSize.width / displaySize.width;
+      const scaleY = naturalSize.height / displaySize.height;
+      const originX = Math.max(0, Math.round(selection.x * scaleX));
+      const originY = Math.max(0, Math.round(selection.y * scaleY));
+      const cropWidth = Math.min(
+        naturalSize.width - originX,
+        Math.round(selection.width * scaleX)
+      );
+      const cropHeight = Math.min(
+        naturalSize.height - originY,
+        Math.round(selection.height * scaleY)
+      );
+
+      const result = await ImageManipulator.manipulateAsync(
+        imageUri,
+        [{ crop: { originX, originY, width: cropWidth, height: cropHeight } }],
+        { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
+      );
+      onConfirm(result.uri);
+    } catch (e) {
+      console.error('[Crop] failed', e);
+      onConfirm(imageUri);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleSkipCrop = () => {
+    resetState();
+    onConfirm(imageUri);
+  };
+
+  const handleCancel = () => {
+    resetState();
+    onCancel();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={handleCancel}>
+      <View style={styles.container}>
+        <Text style={styles.title}>レシートの範囲を選択</Text>
+        <Text style={styles.hint}>ドラッグして切り取る範囲を指定してください</Text>
+
+        <View style={styles.imageArea} onLayout={handleLayout} {...panResponder.panHandlers}>
+          <Image
+            source={{ uri: imageUri }}
+            style={styles.image}
+            resizeMode="contain"
+            onLoad={handleImageLoad}
+          />
+          {selection && selection.width > 0 && selection.height > 0 ? (
+            <View
+              style={[
+                styles.selection,
+                {
+                  left: selection.x,
+                  top: selection.y,
+                  width: selection.width,
+                  height: selection.height,
+                },
+              ]}
+              pointerEvents="none"
+            />
+          ) : null}
+        </View>
+
+        <View style={styles.actions}>
+          <AppButton title="キャンセル" variant="outline" onPress={handleCancel} />
+          <AppButton title="切り取らずに使う" variant="secondary" onPress={handleSkipCrop} />
+          <AppButton
+            title={processing ? '処理中...' : '切り取って解析'}
+            onPress={() => void handleConfirm()}
+            disabled={processing}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+    padding: 16,
+    paddingTop: 48,
+  },
+  title: {
+    ...theme.typography.h2,
+    color: theme.colors.text.main,
+    marginBottom: 4,
+  },
+  hint: {
+    fontSize: 14,
+    color: theme.colors.text.muted,
+    marginBottom: 16,
+  },
+  imageArea: {
+    flex: 1,
+    backgroundColor: '#000',
+    borderRadius: theme.borderRadius.md,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  selection: {
+    position: 'absolute',
+    borderWidth: 2,
+    borderColor: theme.colors.primary,
+    backgroundColor: 'rgba(37, 99, 235, 0.15)',
+  },
+  actions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 16,
+    justifyContent: 'flex-end',
+  },
+});

--- a/frontend/src/contexts/DisplayModeContext.tsx
+++ b/frontend/src/contexts/DisplayModeContext.tsx
@@ -1,0 +1,64 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  loadDisplayLayoutMode,
+  saveDisplayLayoutMode,
+  type DisplayLayoutMode,
+} from '../services/displayModeService';
+
+type DisplayModeContextValue = {
+  mode: DisplayLayoutMode;
+  setMode: (mode: DisplayLayoutMode) => Promise<void>;
+  isReady: boolean;
+};
+
+const DisplayModeContext = createContext<DisplayModeContextValue | null>(null);
+
+export function DisplayModeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<DisplayLayoutMode>('auto');
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    loadDisplayLayoutMode().then((loaded) => {
+      if (active) {
+        setModeState(loaded);
+        setIsReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const setMode = useCallback(async (next: DisplayLayoutMode) => {
+    setModeState(next);
+    await saveDisplayLayoutMode(next);
+  }, []);
+
+  const value = useMemo(
+    () => ({ mode, setMode, isReady }),
+    [mode, setMode, isReady]
+  );
+
+  return (
+    <DisplayModeContext.Provider value={value}>{children}</DisplayModeContext.Provider>
+  );
+}
+
+const FALLBACK: DisplayModeContextValue = {
+  mode: 'auto',
+  setMode: async () => {},
+  isReady: true,
+};
+
+export function useDisplayMode(): DisplayModeContextValue {
+  const ctx = useContext(DisplayModeContext);
+  return ctx ?? FALLBACK;
+}

--- a/frontend/src/hooks/useIsWideLayout.ts
+++ b/frontend/src/hooks/useIsWideLayout.ts
@@ -1,0 +1,26 @@
+import { useWindowDimensions } from 'react-native';
+import { BREAKPOINTS } from '../theme';
+import { useDisplayMode } from '../contexts/DisplayModeContext';
+import { resolveIsWideLayout } from '../utils/displayLayout';
+
+type Options = {
+  /** マスタペイン等を差し引いた有効幅 */
+  width?: number;
+  breakpoint?: number;
+};
+
+/**
+ * 画面幅と表示モード（Web のみ）からワイドレイアウト判定。
+ */
+export function useIsWideLayout(options?: Options): boolean {
+  const { width: windowWidth } = useWindowDimensions();
+  const { mode } = useDisplayMode();
+  const width = options?.width ?? windowWidth;
+  const breakpoint = options?.breakpoint ?? BREAKPOINTS.TABLET;
+  return resolveIsWideLayout(width, mode, breakpoint);
+}
+
+/** HomeScreen 精算メニュー表示用（従来 600px 閾値） */
+export function useIsWideHomeMenu(): boolean {
+  return useIsWideLayout({ breakpoint: 600 });
+}

--- a/frontend/src/hooks/useResponsive.ts
+++ b/frontend/src/hooks/useResponsive.ts
@@ -1,13 +1,13 @@
 import { useWindowDimensions } from 'react-native';
 import { BREAKPOINTS } from '../theme';
+import { useIsWideLayout } from './useIsWideLayout';
 
 /**
  * 画面幅に応じたレスポンシブ判定を行うカスタムフック
  */
 export const useResponsive = () => {
   const { width } = useWindowDimensions();
-
-  const isWideScreen = width >= BREAKPOINTS.TABLET;
+  const isWideScreen = useIsWideLayout();
 
   return {
     width,

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -7,14 +7,14 @@ import {
   TouchableOpacity, 
   ActivityIndicator, 
   Platform, 
-  Alert, 
-  useWindowDimensions 
+  Alert,
 } from 'react-native';
 import apiClient from '../utils/apiClient';
 import { getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 // Issue #66: BREAKPOINTS 参照
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
-import { theme, BREAKPOINTS } from '../theme';
+import { theme } from '../theme';
+import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 
 interface HistoryScreenProps {
@@ -27,9 +27,7 @@ interface HistoryScreenProps {
  * [Issue #67 / #64 / Web・ネイティブ完全互換] 履歴一覧画面
  */
 export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEditor }: HistoryScreenProps) {
-  const { width: windowWidth } = useWindowDimensions();
-  // Issue #66: 定数によるレスポンシブ判定
-  const isWide = windowWidth >= BREAKPOINTS.TABLET; 
+  const isWide = useIsWideLayout();
 
   const [loading, setLoading] = useState(true);
   const [receipts, setReceipts] = useState<any[]>([]);

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -5,18 +5,18 @@ import {
   StyleSheet, 
   TouchableOpacity, 
   ScrollView, 
-  Dimensions, 
   ActivityIndicator, 
-  Alert 
+  Alert,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
 import { AppButton, AppListItem } from '../components/ui';
+import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
-
-const { width: windowWidth } = Dimensions.get('window');
+import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 
 interface HomeScreenProps {
   onAnalysisReady: (data: any) => void; 
@@ -45,6 +45,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const [loading, setLoading] = useState(true);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [jobStatus, setJobStatus] = useState('');
+  const [pendingCropUri, setPendingCropUri] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -101,51 +102,84 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     }, 2000);
   };
 
-  const handleScan = async () => {
+  const uploadReceiptImage = async (imageUri: string) => {
+    const formData = new FormData();
+    const uriParts = imageUri.split('.');
+    const fileType = uriParts[uriParts.length - 1] || 'jpg';
+
+    // @ts-ignore — React Native FormData blob
+    formData.append('image', {
+      uri: imageUri,
+      name: `receipt_upload.${fileType}`,
+      type: `image/${fileType === 'jpg' ? 'jpeg' : fileType}`,
+    });
+    formData.append('memberId', currentMemberId.toString());
+
+    setIsAnalyzing(true);
+    setJobStatus('uploading');
+
+    const uploadRes = await apiClient.post('/receipts/upload', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        'x-member-id': currentMemberId.toString(),
+      },
+    });
+
+    if (uploadRes.data?.success) {
+      const jobId = uploadRes.data.data.jobId;
+      setJobStatus('queued');
+      pollJobStatus(jobId);
+    }
+  };
+
+  const openWebCrop = (imageUri: string) => {
+    setPendingCropUri(imageUri);
+  };
+
+  const pickImageForWeb = async (source: 'camera' | 'library') => {
+    try {
+      const picker =
+        source === 'camera'
+          ? ImagePicker.launchCameraAsync({ mediaTypes: 'images' as const, quality: 0.8 })
+          : ImagePicker.launchImageLibraryAsync({ mediaTypes: 'images' as const, quality: 0.8 });
+      const result = await picker;
+      if (result.canceled || !result.assets?.[0]) return;
+      openWebCrop(result.assets[0].uri);
+    } catch (err) {
+      console.error('pickImageForWeb', err);
+      Alert.alert('エラー', '画像の取得に失敗しました。ギャラリーから選択をお試しください。');
+    }
+  };
+
+  const pickImageNative = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
       Alert.alert('権限エラー', 'カメラの使用を許可してください。');
       return;
     }
 
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: 'images' as const,
+      allowsEditing: true,
+      quality: 0.8,
+    });
+
+    if (result.canceled || !result.assets?.[0]) return;
+    await uploadReceiptImage(result.assets[0].uri);
+  };
+
+  const handleScan = async () => {
+    if (Platform.OS === 'web') {
+      Alert.alert('レシート画像', '取得方法を選んでください', [
+        { text: 'カメラ', onPress: () => void pickImageForWeb('camera') },
+        { text: 'ギャラリー', onPress: () => void pickImageForWeb('library') },
+        { text: 'キャンセル', style: 'cancel' },
+      ]);
+      return;
+    }
+
     try {
-      const result = await ImagePicker.launchCameraAsync({
-        mediaTypes: 'images' as any, 
-        allowsEditing: true,
-        quality: 0.8,
-      });
-
-      if (result.canceled || !result.assets) return;
-
-      const imageUri = result.assets[0].uri;
-      const formData = new FormData();
-      const uriParts = imageUri.split('.');
-      const fileType = uriParts[uriParts.length - 1];
-
-      // @ts-ignore
-      formData.append('image', {
-        uri: imageUri,
-        name: `receipt_upload.${fileType}`,
-        type: `image/${fileType}`,
-      });
-
-      formData.append('memberId', currentMemberId.toString());
-
-      setIsAnalyzing(true);
-      setJobStatus('uploading');
-
-      const uploadRes = await apiClient.post('/receipts/upload', formData, {
-        headers: { 
-          'Content-Type': 'multipart/form-data',
-          'x-member-id': currentMemberId.toString()
-        },
-      });
-
-      if (uploadRes.data && uploadRes.data.success) {
-        const jobId = uploadRes.data.data.jobId;
-        setJobStatus('queued');
-        pollJobStatus(jobId);
-      }
+      await pickImageNative();
     } catch (err) {
       setIsAnalyzing(false);
       console.error('handleScan Error:', err);
@@ -153,14 +187,25 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     }
   };
 
-  const isWide = windowWidth > 600;
+  const handleCropConfirm = async (croppedUri: string) => {
+    setPendingCropUri(null);
+    try {
+      await uploadReceiptImage(croppedUri);
+    } catch (err) {
+      setIsAnalyzing(false);
+      console.error('upload after crop', err);
+      Alert.alert('エラー', '画像のアップロードに失敗しました。');
+    }
+  };
+
+  const isWide = useIsWideHomeMenu();
   const isAdmin = userRole === 'ADMIN';
  
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
-          <Text style={styles.headerSubtitle}>AI Receipt Manager</Text>
+          <Text style={styles.headerSubtitle}>RecAlpt</Text>
           <Text style={styles.headerTitle}>
             {currentMemberId === 1 ? '山本さんのダッシュボード' : '共有メニュー'}
           </Text>
@@ -274,6 +319,15 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           )}
         </View>
       </ScrollView>
+
+      {pendingCropUri ? (
+        <ReceiptImageCropModal
+          visible
+          imageUri={pendingCropUri}
+          onConfirm={(uri) => void handleCropConfirm(uri)}
+          onCancel={() => setPendingCropUri(null)}
+        />
+      ) : null}
     </SafeAreaView>
   );
 };

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -308,7 +308,8 @@ export function LoginScreen({ onLoginSuccess }: Props) {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>家計簿アプリ</Text>
+      <Text style={styles.title}>RecAlpt</Text>
+      <Text style={styles.tagline}>レシートで家計を管理</Text>
       {step === 'invite' && renderInviteStep()}
       {step === 'member' && renderMemberStep()}
       {step === 'password' && renderPasswordStep()}
@@ -329,7 +330,13 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: 'bold',
     color: 'white',
-    marginBottom: 10,
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  tagline: {
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.75)',
+    marginBottom: 16,
     textAlign: 'center',
   },
   familyLabel: {

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -5,7 +5,6 @@ import {
   View, 
   ScrollView, 
   ActivityIndicator, 
-  useWindowDimensions,
 } from 'react-native';
 import {
   AppBackButton,
@@ -17,7 +16,8 @@ import {
   modalStyles,
 } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme, tableStyles, BREAKPOINTS } from '../theme';
+import { theme, tableStyles } from '../theme';
+import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { api } from '../utils/apiClient';
 import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 import { showAlert } from '../utils/alertMessage';
@@ -47,8 +47,7 @@ interface SettlementSummaryScreenProps {
 }
 
 export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = ({ onBack }) => {
-  const { width } = useWindowDimensions();
-  const isWide = width >= BREAKPOINTS.TABLET;
+  const isWide = useIsWideLayout();
 
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -9,12 +9,12 @@ import {
   TouchableOpacity, 
   ActivityIndicator, 
   Platform,
-  useWindowDimensions
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { AppBackButton, AppButton } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme, tableStyles, BREAKPOINTS } from '../theme';
+import { theme, tableStyles } from '../theme';
+import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { api } from '../utils/apiClient';
 import { showAlert } from '../utils/alertMessage';
 import {
@@ -34,8 +34,7 @@ interface SplitEditorScreenProps {
 }
 
 export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({ receipt, onBack }) => {
-  const { width } = useWindowDimensions();
-  const isWide = width >= BREAKPOINTS.TABLET;
+  const isWide = useIsWideLayout();
 
   const [allMembers, setAllMembers] = useState<FamilyMemberSummary[]>([]);
   const [activeMembers, setActiveMembers] = useState<FamilyMemberSummary[]>([]); 

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -17,6 +17,7 @@ import apiClient from '../utils/apiClient';
 import { getCurrentYearMonth, getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
+import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 
@@ -62,7 +63,7 @@ interface StatisticsScreenProps {
  */
 export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMemberId, onBack }) => {
   const { width: windowWidth } = useWindowDimensions();
-  const isWide = windowWidth > 768;
+  const isWide = useIsWideLayout();
 
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);

--- a/frontend/src/services/displayModeService.ts
+++ b/frontend/src/services/displayModeService.ts
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type DisplayLayoutMode = 'auto' | 'mobile' | 'web';
+
+const STORAGE_KEY = '@recalpt_display_layout_mode';
+
+export async function loadDisplayLayoutMode(): Promise<DisplayLayoutMode> {
+  try {
+    const value = await AsyncStorage.getItem(STORAGE_KEY);
+    if (value === 'auto' || value === 'mobile' || value === 'web') {
+      return value;
+    }
+  } catch (e) {
+    console.warn('[DisplayMode] load failed', e);
+  }
+  return 'auto';
+}
+
+export async function saveDisplayLayoutMode(mode: DisplayLayoutMode): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEY, mode);
+}

--- a/frontend/src/utils/displayLayout.test.ts
+++ b/frontend/src/utils/displayLayout.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BREAKPOINTS } from '../theme/breakpoints';
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'web' },
+}));
+
+import { resolveIsWideLayout } from './displayLayout';
+
+describe('resolveIsWideLayout', () => {
+
+  it('mobile mode forces narrow on web', () => {
+    expect(resolveIsWideLayout(1024, 'mobile')).toBe(false);
+  });
+
+  it('auto mode uses breakpoint on web', () => {
+    expect(resolveIsWideLayout(BREAKPOINTS.TABLET - 1, 'auto')).toBe(false);
+    expect(resolveIsWideLayout(BREAKPOINTS.TABLET, 'auto')).toBe(true);
+  });
+
+  it('web mode uses breakpoint on web', () => {
+    expect(resolveIsWideLayout(BREAKPOINTS.TABLET, 'web')).toBe(true);
+  });
+});

--- a/frontend/src/utils/displayLayout.ts
+++ b/frontend/src/utils/displayLayout.ts
@@ -1,0 +1,21 @@
+import { Platform } from 'react-native';
+import { BREAKPOINTS } from '../theme/breakpoints';
+import type { DisplayLayoutMode } from '../services/displayModeService';
+
+/**
+ * 表示モードと画面幅からワイドレイアウト（2カラム等）を使うか判定する。
+ * Native は常に幅ベース。Web のみユーザー選択を反映。
+ */
+export function resolveIsWideLayout(
+  width: number,
+  mode: DisplayLayoutMode,
+  breakpoint: number = BREAKPOINTS.TABLET
+): boolean {
+  if (Platform.OS !== 'web') {
+    return width >= breakpoint;
+  }
+  if (mode === 'mobile') {
+    return false;
+  }
+  return width >= breakpoint;
+}


### PR DESCRIPTION
## Summary
- **#94-2**: アプリ名を **RecAlpt** に統一、PWA / ホーム画面追加向け設定
- **#94-3**: Web 向け表示モード（自動 / スマホ / Web）の選択と AsyncStorage 保持
- **#94-4**: Web 版レシート切り取り UI（カメラ or ギャラリー → 範囲指定 → アップロード）

## 備考
- Native（Expo Go）のカメラ切り取り（`allowsEditing`）は変更なし
- #94-1（CORS）とは独立。`:80` Web 本番は本 PR 単体で動作する
- #94-5（手動動確）はマージ後に実施

## Test plan
- [ ] `cd frontend && npm test` Pass
- [ ] `cd frontend && npx tsc --noEmit` Pass
- [ ] Web: ログイン画面に RecAlpt / サブタイトル表示
- [ ] Web: ホーム画面右上で表示モード切替 → リロード後も保持
- [ ] Web: レシート撮影 → ギャラリー選択 → 切り取り → 解析
- [ ] stable 再ビルド後、ホーム画面に追加でアイコン名 RecAlpt

Closes #324
Closes #325
Closes #326

Made with [Cursor](https://cursor.com)