### PR TITLE
fix(frontend): Web 切り取り・重複 UX・Expo Go アップロード（#94 動確向け）

### DIFF
--- a/docs/recaipt-mobile-web-progress.md
+++ b/docs/recaipt-mobile-web-progress.md
@@ -1,0 +1,244 @@
+# RecAIpt モバイル Web 化 — 経緯と次タスク
+
+最終更新: 2026-06-12  
+関連 Epic: [#322 Issue #94](https://github.com/yama180sx/receipt-ai-app/issues/322)（モバイル Web 本番化 & 表示 UX）
+
+---
+
+## 1. 背景と方針
+
+### アプリ名称
+
+- **正式名称:** RecAIpt（読み：レシート / Receipt + AI）
+- 開発初期の `RecAlpt` 表記は誤り。UI・PWA・ドキュメントを `RecAIpt` に統一済み。
+
+### 運用方針（合意済み）
+
+| 項目 | 方針 |
+|------|------|
+| 日常利用 | **Expo Go 不要** — スマホブラウザで `http://HOST_IP`（stable Web） |
+| 開発・動確 | Expo Go + dev サーバー（`:8081` / `:8082`） |
+| App Store | 当面見送り（$99/年） |
+| 遠隔地メンバー | 将来検討（VPN / トンネル / VPS 等）。非同期受付トレイは **Epic #95** で別途 |
+
+### 環境 URL（stable の例）
+
+| 用途 | URL |
+|------|-----|
+| 本番 Web | `http://HOST_IP` |
+| 開発 Expo Web | `http://HOST_IP:8082` |
+| API | `http://HOST_IP:3000` |
+
+詳細は [mobile-access.md](./mobile-access.md) を参照。
+
+---
+
+## 2. 実装済み（マージ済み）
+
+### PR #329 — Issue #94-1（develop マージ済み）
+
+- stable CORS に Expo dev 用 Origin（`:8082`、`exp://`）を追加
+- `docs/mobile-access.md` 作成
+
+### PR #330 — Issue #94-2〜4（develop マージ済み）
+
+| Issue | 内容 |
+|-------|------|
+| #94-2 | RecAIpt 名称・PWA 設定・UI 表記 |
+| #94-3 | 表示モード（自動 / スマホ / Web）選択と保持 |
+| #94-4 | Web 版レシート切り取り UI（`ReceiptImageCropModal`） |
+
+主な追加・変更ファイル:
+
+- `frontend/app.json` — 名称・slug・PWA
+- `frontend/src/contexts/DisplayModeContext.tsx`
+- `frontend/src/hooks/useIsWideLayout.ts`
+- `frontend/src/components/DisplayModeSettings.tsx`
+- `frontend/src/components/ReceiptImageCropModal.tsx`
+
+---
+
+## 3. PR #331 相当（`fix/recaipt-spelling` ブランチ）
+
+develop へのマージは **未確認 / 未マージ** の可能性あり。以下を含む。
+
+### 3.1 表記・UI 修正
+
+- `RecAlpt` → `RecAIpt`、不要な `uppercase` 削除
+
+### 3.2 Web 撮影・アップロード
+
+| 問題 | 原因 | 対応 |
+|------|------|------|
+| 撮影ボタン無反応 | Web で `Alert.alert` 複数ボタン非対応 | `AppModal` でカメラ / ギャラリー選択 |
+| 「画像がアップロードされていません」 | FormData 送信時に `Content-Type: application/json` が残る | `apiClient` で Web 時は Content-Type を削除 |
+| Android Web で切り取り画面が出ない | Modal / state 消失 | `position: fixed` オーバーレイ + `sessionStorage` で URI 復元 |
+
+関連ファイル:
+
+- `frontend/src/utils/receiptUploadFormData.ts`
+- `frontend/src/utils/webImageFileRegistry.ts`
+- `frontend/src/utils/apiClient.ts`
+- `frontend/src/screens/HomeScreen.tsx`
+
+### 3.3 切り取り座標・Canvas 切り取り（未コミット含む）
+
+| 問題 | 原因 | 対応 |
+|------|------|------|
+| 切り取ったのにプレビューが元画像のまま | `resizeMode="contain"` 時の座標変換誤り | `cropImageWeb.ts` で letterbox 補正 |
+| Web で切り取りが不安定 | `ImageManipulator` が Web で弱い | Canvas による `cropImageUriWeb` |
+
+関連ファイル:
+
+- `frontend/src/utils/cropImageWeb.ts`（新規）
+- `frontend/src/utils/cropImageWeb.test.ts`（新規）
+- `frontend/src/components/ReceiptImageCropModal.tsx`
+
+### 3.4 保存・重複 UX（未コミット含む）
+
+| 問題 | 原因 | 対応 |
+|------|------|------|
+| 重複時にメッセージが出ない（Web） | `Alert.alert` が Web で非表示 | `showAlert`（`window.alert`）に統一 |
+| 重複後も確認画面に留まる | OK 後の画面遷移なし | `onOk: onCancel` でホームへ戻る |
+| 重複時に赤いエラーバナー（Expo Go） | 想定内 409 を `console.error` していた | DUPLICATE 時はログ出力しない |
+
+関連ファイル:
+
+- `frontend/src/screens/ReceiptScanScreen.tsx`
+- `frontend/src/utils/alertMessage.ts`
+
+### 3.5 Expo Go アップロード不能（未コミット含む）
+
+| 問題 | 原因 | 対応 |
+|------|------|------|
+| 画像送信できない | Web 向け Content-Type 削除が Native にも効き、`multipart/form-data` が付かない | `apiClient` で **Web: 削除 / Native: `multipart/form-data` 明示** |
+
+---
+
+## 4. 手動動確で確認されたこと
+
+### 解消済み（再テスト推奨）
+
+- Web: 重複保存時にメッセージ表示
+- Web / Expo Go: 重複 OK 後にホームへ戻る
+- Expo Go: 重複時の赤い `Commit error` バナーが出ない
+
+### 要再確認
+
+- Web: 切り取り後の「加工済みプレビュー」が切り取り範囲と一致するか
+- Web: 新規レシートの撮影 → 切り取り → 解析 → 保存の一連フロー
+- Expo Go: 撮影 → アップロード → 解析（`multipart/form-data` 修正後）
+- #94-5: モバイル Web & Expo Go の総合手動動確
+
+---
+
+## 5. 現在の作業状態（2026-06-12）
+
+### ブランチ
+
+`fix/recaipt-spelling`（`origin/fix/recaipt-spelling` と同期）
+
+### 未コミット変更
+
+| ファイル | 内容 |
+|----------|------|
+| `frontend/src/utils/cropImageWeb.ts` | 新規 — contain 座標変換・Canvas 切り取り |
+| `frontend/src/utils/cropImageWeb.test.ts` | 新規 — 座標変換ユニットテスト |
+| `frontend/src/components/ReceiptImageCropModal.tsx` | 切り取りロジック統合 |
+| `frontend/src/screens/ReceiptScanScreen.tsx` | 重複 UX・ログ抑制 |
+| `frontend/src/utils/apiClient.ts` | FormData の Web / Native 分岐 |
+
+### 推奨コミットメッセージ（参考）
+
+```
+fix(frontend): 切り取り座標・重複保存 UX・Expo Go アップロードを修正
+
+- contain 表示を考慮した切り取り（Web は Canvas）
+- 重複時はアラート後にホームへ戻り、console.error を出さない
+- FormData 送信時の Content-Type を Web / Native で分岐
+```
+
+---
+
+## 6. 次のタスク
+
+### 優先度: 高（すぐ）
+
+1. **未コミット変更のコミット & PR #331 更新**
+   - 上記 5 ファイルをコミットし、`fix/recaipt-spelling` を push
+2. **develop へマージ**
+   - マージ後、T320 で frontend 再ビルド:
+     ```bash
+     docker compose build frontend && docker compose up -d frontend
+     ```
+3. **#94-5 手動動確**
+   - [ ] stable Web（iPhone Safari / Android Chrome）— 撮影・切り取り・保存
+   - [ ] Expo Go — 撮影・アップロード・解析・保存
+   - [ ] 重複レシート — メッセージ → ホーム復帰、エラーバナーなし
+   - [ ] 表示モード切替（スマホ / Web / 自動）
+
+### 優先度: 中（develop 動確後）
+
+4. **develop → main → stable 反映**
+   - 動確 OK 後に main マージ、stable 環境へデプロイ
+5. **Issue #93-6（USER 2FA 手動動確）**
+   - [#314](https://github.com/yama180sx/receipt-ai-app/issues/314) — #94 とは独立だが Open
+
+### 優先度: 低 / Later
+
+6. **Epic #95 — レシート非同期受付・確認トレイ**
+   - Epic: [#332](https://github.com/yama180sx/receipt-ai-app/issues/332)
+   - 解析待ちをブロックしない UX。遠隔地メンバー向けの将来拡張
+7. **#94-6** — Epic #322 上の Later 項目（詳細は Issue 参照）
+8. **App Store 配布** — 当面見送り。必要になった時点で再検討
+
+---
+
+## 7. 技術メモ（後続作業向け）
+
+### Web と Native の FormData 差
+
+| プラットフォーム | Content-Type | 理由 |
+|------------------|--------------|------|
+| Web | 削除（ブラウザが boundary 付きで設定） | 明示すると multer がファイルを受け取れない |
+| Expo Go / Native | `multipart/form-data` | RN axios では明示が必要 |
+
+実装: `frontend/src/utils/apiClient.ts` リクエストインターセプター
+
+### 重複判定タイミング
+
+- **解析時ではなく commit（保存）時**
+- 条件: 同一世帯内で **店名・日付・金額** が一致 → HTTP 409、`message: "DUPLICATE"`
+- Backend: `backend/src/services/receiptService.ts`、`receiptController.ts`
+
+### Web アラート
+
+- `Alert.alert` は Web で複数ボタン・一部メッセージが効かない
+- ユーザー向け通知は `showAlert`（`frontend/src/utils/alertMessage.ts`）を使用
+
+### 切り取り UI
+
+- Native（Expo Go）: ImagePicker の `allowsEditing: true` で OS 標準切り取り（`HomeScreen.pickImageNative`）
+- Web: `ReceiptImageCropModal` — ドラッグ選択 → Canvas 切り取り → アップロード
+
+---
+
+## 8. 関連リンク
+
+| 種別 | リンク |
+|------|--------|
+| Epic #94 | [#322](https://github.com/yama180sx/receipt-ai-app/issues/322) |
+| Epic #95 | [#332](https://github.com/yama180sx/receipt-ai-app/issues/332) |
+| PR #329（#94-1） | develop マージ済み |
+| PR #330（#94-2〜4） | develop マージ済み |
+| PR #331（表記・Web 修正） | `fix/recaipt-spelling` — マージ要確認 |
+| アクセスガイド | [mobile-access.md](./mobile-access.md) |
+| 2FA 手動動確 | [#314](https://github.com/yama180sx/receipt-ai-app/issues/314) |
+
+---
+
+## 9. 変更履歴（本ドキュメント）
+
+| 日付 | 内容 |
+|------|------|
+| 2026-06-12 | 初版 — #94 経緯、動確フィードバック、未コミット修正、次タスクを整理 |

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Platform,
 } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SplashScreen from 'expo-splash-screen';
 
@@ -359,26 +359,30 @@ export default function App() {
         );
       default:
         return (
-          <View style={{ flex: 1 }}>
-            <View style={styles.topActions}>
-              {Platform.OS === 'web' ? <DisplayModeSettings /> : null}
-              {currentUserRole === 'USER' ? (
-                <TouchableOpacity
-                  style={styles.topActionButton}
-                  onPress={() => setCurrentView('totp_settings')}
-                >
-                  <Text style={styles.topActionText}>2FA設定</Text>
-                </TouchableOpacity>
-              ) : null}
-              {biometricEnabled && Platform.OS !== 'web' ? (
-                <TouchableOpacity style={styles.topActionButton} onPress={handleDisableBiometric}>
-                  <Text style={styles.topActionText}>生体認証オフ</Text>
-                </TouchableOpacity>
-              ) : null}
-              <TouchableOpacity style={styles.topActionButton} onPress={handleLogout}>
-                <Text style={styles.topActionText}>ログアウト</Text>
-              </TouchableOpacity>
-            </View>
+          <View style={styles.mainWithToolbar}>
+            <SafeAreaView edges={['top']} style={styles.mainToolbar}>
+              <View style={styles.topActions}>
+                <DisplayModeSettings />
+                <View style={styles.topActionButtons}>
+                  {currentUserRole === 'USER' ? (
+                    <TouchableOpacity
+                      style={styles.topActionButton}
+                      onPress={() => setCurrentView('totp_settings')}
+                    >
+                      <Text style={styles.topActionText}>2FA設定</Text>
+                    </TouchableOpacity>
+                  ) : null}
+                  {biometricEnabled && Platform.OS !== 'web' ? (
+                    <TouchableOpacity style={styles.topActionButton} onPress={handleDisableBiometric}>
+                      <Text style={styles.topActionText}>生体認証オフ</Text>
+                    </TouchableOpacity>
+                  ) : null}
+                  <TouchableOpacity style={styles.topActionButton} onPress={handleLogout}>
+                    <Text style={styles.topActionText}>ログアウト</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </SafeAreaView>
 
             <HomeScreen
               onAnalysisReady={handleAnalysisReady}
@@ -409,12 +413,26 @@ export default function App() {
 
 const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
+  mainWithToolbar: { flex: 1 },
+  mainToolbar: {
+    backgroundColor: theme.colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
   topActions: {
-    position: 'absolute',
-    top: 60,
-    right: 20,
-    zIndex: 10,
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+  },
+  topActionButtons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
     gap: 8,
   },
   topActionButton: {

--- a/frontend/src/components/ReceiptImageCropModal.tsx
+++ b/frontend/src/components/ReceiptImageCropModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,7 @@ import {
   Image,
   Modal,
   PanResponder,
+  Platform,
   type LayoutChangeEvent,
   type GestureResponderEvent,
   type PanResponderGestureState,
@@ -13,6 +14,7 @@ import {
 import * as ImageManipulator from 'expo-image-manipulator';
 import { AppButton } from './ui';
 import { theme } from '../theme';
+import { registerWebImageFile, uriToWebImageFile } from '../utils/webImageFileRegistry';
 
 type Point = { x: number; y: number };
 type Rect = { x: number; y: number; width: number; height: number };
@@ -46,6 +48,13 @@ export function ReceiptImageCropModal({
   const [selection, setSelection] = useState<Rect | null>(null);
   const [processing, setProcessing] = useState(false);
   const dragStart = useRef<Point | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    dragStart.current = null;
+    setDisplaySize({ width: 0, height: 0 });
+    setNaturalSize({ width: 0, height: 0 });
+  }, [imageUri, visible]);
 
   const resetState = useCallback(() => {
     setSelection(null);
@@ -89,13 +98,25 @@ export function ReceiptImageCropModal({
     })
   ).current;
 
+  const finishConfirm = async (uri: string) => {
+    if (Platform.OS === 'web') {
+      try {
+        const file = await uriToWebImageFile(uri, 'receipt_cropped.jpg');
+        registerWebImageFile(uri, file);
+      } catch (e) {
+        console.error('[Crop] web file register failed', e);
+      }
+    }
+    onConfirm(uri);
+  };
+
   const handleConfirm = async () => {
     if (!selection || selection.width < 8 || selection.height < 8) {
-      onConfirm(imageUri);
+      await finishConfirm(imageUri);
       return;
     }
     if (!displaySize.width || !naturalSize.width) {
-      onConfirm(imageUri);
+      await finishConfirm(imageUri);
       return;
     }
 
@@ -119,10 +140,10 @@ export function ReceiptImageCropModal({
         [{ crop: { originX, originY, width: cropWidth, height: cropHeight } }],
         { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
       );
-      onConfirm(result.uri);
+      await finishConfirm(result.uri);
     } catch (e) {
       console.error('[Crop] failed', e);
-      onConfirm(imageUri);
+      await finishConfirm(imageUri);
     } finally {
       setProcessing(false);
     }
@@ -130,7 +151,7 @@ export function ReceiptImageCropModal({
 
   const handleSkipCrop = () => {
     resetState();
-    onConfirm(imageUri);
+    void finishConfirm(imageUri);
   };
 
   const handleCancel = () => {
@@ -138,50 +159,68 @@ export function ReceiptImageCropModal({
     onCancel();
   };
 
+  if (!visible) return null;
+
+  const content = (
+    <View style={[styles.container, Platform.OS === 'web' && styles.webContainer]}>
+      <Text style={styles.title}>レシートの範囲を選択</Text>
+      <Text style={styles.hint}>ドラッグして切り取る範囲を指定してください</Text>
+
+      <View style={styles.imageArea} onLayout={handleLayout} {...panResponder.panHandlers}>
+        <Image
+          source={{ uri: imageUri }}
+          style={styles.image}
+          resizeMode="contain"
+          onLoad={handleImageLoad}
+        />
+        {selection && selection.width > 0 && selection.height > 0 ? (
+          <View
+            style={[
+              styles.selection,
+              {
+                left: selection.x,
+                top: selection.y,
+                width: selection.width,
+                height: selection.height,
+              },
+            ]}
+            pointerEvents="none"
+          />
+        ) : null}
+      </View>
+
+      <View style={styles.actions}>
+        <AppButton title="キャンセル" variant="outline" onPress={handleCancel} />
+        <AppButton title="切り取らずに使う" variant="secondary" onPress={handleSkipCrop} />
+        <AppButton
+          title={processing ? '処理中...' : '切り取って解析'}
+          onPress={() => void handleConfirm()}
+          disabled={processing}
+        />
+      </View>
+    </View>
+  );
+
+  if (Platform.OS === 'web') {
+    return content;
+  }
+
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={handleCancel}>
-      <View style={styles.container}>
-        <Text style={styles.title}>レシートの範囲を選択</Text>
-        <Text style={styles.hint}>ドラッグして切り取る範囲を指定してください</Text>
-
-        <View style={styles.imageArea} onLayout={handleLayout} {...panResponder.panHandlers}>
-          <Image
-            source={{ uri: imageUri }}
-            style={styles.image}
-            resizeMode="contain"
-            onLoad={handleImageLoad}
-          />
-          {selection && selection.width > 0 && selection.height > 0 ? (
-            <View
-              style={[
-                styles.selection,
-                {
-                  left: selection.x,
-                  top: selection.y,
-                  width: selection.width,
-                  height: selection.height,
-                },
-              ]}
-              pointerEvents="none"
-            />
-          ) : null}
-        </View>
-
-        <View style={styles.actions}>
-          <AppButton title="キャンセル" variant="outline" onPress={handleCancel} />
-          <AppButton title="切り取らずに使う" variant="secondary" onPress={handleSkipCrop} />
-          <AppButton
-            title={processing ? '処理中...' : '切り取って解析'}
-            onPress={() => void handleConfirm()}
-            disabled={processing}
-          />
-        </View>
-      </View>
+      {content}
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
+  webContainer: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 9999,
+  } as object,
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,

--- a/frontend/src/components/ReceiptImageCropModal.tsx
+++ b/frontend/src/components/ReceiptImageCropModal.tsx
@@ -15,6 +15,12 @@ import * as ImageManipulator from 'expo-image-manipulator';
 import { AppButton } from './ui';
 import { theme } from '../theme';
 import { registerWebImageFile, uriToWebImageFile } from '../utils/webImageFileRegistry';
+import {
+  computeContainedLayout,
+  cropImageUriWeb,
+  loadImageDimensions,
+  mapSelectionToCrop,
+} from '../utils/cropImageWeb';
 
 type Point = { x: number; y: number };
 type Rect = { x: number; y: number; width: number; height: number };
@@ -98,6 +104,48 @@ export function ReceiptImageCropModal({
     })
   ).current;
 
+  const getNaturalSize = async (): Promise<{ width: number; height: number }> => {
+    if (naturalSize.width > 0 && naturalSize.height > 0) {
+      return naturalSize;
+    }
+    if (Platform.OS === 'web') {
+      return loadImageDimensions(imageUri);
+    }
+    return new Promise((resolve, reject) => {
+      Image.getSize(
+        imageUri,
+        (width, height) => resolve({ width, height }),
+        reject
+      );
+    });
+  };
+
+  const cropSelectedRegion = async (): Promise<string | null> => {
+    if (!selection || selection.width < 8 || selection.height < 8) return null;
+    if (!displaySize.width || !displaySize.height) return null;
+
+    const natural = await getNaturalSize();
+    const layout = computeContainedLayout(
+      displaySize.width,
+      displaySize.height,
+      natural.width,
+      natural.height
+    );
+    const crop = mapSelectionToCrop(selection, layout, natural.width, natural.height);
+    if (!crop) return null;
+
+    if (Platform.OS === 'web') {
+      return cropImageUriWeb(imageUri, crop);
+    }
+
+    const result = await ImageManipulator.manipulateAsync(
+      imageUri,
+      [{ crop }],
+      { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
+    );
+    return result.uri;
+  };
+
   const finishConfirm = async (uri: string) => {
     if (Platform.OS === 'web') {
       try {
@@ -111,36 +159,10 @@ export function ReceiptImageCropModal({
   };
 
   const handleConfirm = async () => {
-    if (!selection || selection.width < 8 || selection.height < 8) {
-      await finishConfirm(imageUri);
-      return;
-    }
-    if (!displaySize.width || !naturalSize.width) {
-      await finishConfirm(imageUri);
-      return;
-    }
-
     setProcessing(true);
     try {
-      const scaleX = naturalSize.width / displaySize.width;
-      const scaleY = naturalSize.height / displaySize.height;
-      const originX = Math.max(0, Math.round(selection.x * scaleX));
-      const originY = Math.max(0, Math.round(selection.y * scaleY));
-      const cropWidth = Math.min(
-        naturalSize.width - originX,
-        Math.round(selection.width * scaleX)
-      );
-      const cropHeight = Math.min(
-        naturalSize.height - originY,
-        Math.round(selection.height * scaleY)
-      );
-
-      const result = await ImageManipulator.manipulateAsync(
-        imageUri,
-        [{ crop: { originX, originY, width: cropWidth, height: cropHeight } }],
-        { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
-      );
-      await finishConfirm(result.uri);
+      const croppedUri = await cropSelectedRegion();
+      await finishConfirm(croppedUri ?? imageUri);
     } catch (e) {
       console.error('[Crop] failed', e);
       await finishConfirm(imageUri);

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -225,7 +225,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
  
   return (
     <>
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
           <Text style={styles.headerSubtitle}>RecAIpt</Text>

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -15,6 +15,8 @@ import { AppButton, AppListItem, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
+import { buildReceiptUploadFormData } from '../utils/receiptUploadFormData';
+import { showAlert } from '../utils/alertMessage';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 
@@ -104,24 +106,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const uploadReceiptImage = async (imageUri: string) => {
-    const formData = new FormData();
-    const uriParts = imageUri.split('.');
-    const fileType = uriParts[uriParts.length - 1] || 'jpg';
-
-    // @ts-ignore — React Native FormData blob
-    formData.append('image', {
-      uri: imageUri,
-      name: `receipt_upload.${fileType}`,
-      type: `image/${fileType === 'jpg' ? 'jpeg' : fileType}`,
-    });
-    formData.append('memberId', currentMemberId.toString());
+    const formData = await buildReceiptUploadFormData(imageUri, currentMemberId);
 
     setIsAnalyzing(true);
     setJobStatus('uploading');
 
     const uploadRes = await apiClient.post('/receipts/upload', formData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
         'x-member-id': currentMemberId.toString(),
       },
     });
@@ -192,7 +183,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     } catch (err) {
       setIsAnalyzing(false);
       console.error('upload after crop', err);
-      Alert.alert('エラー', '画像のアップロードに失敗しました。');
+      const message = err instanceof Error ? err.message : '画像のアップロードに失敗しました。';
+      if (Platform.OS === 'web') {
+        showAlert('エラー', message);
+      } else {
+        Alert.alert('エラー', message);
+      }
     }
   };
 

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -16,6 +16,12 @@ import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
 import { buildReceiptUploadFormData } from '../utils/receiptUploadFormData';
+import {
+  consumePendingCropUri,
+  persistPendingCropUri,
+  registerWebImageFile,
+  clearPendingCropUri,
+} from '../utils/webImageFileRegistry';
 import { showAlert } from '../utils/alertMessage';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
@@ -78,6 +84,15 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     fetchData();
   }, [fetchData]);
 
+  // Android Web: カメラ撮影後にページが再描画されても切り取り画面を復元
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const restored = consumePendingCropUri();
+    if (restored) {
+      setPendingCropUri(restored);
+    }
+  }, []);
+
   const pollJobStatus = async (jobId: string) => {
     const interval = setInterval(async () => {
       try {
@@ -125,6 +140,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const openWebCrop = (imageUri: string) => {
+    if (Platform.OS === 'web') {
+      persistPendingCropUri(imageUri);
+    }
     setPendingCropUri(imageUri);
   };
 
@@ -136,10 +154,14 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           : ImagePicker.launchImageLibraryAsync({ mediaTypes: 'images' as const, quality: 0.8 });
       const result = await picker;
       if (result.canceled || !result.assets?.[0]) return;
-      openWebCrop(result.assets[0].uri);
+      const asset = result.assets[0];
+      if (Platform.OS === 'web' && asset.file) {
+        registerWebImageFile(asset.uri, asset.file);
+      }
+      openWebCrop(asset.uri);
     } catch (err) {
       console.error('pickImageForWeb', err);
-      Alert.alert('エラー', '画像の取得に失敗しました。ギャラリーから選択をお試しください。');
+      showAlert('エラー', '画像の取得に失敗しました。ギャラリーから選択をお試しください。');
     }
   };
 
@@ -177,6 +199,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const handleCropConfirm = async (croppedUri: string) => {
+    clearPendingCropUri();
     setPendingCropUri(null);
     try {
       await uploadReceiptImage(croppedUri);
@@ -192,10 +215,16 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     }
   };
 
+  const handleCropCancel = () => {
+    clearPendingCropUri();
+    setPendingCropUri(null);
+  };
+
   const isWide = useIsWideHomeMenu();
   const isAdmin = userRole === 'ADMIN';
  
   return (
+    <>
     <SafeAreaView style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
@@ -345,15 +374,17 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
         }
       />
 
+    </SafeAreaView>
+
       {pendingCropUri ? (
         <ReceiptImageCropModal
           visible
           imageUri={pendingCropUri}
           onConfirm={(uri) => void handleCropConfirm(uri)}
-          onCancel={() => setPendingCropUri(null)}
+          onCancel={handleCropCancel}
         />
       ) : null}
-    </SafeAreaView>
+    </>
   );
 };
 

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Image,
@@ -18,6 +17,7 @@ import { modalStyles } from '../theme';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
+import { showAlert } from '../utils/alertMessage';
 
 const c = theme.colors;
 const s = theme.colors.semantic.scan;
@@ -129,23 +129,24 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
       
       const res = await apiClient.post('/receipts/commit', payload);
       if (res.data?.success) {
-        Alert.alert('成功', 'レシートを保存しました。');
-        onSuccess();
+        showAlert('成功', 'レシートを保存しました。', { onOk: onSuccess });
+        return;
       }
     } catch (err: any) {
       const apiError = err.response?.data;
-      console.error('Commit error:', apiError || err.message);
+      const message = apiError?.message || err.message;
 
-      if (apiError?.message === 'DUPLICATE') {
-        Alert.alert(
+      if (message === 'DUPLICATE') {
+        showAlert(
           '既に登録済みです',
           '同じ店名・日付・金額のレシートが世帯内に存在します。履歴画面で確認してください。',
-          [{ text: 'OK' }],
+          { onOk: onCancel }
         );
         return;
       }
 
-      Alert.alert('エラー', apiError?.message || '保存に失敗しました。');
+      console.error('Commit error:', apiError || err.message);
+      showAlert('エラー', message || '保存に失敗しました。');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -58,11 +58,22 @@ apiClient.interceptors.request.use(async (config) => {
     config.headers['x-member-id'] = memberId;
   }
 
-  // FormData 送信時は application/json を外し、boundary 付き multipart を自動設定させる
-  if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+  const isFormData =
+    typeof FormData !== 'undefined' &&
+    (config.data instanceof FormData ||
+      (typeof config.data === 'object' &&
+        config.data !== null &&
+        typeof (config.data as FormData).append === 'function'));
+
+  if (isFormData) {
+    // Web: boundary 付き multipart をブラウザに任せる（明示すると multer が壊れる）
+    // Native: Expo/RN では multipart/form-data の明示が必要
     if (config.headers) {
       delete config.headers['Content-Type'];
       delete config.headers['content-type'];
+      if (Platform.OS !== 'web') {
+        config.headers['Content-Type'] = 'multipart/form-data';
+      }
     }
   }
 

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -57,7 +57,15 @@ apiClient.interceptors.request.use(async (config) => {
   if (memberId) {
     config.headers['x-member-id'] = memberId;
   }
-  
+
+  // FormData 送信時は application/json を外し、boundary 付き multipart を自動設定させる
+  if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+    if (config.headers) {
+      delete config.headers['Content-Type'];
+      delete config.headers['content-type'];
+    }
+  }
+
   return config;
 }, (error) => Promise.reject(error));
 

--- a/frontend/src/utils/cropImageWeb.test.ts
+++ b/frontend/src/utils/cropImageWeb.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { computeContainedLayout, mapSelectionToCrop } from './cropImageWeb';
+
+describe('cropImageWeb layout', () => {
+  it('maps selection within letterboxed contain area', () => {
+    const layout = computeContainedLayout(400, 300, 800, 2000);
+    expect(layout.offsetX).toBeGreaterThan(0);
+
+    const crop = mapSelectionToCrop(
+      { x: layout.offsetX + 10, y: layout.offsetY + 10, width: 100, height: 200 },
+      layout,
+      800,
+      2000
+    );
+    expect(crop).not.toBeNull();
+    expect(crop!.originX).toBeGreaterThanOrEqual(0);
+    expect(crop!.width).toBeGreaterThan(0);
+  });
+
+  it('returns null when selection is only in letterbox margin', () => {
+    const layout = computeContainedLayout(400, 300, 800, 2000);
+    const crop = mapSelectionToCrop({ x: 0, y: 0, width: 50, height: 50 }, layout, 800, 2000);
+    expect(crop).toBeNull();
+  });
+});

--- a/frontend/src/utils/cropImageWeb.ts
+++ b/frontend/src/utils/cropImageWeb.ts
@@ -1,0 +1,118 @@
+export type ContainedLayout = {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  renderedWidth: number;
+  renderedHeight: number;
+};
+
+export type CropRect = {
+  originX: number;
+  originY: number;
+  width: number;
+  height: number;
+};
+
+export type SelectionRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** resizeMode="contain" 時の画像表示領域を算出 */
+export function computeContainedLayout(
+  containerWidth: number,
+  containerHeight: number,
+  imageWidth: number,
+  imageHeight: number
+): ContainedLayout {
+  const scale = Math.min(containerWidth / imageWidth, containerHeight / imageHeight);
+  const renderedWidth = imageWidth * scale;
+  const renderedHeight = imageHeight * scale;
+  return {
+    scale,
+    offsetX: (containerWidth - renderedWidth) / 2,
+    offsetY: (containerHeight - renderedHeight) / 2,
+    renderedWidth,
+    renderedHeight,
+  };
+}
+
+/** コンテナ座標の選択範囲 → 原画像ピクセル座標 */
+export function mapSelectionToCrop(
+  selection: SelectionRect,
+  layout: ContainedLayout,
+  imageWidth: number,
+  imageHeight: number
+): CropRect | null {
+  const x1 = Math.max(selection.x, layout.offsetX);
+  const y1 = Math.max(selection.y, layout.offsetY);
+  const x2 = Math.min(selection.x + selection.width, layout.offsetX + layout.renderedWidth);
+  const y2 = Math.min(selection.y + selection.height, layout.offsetY + layout.renderedHeight);
+
+  if (x2 - x1 < 2 || y2 - y1 < 2) return null;
+
+  const originX = Math.round((x1 - layout.offsetX) / layout.scale);
+  const originY = Math.round((y1 - layout.offsetY) / layout.scale);
+  const width = Math.round((x2 - x1) / layout.scale);
+  const height = Math.round((y2 - y1) / layout.scale);
+
+  const clampedX = Math.max(0, Math.min(originX, imageWidth - 1));
+  const clampedY = Math.max(0, Math.min(originY, imageHeight - 1));
+
+  return {
+    originX: clampedX,
+    originY: clampedY,
+    width: Math.max(1, Math.min(width, imageWidth - clampedX)),
+    height: Math.max(1, Math.min(height, imageHeight - clampedY)),
+  };
+}
+
+export function loadImageDimensions(uri: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => {
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.onerror = () => reject(new Error('画像の読み込みに失敗しました'));
+    img.src = uri;
+  });
+}
+
+function loadHtmlImage(uri: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('画像の読み込みに失敗しました'));
+    img.src = uri;
+  });
+}
+
+/** Web: Canvas で切り取り → blob URL */
+export async function cropImageUriWeb(imageUri: string, crop: CropRect): Promise<string> {
+  const img = await loadHtmlImage(imageUri);
+  const canvas = document.createElement('canvas');
+  canvas.width = crop.width;
+  canvas.height = crop.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas が利用できません');
+
+  ctx.drawImage(
+    img,
+    crop.originX,
+    crop.originY,
+    crop.width,
+    crop.height,
+    0,
+    0,
+    crop.width,
+    crop.height
+  );
+
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, 'image/jpeg', 0.85);
+  });
+  if (!blob) throw new Error('切り取りに失敗しました');
+  return URL.createObjectURL(blob);
+}

--- a/frontend/src/utils/receiptUploadFormData.ts
+++ b/frontend/src/utils/receiptUploadFormData.ts
@@ -1,0 +1,35 @@
+import { Platform } from 'react-native';
+
+/**
+ * レシート画像アップロード用 FormData。
+ * Web では File/Blob が必要（RN 形式 { uri, name, type } は multer に届かない）。
+ */
+export async function buildReceiptUploadFormData(
+  imageUri: string,
+  memberId: number
+): Promise<FormData> {
+  const formData = new FormData();
+  formData.append('memberId', memberId.toString());
+
+  if (Platform.OS === 'web') {
+    const response = await fetch(imageUri);
+    if (!response.ok) {
+      throw new Error(`画像の読み込みに失敗しました (${response.status})`);
+    }
+    const blob = await response.blob();
+    const mime = blob.type && blob.type.startsWith('image/') ? blob.type : 'image/jpeg';
+    const ext = mime === 'image/png' ? 'png' : 'jpg';
+    formData.append('image', new File([blob], `receipt_upload.${ext}`, { type: mime }));
+    return formData;
+  }
+
+  const uriParts = imageUri.split('.');
+  const fileType = uriParts[uriParts.length - 1] || 'jpg';
+  // @ts-ignore — React Native FormData blob
+  formData.append('image', {
+    uri: imageUri,
+    name: `receipt_upload.${fileType}`,
+    type: `image/${fileType === 'jpg' ? 'jpeg' : fileType}`,
+  });
+  return formData;
+}

--- a/frontend/src/utils/receiptUploadFormData.ts
+++ b/frontend/src/utils/receiptUploadFormData.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { takeWebImageFile, uriToWebImageFile } from './webImageFileRegistry';
 
 /**
  * レシート画像アップロード用 FormData。
@@ -12,14 +13,9 @@ export async function buildReceiptUploadFormData(
   formData.append('memberId', memberId.toString());
 
   if (Platform.OS === 'web') {
-    const response = await fetch(imageUri);
-    if (!response.ok) {
-      throw new Error(`画像の読み込みに失敗しました (${response.status})`);
-    }
-    const blob = await response.blob();
-    const mime = blob.type && blob.type.startsWith('image/') ? blob.type : 'image/jpeg';
-    const ext = mime === 'image/png' ? 'png' : 'jpg';
-    formData.append('image', new File([blob], `receipt_upload.${ext}`, { type: mime }));
+    const cached = takeWebImageFile(imageUri);
+    const file = cached ?? (await uriToWebImageFile(imageUri));
+    formData.append('image', file);
     return formData;
   }
 

--- a/frontend/src/utils/webImageFileRegistry.ts
+++ b/frontend/src/utils/webImageFileRegistry.ts
@@ -1,0 +1,59 @@
+/** Web 専用: blob/data URI → File の一時保持（FormData アップロード用） */
+const filesByUri = new Map<string, File>();
+
+export function registerWebImageFile(uri: string, file: File): void {
+  filesByUri.set(uri, file);
+}
+
+export function takeWebImageFile(uri: string): File | undefined {
+  const file = filesByUri.get(uri);
+  if (file) {
+    filesByUri.delete(uri);
+  }
+  return file;
+}
+
+export async function uriToWebImageFile(
+  uri: string,
+  filename = 'receipt_upload.jpg'
+): Promise<File> {
+  const cached = takeWebImageFile(uri);
+  if (cached) return cached;
+
+  const response = await fetch(uri);
+  if (!response.ok) {
+    throw new Error(`画像の読み込みに失敗しました (${response.status})`);
+  }
+  const blob = await response.blob();
+  const mime = blob.type && blob.type.startsWith('image/') ? blob.type : 'image/jpeg';
+  const ext = mime === 'image/png' ? 'png' : 'jpg';
+  return new File([blob], filename.replace(/\.\w+$/, `.${ext}`), { type: mime });
+}
+
+const PENDING_CROP_KEY = '@recaipt_pending_crop_uri';
+
+export function persistPendingCropUri(uri: string): void {
+  try {
+    sessionStorage.setItem(PENDING_CROP_KEY, uri);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function consumePendingCropUri(): string | null {
+  try {
+    const uri = sessionStorage.getItem(PENDING_CROP_KEY);
+    if (uri) sessionStorage.removeItem(PENDING_CROP_KEY);
+    return uri;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingCropUri(): void {
+  try {
+    sessionStorage.removeItem(PENDING_CROP_KEY);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary

Issue #94 手動動確で見つかった不具合の修正（PR #331 マージ後の追加分）。

- Web 切り取り: `resizeMode="contain"` を考慮した座標変換、Web は Canvas で切り取り
- Android Web: 切り取り画面の fixed オーバーレイ + sessionStorage 復元（前コミット）
- Web アップロード: 切り取り後 FormData / 画像配信の修正（前コミット）
- 重複保存: `showAlert` で通知、OK 後にホームへ復帰、想定内 409 の `console.error` 抑制
- Expo Go: FormData 送信時 `Content-Type` を Web / Native で分岐
- 表示モードツールバー: `position: absolute` をやめ通常ヘッダーに配置（スクロール重なり解消）
- 進捗ドキュメント `docs/recaipt-mobile-web-progress.md` を追加

## Test plan

- [ ] Web: 撮影 → 切り取り → 解析 → 保存（プレビューが切り取り範囲と一致）
- [ ] Web / Expo Go: 重複レシート保存 → メッセージ → ホーム復帰、赤エラーバナーなし
- [ ] Expo Go: 撮影 → アップロード → 解析
- [ ] Web / Expo Go: ホームスクロール時に表示モード・ログアウトがコンテンツと重ならない
- [ ] `npm test -- --run src/utils/cropImageWeb.test.ts`


Made with [Cursor](https://cursor.com)