### PR TITLE
feat(auth): 全メンバーで TOTP 必須化と iOS ログイン画面のキーボード対応

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import { createApp } from './app';
 import {
-  ensureTestAdminTotp,
+  ensureTestMemberTotp,
   ensureTestMemberPassword,
   getTestTotpCode,
   getTenantBItemId,
@@ -50,8 +50,9 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
     await ensureTestMemberPassword(1);
     await ensureTestMemberPassword(2);
     await ensureTestMemberPassword(TENANT_B_ADMIN_MEMBER_ID);
-    await ensureTestAdminTotp(1);
-    await ensureTestAdminTotp(TENANT_B_ADMIN_MEMBER_ID);
+    await ensureTestMemberTotp(1);
+    await ensureTestMemberTotp(2);
+    await ensureTestMemberTotp(TENANT_B_ADMIN_MEMBER_ID);
 
     const fixturePath = path.join(process.cwd(), 'uploads', 'tenant-isolation-fixture.webp');
     fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
@@ -179,7 +180,12 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
       expect(res.status).toBe(401);
     });
 
-    it('POST /api/auth/login issues token directly for USER without TOTP', async () => {
+    it('POST /api/auth/login returns requiresTotpSetup for USER without TOTP', async () => {
+      await prisma.familyMember.update({
+        where: { id: 2 },
+        data: { totpSecret: null, totpEnabled: false, totpVerifiedAt: null },
+      });
+
       const res = await request(app)
         .post('/api/auth/login')
         .send({
@@ -189,9 +195,12 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
         });
 
       expect(res.status).toBe(200);
-      expect(res.body.data.token).toBeDefined();
-      expect(res.body.data.requiresTotpSetup).toBe(false);
+      expect(res.body.data.token).toBeNull();
+      expect(res.body.data.requiresTotpSetup).toBe(true);
+      expect(res.body.data.pendingToken).toBeDefined();
       expect(res.body.data.requiresTotpVerification).toBe(false);
+
+      await ensureTestMemberTotp(2);
     });
   });
 
@@ -215,7 +224,7 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
       expect(res.body.data.pendingToken).toBeDefined();
       expect(res.body.data.token).toBeNull();
 
-      await ensureTestAdminTotp(1);
+      await ensureTestMemberTotp(1);
     });
 
     it('admin setup flow issues access token', async () => {
@@ -248,7 +257,7 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
       expect(confirmRes.status).toBe(200);
       expect(confirmRes.body.data.token).toBeDefined();
 
-      await ensureTestAdminTotp(1);
+      await ensureTestMemberTotp(1);
     });
 
     it('blocks admin API when TOTP not enabled', async () => {
@@ -288,7 +297,7 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
       expect(adminRes.status).toBe(403);
       expect(adminRes.body.code).toBe('TOTP_REQUIRED');
 
-      await ensureTestAdminTotp(1);
+      await ensureTestMemberTotp(1);
     });
   });
 

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -206,7 +206,7 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
   }
 };
 
-/** TOTP セットアップ開始（pending setup またはログイン済み USER） */
+/** TOTP セットアップ開始（pending setup またはログイン済みメンバー） */
 export const startTotpSetup = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const user = (req as Request & { user: AuthUser }).user;
@@ -312,7 +312,7 @@ export const verifyTotp = async (req: Request, res: Response, next: NextFunction
   }
 };
 
-/** USER 任意: 二要素認証を無効化 */
+/** 二要素認証を無効化（必須ロールでは拒否） */
 export const disableTotp = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const user = (req as Request & { user: AuthUser }).user;
@@ -326,7 +326,7 @@ export const disableTotp = async (req: Request, res: Response, next: NextFunctio
       throw new AppError('二要素認証が有効ではありません。', 400);
     }
     if (isTotpRequiredForRole(member.role)) {
-      throw new AppError('管理者は二要素認証を無効にできません。', 403);
+      throw new AppError('二要素認証は必須のため無効にできません。', 403);
     }
 
     const passwordOk = await bcrypt.compare(password, member.password_hash);

--- a/backend/src/services/totpService.ts
+++ b/backend/src/services/totpService.ts
@@ -26,7 +26,7 @@ export function decryptSecretFromStorage(encrypted: string): string {
   return decryptTotpSecret(encrypted);
 }
 
