### PR TITLE
fix(frontend): RecAlpt → RecAIpt 表記修正

### DIFF
--- a/docs/mobile-access.md
+++ b/docs/mobile-access.md
@@ -1,6 +1,6 @@
 # モバイル・Web アクセスガイド（Issue #94）
 
-RecAlpt（読み：レシート）の **本番入口** と **開発用 Expo** の使い分け。
+RecAIpt（読み：レシート、Receipt + AI）の **本番入口** と **開発用 Expo** の使い分け。
 
 ## URL 一覧（stable 環境の例）
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "RecAlpt",
-    "slug": "recalpt",
+    "name": "RecAIpt",
+    "slug": "recaipt",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "NSFaceIDUsageDescription": "RecAlpt のロック解除に Face ID を使用します。"
+        "NSFaceIDUsageDescription": "RecAIpt のロック解除に Face ID を使用します。"
       }
     },
     "android": {
@@ -28,8 +28,8 @@
     },
     "web": {
       "favicon": "./assets/favicon.png",
-      "name": "RecAlpt",
-      "shortName": "RecAlpt",
+      "name": "RecAIpt",
+      "shortName": "RecAIpt",
       "display": "standalone",
       "themeColor": "#2563eb",
       "backgroundColor": "#ffffff"
@@ -39,7 +39,7 @@
       [
         "expo-local-authentication",
         {
-          "faceIDPermission": "RecAlpt のロック解除に Face ID を使用します。"
+          "faceIDPermission": "RecAIpt のロック解除に Face ID を使用します。"
         }
       ]
     ]

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
-import { AppButton, AppListItem } from '../components/ui';
+import { AppButton, AppListItem, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
@@ -46,6 +46,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [jobStatus, setJobStatus] = useState('');
   const [pendingCropUri, setPendingCropUri] = useState<string | null>(null);
+  const [showImageSourcePicker, setShowImageSourcePicker] = useState(false);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -170,11 +171,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
 
   const handleScan = async () => {
     if (Platform.OS === 'web') {
-      Alert.alert('レシート画像', '取得方法を選んでください', [
-        { text: 'カメラ', onPress: () => void pickImageForWeb('camera') },
-        { text: 'ギャラリー', onPress: () => void pickImageForWeb('library') },
-        { text: 'キャンセル', style: 'cancel' },
-      ]);
+      // Web では Alert.alert の複数ボタンが効かないためモーダルを使う
+      setShowImageSourcePicker(true);
       return;
     }
 
@@ -320,6 +318,37 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
         </View>
       </ScrollView>
 
+      <AppModal
+        visible={showImageSourcePicker}
+        onRequestClose={() => setShowImageSourcePicker(false)}
+        title="レシート画像"
+        description="取得方法を選んでください"
+        footer={
+          <View style={styles.sourcePickerActions}>
+            <AppButton
+              title="カメラ"
+              onPress={() => {
+                setShowImageSourcePicker(false);
+                void pickImageForWeb('camera');
+              }}
+            />
+            <AppButton
+              title="ギャラリー"
+              variant="secondary"
+              onPress={() => {
+                setShowImageSourcePicker(false);
+                void pickImageForWeb('library');
+              }}
+            />
+            <AppButton
+              title="キャンセル"
+              variant="outline"
+              onPress={() => setShowImageSourcePicker(false)}
+            />
+          </View>
+        }
+      />
+
       {pendingCropUri ? (
         <ReceiptImageCropModal
           visible
@@ -355,6 +384,7 @@ const styles = StyleSheet.create({
   captureButtonDisabled: { borderColor: theme.colors.border, backgroundColor: theme.colors.semantic.disabled.bg },
   iconCircle: { width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.primary, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
   captureButtonText: { ...theme.typography.h2, color: theme.colors.primary },
+  sourcePickerActions: { gap: 10, width: '100%' },
   jobStatusText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 2 },
   
   // ★ メニュー部分を Grid (flexWrap) 対応に変更

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -205,7 +205,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     <SafeAreaView style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
-          <Text style={styles.headerSubtitle}>RecAlpt</Text>
+          <Text style={styles.headerSubtitle}>RecAIpt</Text>
           <Text style={styles.headerTitle}>
             {currentMemberId === 1 ? '山本さんのダッシュボード' : '共有メニュー'}
           </Text>
@@ -336,7 +336,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   scrollContent: { padding: theme.spacing.lg, paddingBottom: 40 },
   header: { marginBottom: theme.spacing.lg, marginTop: theme.spacing.md },
-  headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, textTransform: 'uppercase', letterSpacing: 1.5 },
+  headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, letterSpacing: 0.5 },
   headerTitle: { ...theme.typography.h1, color: theme.colors.text.main, marginTop: theme.spacing.xs },
   summaryCard: { backgroundColor: theme.colors.primary, borderRadius: theme.borderRadius.lg, padding: theme.spacing.xl, marginBottom: theme.spacing.lg, elevation: 4 },
   summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, fontWeight: '600' },

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -308,7 +308,7 @@ export function LoginScreen({ onLoginSuccess }: Props) {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>RecAlpt</Text>
+      <Text style={styles.title}>RecAIpt</Text>
       <Text style={styles.tagline}>レシートで家計を管理</Text>
       {step === 'invite' && renderInviteStep()}
       {step === 'member' && renderMemberStep()}

--- a/frontend/src/services/displayModeService.ts
+++ b/frontend/src/services/displayModeService.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export type DisplayLayoutMode = 'auto' | 'mobile' | 'web';
 
-const STORAGE_KEY = '@recalpt_display_layout_mode';
+const STORAGE_KEY = '@recaipt_display_layout_mode';
 
 export async function loadDisplayLayoutMode(): Promise<DisplayLayoutMode> {
   try {


### PR DESCRIPTION
## Summary
- 正式名称 **RecAIpt**（読み：レシート）に統一
- `app.json` slug: `recaipt`
- ホーム画面サブタイトルの `textTransform: uppercase` を削除（RECALPT 表記を防止）

## 背景
Project Short description の **I（AI）** を **L** と誤読していた。動確で発覚。

## Test plan
- [ ] ホーム画面左上に **RecAIpt** と表示（RECALPT ではない）
- [ ] ログイン画面タイトル **RecAIpt**
- [ ] Expo Go 表示名 **RecAIpt**

Made with [Cursor](https://cursor.com)