### PR TITLE
feat(backend): [Issue #95-1] 解析ジョブ一覧 API と早期重複判定

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -382,6 +382,89 @@ describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {
     expect(res.body.data.state).toBe('completed');
   });
 
+  it('GET /receipts/jobs returns only logged-in member jobs', async () => {
+    clearMockReceiptJobs();
+    registerMockReceiptJob('member1-job', {
+      memberId: 1,
+      familyGroupId: 1,
+      imagePath: 'uploads/member1.webp',
+    }, { timestamp: 2000 });
+    registerMockReceiptJob('member2-job', {
+      memberId: 2,
+      familyGroupId: 1,
+      imagePath: 'uploads/member2.webp',
+    }, { timestamp: 1000 });
+
+    const tokenMember1 = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get('/api/receipts/jobs')
+      .set('Authorization', `Bearer ${tokenMember1}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe('member1-job');
+  });
+
+  it('GET /receipts/jobs flags duplicateSuspected on completed jobs', async () => {
+    clearMockReceiptJobs();
+    registerMockReceiptJob('dup-job', {
+      memberId: 1,
+      familyGroupId: 1,
+      imagePath: 'uploads/new-dup.webp',
+    }, {
+      returnvalue: {
+        parsedData: {
+          storeName: '山本家テスト店',
+          purchaseDate: '2026-01-10',
+          totalAmount: 100,
+          items: [{ name: 'テスト商品', price: 100, quantity: 1 }],
+        },
+        imagePath: 'uploads/new-dup.webp',
+        validation: { isSuspicious: false, warnings: [] },
+      },
+    });
+
+    const token = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get('/api/receipts/jobs')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const job = res.body.data.find((j: { id: string }) => j.id === 'dup-job');
+    expect(job).toBeDefined();
+    expect(job.duplicateSuspected).toBe(true);
+    expect(job.existingReceiptId).toBeGreaterThan(0);
+    expect(job.parsedData.storeName).toBe('山本家テスト店');
+  });
+
+  it('getJobStatus enriches completed jobs with duplicate flags', async () => {
+    registerMockReceiptJob('dup-status-job', {
+      memberId: 1,
+      familyGroupId: 1,
+      imagePath: 'uploads/dup-status.webp',
+    }, {
+      returnvalue: {
+        parsedData: {
+          storeName: '山本家テスト店',
+          purchaseDate: '2026-01-10',
+          totalAmount: 100,
+          items: [],
+        },
+        imagePath: 'uploads/dup-status.webp',
+      },
+    });
+
+    const token = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get('/api/receipts/status/dup-status-job')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.duplicateSuspected).toBe(true);
+    expect(res.body.data.existingReceiptId).toBeGreaterThan(0);
+  });
+
   it('rejects unauthenticated upload image access', async () => {
     const res = await request(app).get('/api/uploads/tenant-isolation-fixture.webp');
     expect(res.status).toBe(401);

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -4,7 +4,8 @@ import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
 import { getCleanText } from '../utils/normalizer';
 import { receiptQueue } from '../queues/receiptQueue';
-import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService'; 
+import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService';
+import { enrichCompletedJobPayload, listReceiptJobsForMember } from '../services/receiptJobService'; 
 import { getFamilyGroupId, getMemberId } from '../utils/context';
 import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
 import { calcItemLineTotal } from '../utils/itemLineTotal';
@@ -26,15 +27,34 @@ export const getJobStatus = async (req: Request<{ jobId: string }>, res: Respons
     }
 
     const state = await job.getState();
+    let data: Record<string, unknown> = {
+      id: job.id,
+      state,
+      result: job.returnvalue,
+      error: job.failedReason,
+    };
+    data = await enrichCompletedJobPayload(job, familyGroupId, data);
+
     res.status(200).json({
       success: true,
-      data: {
-        id: job.id,
-        state,
-        result: job.returnvalue,
-        error: job.failedReason
-      }
+      data,
     });
+  } catch (error) { next(error); }
+};
+
+/**
+ * [Issue #95-1] ログインメンバー本人の解析ジョブ一覧（確認トレイ用）
+ */
+export const getReceiptJobs = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const familyGroupId = getFamilyGroupId();
+    const memberId = getMemberId();
+    if (!memberId) {
+      throw new AppError('メンバーIDが指定されていません。', 400);
+    }
+
+    const jobs = await listReceiptJobsForMember(familyGroupId, Number(memberId));
+    res.status(200).json({ success: true, data: jobs });
   } catch (error) { next(error); }
 };
 

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -20,6 +20,7 @@ import {
   updateItemCategory,
   getMonthlyStats,
   getJobStatus,
+  getReceiptJobs,
   getAdvancedStats,
   commitReceipt,
   getFamilyMembers,
@@ -95,6 +96,7 @@ router.get('/family-groups/members', getFamilyMembers);
 router.get('/uploads/:filename', serveReceiptImage);
 
 router.get('/receipts', getReceipts);
+router.get('/receipts/jobs', getReceiptJobs);
 router.get('/receipts/latest', getLatestReceipt);
 router.get('/receipts/status/:jobId', getJobStatus);
 router.get('/stats/monthly', getMonthlyStats);

--- a/backend/src/services/duplicateReceiptService.ts
+++ b/backend/src/services/duplicateReceiptService.ts
@@ -1,0 +1,95 @@
+import { prisma } from '../utils/prismaClient';
+import { getCleanText, normalizeStoreName } from '../utils/normalizer';
+
+export type DuplicateCheckResult = {
+  duplicateSuspected: boolean;
+  existingReceiptId?: number;
+};
+
+/** Gemini / フロントと同じ日付パース（saveParsedReceipt と整合） */
+export function parseReceiptDate(dateStr: string | null | undefined): Date {
+  if (!dateStr) return new Date();
+
+  const match = dateStr.match(/(\d{4})[-\/\.](\d{2})[-\/\.](\d{2})(?:\s+(\d{2}):(\d{2}))?/);
+  if (match) {
+    const y = parseInt(match[1], 10);
+    const m = parseInt(match[2], 10);
+    const d = parseInt(match[3], 10);
+    const hh = match[4] ? parseInt(match[4], 10) : 0;
+    const mm = match[5] ? parseInt(match[5], 10) : 0;
+    const date = new Date(y, m - 1, d, hh, mm, 0, 0);
+    if (!isNaN(date.getTime())) return date;
+  }
+
+  const fallback = new Date(dateStr);
+  return isNaN(fallback.getTime()) ? new Date() : fallback;
+}
+
+type ParsedLike = {
+  storeName?: string | null;
+  purchaseDate?: string | null;
+  date?: string | null;
+  totalAmount?: number | null;
+};
+
+/**
+ * commit 前の read-only 重複候補判定（店名・日付・金額）。
+ * saveParsedReceipt と同一ロジック。
+ */
+export async function checkDuplicateReceipt(
+  familyGroupId: number,
+  parsedData: ParsedLike,
+  imagePath?: string | null
+): Promise<DuplicateCheckResult> {
+  const normalizedImage = imagePath?.replace(/\\/g, '/');
+
+  if (normalizedImage) {
+    const existingByImage = await prisma.receipt.findFirst({
+      where: { familyGroupId, imagePath: normalizedImage },
+      select: { id: true },
+    });
+    if (existingByImage) {
+      return { duplicateSuspected: false, existingReceiptId: existingByImage.id };
+    }
+  }
+
+  const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
+  const cleanStore = getCleanText(officialStoreName);
+  const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
+  const totalAmount = Math.round(Number(parsedData.totalAmount || 0));
+
+  const duplicateWhere: {
+    familyGroupId: number;
+    totalAmount: number;
+    date: { gte: Date; lte: Date };
+  } = {
+    familyGroupId,
+    totalAmount,
+    date: { gte: new Date(), lte: new Date() },
+  };
+
+  if (jstDate.getHours() === 0 && jstDate.getMinutes() === 0) {
+    const startOfDay = new Date(jstDate);
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date(jstDate);
+    endOfDay.setHours(23, 59, 59, 999);
+    duplicateWhere.date = { gte: startOfDay, lte: endOfDay };
+  } else {
+    const margin = 1 * 60 * 1000;
+    duplicateWhere.date = {
+      gte: new Date(jstDate.getTime() - margin),
+      lte: new Date(jstDate.getTime() + margin),
+    };
+  }
+
+  const existing = await prisma.receipt.findFirst({
+    where: duplicateWhere,
+    select: { id: true, storeName: true },
+  });
+
+  if (existing && getCleanText(existing.storeName) === cleanStore) {
+    return { duplicateSuspected: true, existingReceiptId: existing.id };
+  }
+
+  return { duplicateSuspected: false };
+}

--- a/backend/src/services/receiptJobService.ts
+++ b/backend/src/services/receiptJobService.ts
@@ -1,0 +1,143 @@
+import type { Job } from 'bullmq';
+import { receiptQueue } from '../queues/receiptQueue';
+import { checkDuplicateReceipt } from './duplicateReceiptService';
+
+const LIST_JOB_STATES = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused'] as const;
+
+export type ReceiptJobListItem = {
+  id: string;
+  state: string;
+  imagePath: string | null;
+  createdAt: number;
+  failedReason?: string | null;
+  parsedData?: {
+    storeName: string;
+    purchaseDate: string;
+    totalAmount: number;
+    taxAmount?: number;
+    itemCount: number;
+  };
+  validation?: {
+    isSuspicious: boolean;
+    warnings: string[];
+  };
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number;
+};
+
+type AnalyzeJobReturn = {
+  parsedData?: {
+    storeName?: string;
+    purchaseDate?: string;
+    totalAmount?: number;
+    taxAmount?: number;
+    items?: unknown[];
+  };
+  imagePath?: string;
+  validation?: { isSuspicious: boolean; warnings: string[] };
+};
+
+function summarizeParsedData(parsedData: AnalyzeJobReturn['parsedData']) {
+  if (!parsedData) return undefined;
+  return {
+    storeName: String(parsedData.storeName ?? ''),
+    purchaseDate: String(parsedData.purchaseDate ?? ''),
+    totalAmount: Math.round(Number(parsedData.totalAmount ?? 0)),
+    taxAmount: parsedData.taxAmount != null ? Number(parsedData.taxAmount) : undefined,
+    itemCount: Array.isArray(parsedData.items) ? parsedData.items.length : 0,
+  };
+}
+
+export async function formatReceiptJobForApi(
+  job: Job,
+  familyGroupId: number
+): Promise<ReceiptJobListItem> {
+  const state = await job.getState();
+  const imagePath =
+    typeof job.data?.imagePath === 'string'
+      ? job.data.imagePath.replace(/\\/g, '/')
+      : null;
+
+  const base: ReceiptJobListItem = {
+    id: String(job.id),
+    state,
+    imagePath,
+    createdAt: job.timestamp,
+    failedReason: state === 'failed' ? job.failedReason ?? null : undefined,
+  };
+
+  if (state !== 'completed' || !job.returnvalue) {
+    return base;
+  }
+
+  const result = job.returnvalue as AnalyzeJobReturn;
+  const parsedData = result.parsedData;
+  const validation = result.validation;
+
+  const duplicate = parsedData
+    ? await checkDuplicateReceipt(
+        familyGroupId,
+        parsedData,
+        result.imagePath ?? imagePath
+      )
+    : { duplicateSuspected: false };
+
+  return {
+    ...base,
+    parsedData: summarizeParsedData(parsedData),
+    validation: validation
+      ? {
+          isSuspicious: Boolean(validation.isSuspicious),
+          warnings: validation.warnings ?? [],
+        }
+      : undefined,
+    duplicateSuspected: duplicate.duplicateSuspected,
+    existingReceiptId: duplicate.existingReceiptId,
+  };
+}
+
+/** ログインメンバー本人の解析ジョブ一覧（確認トレイ用） */
+export async function listReceiptJobsForMember(
+  familyGroupId: number,
+  memberId: number
+): Promise<ReceiptJobListItem[]> {
+  const jobs = await receiptQueue.getJobs([...LIST_JOB_STATES], 0, 200, true);
+
+  const owned = jobs.filter(
+    (job) =>
+      Number(job.data?.familyGroupId) === familyGroupId &&
+      Number(job.data?.memberId) === memberId
+  );
+
+  owned.sort((a, b) => b.timestamp - a.timestamp);
+
+  return Promise.all(owned.map((job) => formatReceiptJobForApi(job, familyGroupId)));
+}
+
+export async function enrichCompletedJobPayload(
+  job: Job,
+  familyGroupId: number,
+  payload: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const state = payload.state as string;
+  if (state !== 'completed' || !job.returnvalue) {
+    return payload;
+  }
+
+  const result = job.returnvalue as AnalyzeJobReturn;
+  if (!result.parsedData) {
+    return payload;
+  }
+
+  const duplicate = await checkDuplicateReceipt(
+    familyGroupId,
+    result.parsedData,
+    result.imagePath ?? job.data?.imagePath
+  );
+
+  return {
+    ...payload,
+    duplicateSuspected: duplicate.duplicateSuspected,
+    existingReceiptId: duplicate.existingReceiptId,
+  };
+}

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -1,40 +1,12 @@
 import { PrismaClient } from '@prisma/client';
 import { analyzeReceiptImage, ParsedReceipt } from './geminiService';
 import { estimateCategoryId } from './categoryService';
-import { validateReceiptItems } from './validationService'; 
+import { validateReceiptItems } from './validationService';
+import { checkDuplicateReceipt, parseReceiptDate } from './duplicateReceiptService';
 import logger from '../utils/logger';
 import { normalizeStoreName, getCleanText } from '../utils/normalizer';
 
 const prisma = new PrismaClient();
-
-/**
- * [Issue #71] 文字列からDateオブジェクトを生成する (HH:mm 対応版)
- * Geminiから返却される "YYYY-MM-DD HH:mm" を正確にパースします。
- */
-const parseSafeDate = (dateStr: string | null | undefined): Date => {
-  if (!dateStr) return new Date();
-  
-  // YYYY-MM-DD HH:mm または YYYY-MM-DD の形式を抽出
-  const match = dateStr.match(/(\d{4})[-\/\.](\d{2})[-\/\.](\d{2})(?:\s+(\d{2}):(\d{2}))?/);
-  
-  if (match) {
-    const y = parseInt(match[1], 10);
-    const m = parseInt(match[2], 10);
-    const d = parseInt(match[3], 10);
-    const hh = match[4] ? parseInt(match[4], 10) : 0;
-    const mm = match[5] ? parseInt(match[5], 10) : 0;
-    
-    // タイムゾーンによるズレを防ぐため、OSローカル（JST前提）で生成
-    const date = new Date(y, m - 1, d, hh, mm, 0, 0);
-    if (!isNaN(date.getTime())) {
-      return date;
-    }
-  }
-  
-  // パース失敗時のフォールバック
-  const fallback = new Date(dateStr);
-  return isNaN(fallback.getTime()) ? new Date() : fallback;
-};
 
 /**
  * [Issue #49-8 / #72 / #63] 解析のみを実行し、推論カテゴリを付与して返す
@@ -103,7 +75,7 @@ export const saveParsedReceipt = async (
   try {
     const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
     const cleanStore = getCleanText(officialStoreName);
-    const jstDate = parseSafeDate(parsedData.purchaseDate || parsedData.date);
+    const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
     
     // Receipt.totalAmount は Int、taxAmount は Float
     const totalAmount = Math.round(Number(parsedData.totalAmount || 0));
@@ -132,32 +104,15 @@ export const saveParsedReceipt = async (
     /**
      * 重複チェック（別画像で店名・日付・金額が同一の場合）
      */
-    let duplicateWhere: any = { 
-      familyGroupId, 
-      totalAmount,
-    };
-
-    if (jstDate.getHours() === 0 && jstDate.getMinutes() === 0) {
-      const startOfDay = new Date(jstDate); startOfDay.setHours(0, 0, 0, 0);
-      const endOfDay = new Date(jstDate); endOfDay.setHours(23, 59, 59, 999);
-      duplicateWhere.date = { gte: startOfDay, lte: endOfDay };
-    } else {
-      const margin = 1 * 60 * 1000; // 前後1分
-      duplicateWhere.date = { 
-        gte: new Date(jstDate.getTime() - margin), 
-        lte: new Date(jstDate.getTime() + margin) 
-      };
-    }
-
-    const existing = await prisma.receipt.findFirst({
-      where: duplicateWhere,
-      select: { id: true, storeName: true }
-    });
-
-    if (existing && getCleanText(existing.storeName) === cleanStore) {
+    const duplicate = await checkDuplicateReceipt(
+      familyGroupId,
+      parsedData,
+      imagePath
+    );
+    if (duplicate.duplicateSuspected) {
       const error = new Error('DUPLICATE_RECEIPT_DETECTED');
       (error as any).statusCode = 409;
-      (error as any).existingId = existing.id;
+      (error as any).existingId = duplicate.existingReceiptId;
       throw error;
     }
 

--- a/backend/src/test/mockJobStore.ts
+++ b/backend/src/test/mockJobStore.ts
@@ -3,6 +3,7 @@ export type MockReceiptJob = {
   data: { memberId?: number; familyGroupId?: number; imagePath?: string };
   returnvalue: unknown;
   failedReason: string | null;
+  timestamp: number;
   getState: () => Promise<string>;
 };
 
@@ -10,14 +11,22 @@ export const mockReceiptJobs = new Map<string, MockReceiptJob>();
 
 export function registerMockReceiptJob(
   id: string,
-  data: { memberId: number; familyGroupId: number; imagePath?: string }
+  data: { memberId: number; familyGroupId: number; imagePath?: string },
+  options?: {
+    state?: string;
+    returnvalue?: unknown;
+    failedReason?: string | null;
+    timestamp?: number;
+  }
 ): void {
+  const state = options?.state ?? 'completed';
   mockReceiptJobs.set(id, {
     id,
     data,
-    returnvalue: null,
-    failedReason: null,
-    getState: async () => 'completed',
+    returnvalue: options?.returnvalue ?? null,
+    failedReason: options?.failedReason ?? null,
+    timestamp: options?.timestamp ?? Date.now(),
+    getState: async () => state,
   });
 }
 


### PR DESCRIPTION
## Summary
- `GET /api/receipts/jobs` を追加し、ログイン中メンバー本人の BullMQ 解析ジョブ一覧を返す（確認トレイ用）
- 完了ジョブに `duplicateSuspected` / `existingReceiptId` / `parsedData` サマリを付与
- 重複判定ロジックを `duplicateReceiptService` に共通化し、`saveParsedReceipt` と `getJobStatus` から再利用
- 既存 `GET /api/receipts/status/:jobId` は後方互換を維持しつつ、完了時に重複フラグを追加

Closes #333

## Test plan
- [x] `cd backend && npm test`（32 passed）
- [ ] `cd backend && npm run test:integration`（DB 起動時）
- [ ] dev 環境で `GET /api/receipts/jobs` が認証付きで 200 を返すこと
- [ ] 同一世帯の別メンバーのジョブが一覧に含まれないこと
- [ ] 既存レシートと一致する完了ジョブで `duplicateSuspected: true` になること


Made with [Cursor](https://cursor.com)