-/** Admin は 2FA 必須、USER は任意 */
-export function isTotpRequiredForRole(role: Role): boolean {
-  return role === Role.ADMIN;
+/** 全メンバーで初回ログイン時に 2FA セットアップ必須 */
+export function isTotpRequiredForRole(_role: Role): boolean {
+  return true;
 }

--- a/backend/src/test/integrationHelpers.ts
+++ b/backend/src/test/integrationHelpers.ts
@@ -4,7 +4,6 @@ import request from 'supertest';
 import type { Express } from 'express';
 import { prisma } from '../utils/prismaClient';
 import { encryptSecretForStorage } from '../services/totpService';
-import { Role } from '@prisma/client';
 
 export const TEST_MEMBER_PASSWORD = 'integration-test-password';
 /** 結合テスト用固定 TOTP シークレット（base32） */
@@ -33,13 +32,12 @@ export async function ensureTestMemberPassword(memberId = 1): Promise<void> {
   });
 }
 
-/** Admin 結合テスト用: 既知シークレットで TOTP を有効化 */
-export async function ensureTestAdminTotp(memberId: number): Promise<void> {
+/** 結合テスト用: 既知シークレットで TOTP を有効化 */
+export async function ensureTestMemberTotp(memberId: number): Promise<void> {
   const member = await prisma.familyMember.findUnique({ where: { id: memberId } });
   if (!member) {
     throw new Error(`Test member id=${memberId} not found.`);
   }
-  if (member.role !== Role.ADMIN) return;
   if (member.totpEnabled) return;
 
   await prisma.familyMember.update({
@@ -102,9 +100,7 @@ export async function loginAsTestMember(app: Express, memberId = 1): Promise<str
     throw new Error(`Test member id=${memberId} not found. Run prisma seed first.`);
   }
 
-  if (member.role === Role.ADMIN) {
-    await ensureTestAdminTotp(memberId);
-  }
+  await ensureTestMemberTotp(memberId);
 
   return completeTotpLogin(app, {
     familyGroupId: member.familyGroupId,

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -364,14 +364,6 @@ export default function App() {
               <View style={styles.topActions}>
                 <DisplayModeSettings />
                 <View style={styles.topActionButtons}>
-                  {currentUserRole === 'USER' ? (
-                    <TouchableOpacity
-                      style={styles.topActionButton}
-                      onPress={() => setCurrentView('totp_settings')}
-                    >
-                      <Text style={styles.topActionText}>2FA設定</Text>
-                    </TouchableOpacity>
-                  ) : null}
                   {biometricEnabled && Platform.OS !== 'web' ? (
                     <TouchableOpacity style={styles.topActionButton} onPress={handleDisableBiometric}>
                       <Text style={styles.topActionText}>生体認証オフ</Text>

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -20,6 +22,7 @@ type Props = {
 };
 
 export function LoginScreen({ onLoginSuccess }: Props) {
+  const scrollRef = useRef<ScrollView>(null);
   const [step, setStep] = useState<LoginStep>('invite');
   const [inviteCode, setInviteCode] = useState('');
   const [family, setFamily] = useState<ResolvedFamily | null>(null);
@@ -167,12 +170,22 @@ export function LoginScreen({ onLoginSuccess }: Props) {
     }
   };
 
+  const scrollToFormBottom = () => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  };
+
+  useEffect(() => {
+    if (step !== 'totp_setup' && step !== 'totp_verify') return;
+    const timer = setTimeout(scrollToFormBottom, 150);
+    return () => clearTimeout(timer);
+  }, [step, totpSecret]);
+
   const renderTotpStep = (isSetup: boolean) => (
     <>
       <Text style={styles.familyLabel}>{family?.name}</Text>
       <Text style={styles.subtitle}>
         {isSetup
-          ? '二要素認証の設定（管理者必須）'
+          ? '二要素認証の設定（初回ログイン）'
           : '二要素認証コードを入力'}
       </Text>
       {isSetup && totpSecret ? (
@@ -190,6 +203,7 @@ export function LoginScreen({ onLoginSuccess }: Props) {
           placeholderTextColor="rgba(255,255,255,0.6)"
           value={totpCode}
           onChangeText={setTotpCode}
+          onFocus={scrollToFormBottom}
           keyboardType="number-pad"
           maxLength={6}
           editable={!loading}
@@ -306,25 +320,51 @@ export function LoginScreen({ onLoginSuccess }: Props) {
     </>
   );
 
+  const isTotpStep = step === 'totp_setup' || step === 'totp_verify';
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>RecAIpt</Text>
-      <Text style={styles.tagline}>レシートで家計を管理</Text>
-      {step === 'invite' && renderInviteStep()}
-      {step === 'member' && renderMemberStep()}
-      {step === 'password' && renderPasswordStep()}
-      {step === 'totp_setup' && renderTotpStep(true)}
-      {step === 'totp_verify' && renderTotpStep(false)}
-    </View>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        ref={scrollRef}
+        contentContainerStyle={[
+          styles.scrollContent,
+          isTotpStep ? styles.scrollContentTotp : styles.scrollContentCentered,
+        ]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.title}>RecAIpt</Text>
+        <Text style={styles.tagline}>レシートで家計を管理</Text>
+        {step === 'invite' && renderInviteStep()}
+        {step === 'member' && renderMemberStep()}
+        {step === 'password' && renderPasswordStep()}
+        {step === 'totp_setup' && renderTotpStep(true)}
+        {step === 'totp_verify' && renderTotpStep(false)}
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
     backgroundColor: theme.colors.primary,
+  },
+  scrollContent: {
+    flexGrow: 1,
     padding: 40,
+    paddingBottom: 48,
+  },
+  scrollContentCentered: {
+    justifyContent: 'center',
+  },
+  scrollContentTotp: {
+    justifyContent: 'flex-start',
+    paddingTop: 24,
+    paddingBottom: 160,
   },
   title: {
     fontSize: 32,

--- a/frontend/src/screens/TotpSettingsScreen.tsx
+++ b/frontend/src/screens/TotpSettingsScreen.tsx
@@ -20,7 +20,6 @@ type Props = {
 export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
   const [secret, setSecret] = useState<string | null>(null);
   const [code, setCode] = useState('');
-  const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
 
   const handleStartEnable = async () => {
@@ -55,25 +54,6 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
     }
   };
 
-  const handleDisable = async () => {
-    if (!password || !code.trim()) {
-      Alert.alert('入力エラー', 'パスワードと6桁コードを入力してください。');
-      return;
-    }
-    setLoading(true);
-    try {
-      await loginService.disableTotp(password, code);
-      setPassword('');
-      setCode('');
-      onChanged(false);
-      Alert.alert('完了', '二要素認証を無効にしました。');
-    } catch (e: unknown) {
-      Alert.alert('エラー', e instanceof Error ? e.message : '無効化に失敗しました。');
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <View style={styles.container}>
       <TouchableOpacity onPress={onBack} style={styles.backButton}>
@@ -84,32 +64,9 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
       {totpEnabled ? (
         <>
           <Text style={styles.subtitle}>現在: 有効</Text>
-          <TextInput
-            style={styles.input}
-            placeholder="パスワード"
-            secureTextEntry
-            value={password}
-            onChangeText={setPassword}
-          />
-          <TextInput
-            style={styles.input}
-            placeholder="6桁コード"
-            keyboardType="number-pad"
-            maxLength={6}
-            value={code}
-            onChangeText={setCode}
-          />
-          <TouchableOpacity
-            style={styles.dangerButton}
-            onPress={handleDisable}
-            disabled={loading}
-          >
-            {loading ? (
-              <ActivityIndicator color="white" />
-            ) : (
-              <Text style={styles.dangerButtonText}>二要素認証を無効にする</Text>
-            )}
-          </TouchableOpacity>
+          <Text style={styles.subtitle}>
+            二要素認証は全メンバー必須のため、無効にできません。
+          </Text>
         </>
       ) : secret ? (
         <>
@@ -187,11 +144,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   primaryButtonText: { color: 'white', fontWeight: 'bold' },
-  dangerButton: {
-    backgroundColor: '#c0392b',
-    padding: 16,
-    borderRadius: 12,
-    alignItems: 'center',
-  },
-  dangerButtonText: { color: 'white', fontWeight: 'bold' },
 });


### PR DESCRIPTION
## Summary
- 全 Role（ADMIN / USER）で初回ログイン時に TOTP セットアップを必須化し、家族全員の認証フローを管理者と同一に統一
- USER 限定だった「2FA設定」ツールバーボタンを削除（ログイン時セットアップに一本化）
- iPhone 6s 等の小画面で TOTP 入力時にキーボードが「設定を完了」ボタンを隠す問題を `KeyboardAvoidingView` + `ScrollView` で修正
- 結合テストを全メンバー TOTP 必須仕様に合わせて更新

## Test plan
- [ ] iPhone（Expo Go）で USER 初回ログイン → TOTP セットアップ → 6桁入力後「設定を完了」が押せる
- [ ] Android で同様に初回 TOTP セットアップ → 生体認証プロンプト
- [ ] 2回目以降ログインで TOTP 検証のみ
- [ ] Web `:80` / Expo Go `:8082` でログイン動作確認
- [ ] `develop` マージ後、`main` へ CD で stable 反映


Made with [Cursor](https://cursor.com)