### PR TITLE
feat(frontend): [Issue #95-2] 非ブロッキング撮影と受付一覧

### DIFF
--- a/frontend/src/hooks/useReceiptJobs.ts
+++ b/frontend/src/hooks/useReceiptJobs.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import apiClient from '../utils/apiClient';
+import { countActiveReceiptJobs } from '../utils/receiptJobDisplay';
+import type { ReceiptJobListItem } from '../types/receiptJob';
+
+const POLL_INTERVAL_MS = 2000;
+
+export function useReceiptJobs(enabled: boolean) {
+  const [jobs, setJobs] = useState<ReceiptJobListItem[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const jobsRef = useRef(jobs);
+  jobsRef.current = jobs;
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    setRefreshing(true);
+    try {
+      const res = await apiClient.get('/receipts/jobs');
+      if (res.data?.success && Array.isArray(res.data.data)) {
+        setJobs(res.data.data as ReceiptJobListItem[]);
+      }
+    } catch (error) {
+      console.error('[ReceiptJobs] refresh failed:', error);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setJobs([]);
+      return;
+    }
+
+    void refresh();
+  }, [enabled, refresh]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const interval = setInterval(() => {
+      if (countActiveReceiptJobs(jobsRef.current) > 0) {
+        void refresh();
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [enabled, refresh]);
+
+  const activeCount = countActiveReceiptJobs(jobs);
+
+  return {
+    jobs,
+    activeCount,
+    refreshing,
+    refresh,
+  };
+}

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  View, 
-  Text, 
-  StyleSheet, 
-  TouchableOpacity, 
-  ScrollView, 
-  ActivityIndicator, 
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
   Alert,
   Platform,
 } from 'react-native';
@@ -14,7 +14,9 @@ import * as ImagePicker from 'expo-image-picker';
 import { AppButton, AppListItem, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { getAppDisplayName, getMemberMenuTitle, isDevAppEnv } from '../config/appEnv';
+import { useReceiptJobs } from '../hooks/useReceiptJobs';
 import { theme } from '../theme';
+import type { LocalFailedReceiptJob, ReceiptTrayItem } from '../types/receiptJob';
 import apiClient from '../utils/apiClient';
 import { buildReceiptUploadFormData } from '../utils/receiptUploadFormData';
 import {
@@ -24,40 +26,79 @@ import {
   clearPendingCropUri,
 } from '../utils/webImageFileRegistry';
 import { showAlert } from '../utils/alertMessage';
+import {
+  getReceiptJobDisplay,
+  getReceiptTrayItemTitle,
+  sortReceiptTrayItems,
+} from '../utils/receiptJobDisplay';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 
 interface HomeScreenProps {
-  onAnalysisReady: (data: any) => void; 
+  onAnalysisReady: (data: any) => void;
   onGoToHistory: () => void;
   onGoToStats: () => void;
-  onGoToSettlement?: () => void; // ★ [Issue #80] 精算サマリー画面への遷移ハンドラを追加
+  onGoToSettlement?: () => void;
   onGoToAdminMenu?: () => void;
   currentMemberId: number;
   memberName?: string | null;
   userRole?: string | null;
 }
 
+const ACCEPTANCE_MESSAGE_MS = 3000;
+
+function formatTrayTime(createdAt: number): string {
+  return new Date(createdAt).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function trayBadgeStyle(kind: ReturnType<typeof getReceiptJobDisplay>['kind']) {
+  switch (kind) {
+    case 'failed':
+      return styles.trayBadgeFailed;
+    case 'duplicate_suspected':
+      return styles.trayBadgeDuplicate;
+    case 'ready':
+      return styles.trayBadgeReady;
+    case 'processing':
+      return styles.trayBadgeProcessing;
+    default:
+      return styles.trayBadgeQueued;
+  }
+}
+
 /**
  * ホーム画面（ダッシュボード）
  */
-export const HomeScreen: React.FC<HomeScreenProps> = ({ 
-  onAnalysisReady, 
-  onGoToHistory, 
-  onGoToStats, 
-  onGoToSettlement, // ★ 追加
+export const HomeScreen: React.FC<HomeScreenProps> = ({
+  onAnalysisReady: _onAnalysisReady,
+  onGoToHistory,
+  onGoToStats,
+  onGoToSettlement,
   onGoToAdminMenu,
   currentMemberId,
   memberName,
-  userRole 
+  userRole,
 }) => {
   const [latestReceipt, setLatestReceipt] = useState<any>(null);
   const [monthlyTotal, setMonthlyTotal] = useState<number>(0);
   const [loading, setLoading] = useState(true);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [jobStatus, setJobStatus] = useState('');
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const [localFailedJobs, setLocalFailedJobs] = useState<LocalFailedReceiptJob[]>([]);
+  const [acceptanceMessage, setAcceptanceMessage] = useState<string | null>(null);
   const [pendingCropUri, setPendingCropUri] = useState<string | null>(null);
   const [showImageSourcePicker, setShowImageSourcePicker] = useState(false);
+
+  const { jobs, activeCount, refresh: refreshJobs } = useReceiptJobs(currentMemberId > 0);
+
+  const trayItems = useMemo(
+    () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
+    [jobs, localFailedJobs]
+  );
+
+  const pendingBadgeCount = activeCount + uploadingCount;
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -65,13 +106,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
       const currentMonth = getCurrentYearMonth();
       const [latestRes, statsRes] = await Promise.all([
         apiClient.get('/receipts/latest', { params: { memberId: currentMemberId } }),
-        apiClient.get('/stats/monthly', { params: { month: currentMonth } })
+        apiClient.get('/stats/monthly', { params: { month: currentMonth } }),
       ]);
 
       if (latestRes.data && latestRes.data.success) {
         setLatestReceipt(latestRes.data.data);
       }
-      
+
       if (statsRes.data && statsRes.data.success) {
         const total = statsRes.data.data.totalAmount || 0;
         setMonthlyTotal(Math.round(total));
@@ -87,7 +128,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     fetchData();
   }, [fetchData]);
 
-  // Android Web: カメラ撮影後にページが再描画されても切り取り画面を復元
   useEffect(() => {
     if (Platform.OS !== 'web') return;
     const restored = consumePendingCropUri();
@@ -96,49 +136,59 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     }
   }, []);
 
-  const pollJobStatus = async (jobId: string) => {
-    const interval = setInterval(async () => {
-      try {
-        const res = await apiClient.get(`/receipts/status/${jobId}`);
-        const { state, result, error } = res.data.data;
-        
-        setJobStatus(state);
+  useEffect(() => {
+    if (!acceptanceMessage) return;
+    const timer = setTimeout(() => setAcceptanceMessage(null), ACCEPTANCE_MESSAGE_MS);
+    return () => clearTimeout(timer);
+  }, [acceptanceMessage]);
 
-        if (state === 'completed') {
-          clearInterval(interval);
-          setIsAnalyzing(false);
-          setJobStatus('');
-          if (result) onAnalysisReady(result);
-        } else if (state === 'failed') {
-          clearInterval(interval);
-          setIsAnalyzing(false);
-          setJobStatus('');
-          Alert.alert('解析失敗', error || 'AIによる解析中にエラーが発生しました。');
-        }
-      } catch (err) {
-        clearInterval(interval);
-        setIsAnalyzing(false);
-        console.error('Polling error:', err);
-      }
-    }, 2000);
-  };
+  const showAcceptanceFeedback = useCallback((message: string) => {
+    setAcceptanceMessage(message);
+  }, []);
+
+  const registerLocalUploadFailure = useCallback((reason: string) => {
+    setLocalFailedJobs((prev) => [
+      {
+        id: `local-failed-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        state: 'failed',
+        createdAt: Date.now(),
+        failedReason: reason,
+        localOnly: true,
+      },
+      ...prev,
+    ]);
+  }, []);
 
   const uploadReceiptImage = async (imageUri: string) => {
-    const formData = await buildReceiptUploadFormData(imageUri, currentMemberId);
+    setUploadingCount((count) => count + 1);
+    try {
+      const formData = await buildReceiptUploadFormData(imageUri, currentMemberId);
+      const uploadRes = await apiClient.post('/receipts/upload', formData, {
+        headers: {
+          'x-member-id': currentMemberId.toString(),
+        },
+      });
 
-    setIsAnalyzing(true);
-    setJobStatus('uploading');
+      if (uploadRes.data?.success) {
+        showAcceptanceFeedback('受付しました。解析結果は下の一覧に表示されます。');
+        await refreshJobs();
+        return;
+      }
 
-    const uploadRes = await apiClient.post('/receipts/upload', formData, {
-      headers: {
-        'x-member-id': currentMemberId.toString(),
-      },
-    });
-
-    if (uploadRes.data?.success) {
-      const jobId = uploadRes.data.data.jobId;
-      setJobStatus('queued');
-      pollJobStatus(jobId);
+      registerLocalUploadFailure('サーバーが受付を拒否しました。');
+      showAlert('エラー', 'レシートの受付に失敗しました。');
+    } catch (err) {
+      console.error('uploadReceiptImage', err);
+      const message =
+        err instanceof Error ? err.message : '画像のアップロードに失敗しました。';
+      registerLocalUploadFailure(message);
+      if (Platform.OS === 'web') {
+        showAlert('エラー', message);
+      } else {
+        Alert.alert('エラー', message);
+      }
+    } finally {
+      setUploadingCount((count) => Math.max(0, count - 1));
     }
   };
 
@@ -187,7 +237,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
 
   const handleScan = async () => {
     if (Platform.OS === 'web') {
-      // Web では Alert.alert の複数ボタンが効かないためモーダルを使う
       setShowImageSourcePicker(true);
       return;
     }
@@ -195,7 +244,6 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     try {
       await pickImageNative();
     } catch (err) {
-      setIsAnalyzing(false);
       console.error('handleScan Error:', err);
       Alert.alert('エラー', '画像のアップロードに失敗しました。');
     }
@@ -204,18 +252,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const handleCropConfirm = async (croppedUri: string) => {
     clearPendingCropUri();
     setPendingCropUri(null);
-    try {
-      await uploadReceiptImage(croppedUri);
-    } catch (err) {
-      setIsAnalyzing(false);
-      console.error('upload after crop', err);
-      const message = err instanceof Error ? err.message : '画像のアップロードに失敗しました。';
-      if (Platform.OS === 'web') {
-        showAlert('エラー', message);
-      } else {
-        Alert.alert('エラー', message);
-      }
-    }
+    await uploadReceiptImage(croppedUri);
   };
 
   const handleCropCancel = () => {
@@ -223,159 +260,217 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     setPendingCropUri(null);
   };
 
-  const isWide = useIsWideHomeMenu();
-  const isAdmin = userRole === 'ADMIN';
- 
-  return (
-    <>
-    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
-        <View style={[styles.header, isDevAppEnv() && styles.headerDev]}>
-          <Text style={styles.headerSubtitle}>{getAppDisplayName()}</Text>
-          <Text style={styles.headerTitle}>{getMemberMenuTitle(memberName)}</Text>
+  const renderTrayItem = (item: ReceiptTrayItem) => {
+    const display =
+      'localOnly' in item && item.localOnly
+        ? { kind: 'failed' as const, label: '失敗', isActive: false }
+        : getReceiptJobDisplay(item);
+    const subtitle =
+      'localOnly' in item && item.localOnly
+        ? item.failedReason
+        : item.state === 'failed'
+          ? item.failedReason || '解析に失敗しました'
+          : item.parsedData
+            ? `¥${Math.round(item.parsedData.totalAmount || 0).toLocaleString()}`
+            : display.label;
+
+    return (
+      <View key={item.id} style={styles.trayRow}>
+        <View style={styles.trayRowMain}>
+          <Text style={styles.trayRowTitle} numberOfLines={1}>
+            {getReceiptTrayItemTitle(item)}
+          </Text>
+          <Text style={styles.trayRowMeta} numberOfLines={1}>
+            {formatTrayTime(item.createdAt)} · {subtitle}
+          </Text>
         </View>
-
-        <View style={styles.summaryCard}>
-          <Text style={styles.summaryLabel}>今月の利用合計</Text>
-          <View style={styles.summaryAmountRow}>
-            <Text style={styles.summarySymbol}>¥</Text>
-            <Text style={styles.summaryAmount}>{monthlyTotal.toLocaleString()}</Text>
-          </View>
-          <View style={styles.summaryDivider} />
-          <AppButton
-            title="統計の詳細を見る ›"
-            onPress={onGoToStats}
-            variant="outline"
-            size="sm"
-            style={styles.summaryLinkButton}
-            textStyle={styles.summaryLinkText}
-          />
-        </View>
-
-        <TouchableOpacity 
-          style={[styles.captureButton, isAnalyzing && styles.captureButtonDisabled]} 
-          activeOpacity={0.8}
-          onPress={handleScan}
-          disabled={isAnalyzing}
-        >
-          <View style={styles.iconCircle}>
-            {isAnalyzing ? <ActivityIndicator color="white" /> : <Text style={{ fontSize: 20 }}>📷</Text>}
-          </View>
-          <View style={{ flex: 1 }}>
-            <Text style={styles.captureButtonText}>
-              {isAnalyzing ? 'AI解析中...' : 'レシートを撮影・解析'}
-            </Text>
-            {isAnalyzing && <Text style={styles.jobStatusText}>解析結果を待っています...</Text>}
-          </View>
-        </TouchableOpacity>
-
-        {/* メニューカード群：グリッド表示 */}
-        <View style={styles.gridContainer}>
-          <AppListItem
-            variant="nav"
-            onPress={onGoToHistory}
-            title="履歴一覧"
-            left={<Text style={styles.gridEmoji}>📋</Text>}
-            right={<View />}
-            style={styles.gridCard}
-          />
-          <AppListItem
-            variant="nav"
-            onPress={onGoToStats}
-            title="支出統計"
-            left={<Text style={styles.gridEmoji}>📊</Text>}
-            right={<View />}
-            style={styles.gridCard}
-          />
-          {onGoToSettlement && isWide && (
-            <AppListItem
-              variant="nav"
-              onPress={onGoToSettlement}
-              title="精算サマリー"
-              left={<Text style={styles.gridEmoji}>🤝</Text>}
-              right={<View />}
-              style={styles.gridCard}
-            />
+        <View style={[styles.trayBadge, trayBadgeStyle(display.kind)]}>
+          {display.isActive ? (
+            <ActivityIndicator size="small" color={theme.colors.text.inverse} />
+          ) : (
+            <Text style={styles.trayBadgeText}>{display.label}</Text>
           )}
         </View>
+      </View>
+    );
+  };
 
-        {/* 管理者限定メニューへのハブ導線 */}
-        {isAdmin && (
-          <View style={styles.section}>
-            <AppListItem
-              variant="nav"
-              onPress={onGoToAdminMenu}
-              title="管理者メニュー"
-              subtitle="マスタ管理・システム設定"
-              style={{ backgroundColor: theme.colors.semantic.icon.adminSettings }}
-              left={
-                <View style={[styles.settingsIconWrapper, { backgroundColor: theme.colors.semantic.icon.adminCard }]}>
-                  <Text>🛡️</Text>
-                </View>
-              }
+  const isWide = useIsWideHomeMenu();
+  const isAdmin = userRole === 'ADMIN';
+
+  return (
+    <>
+      <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
+        <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
+          <View style={[styles.header, isDevAppEnv() && styles.headerDev]}>
+            <Text style={styles.headerSubtitle}>{getAppDisplayName()}</Text>
+            <Text style={styles.headerTitle}>{getMemberMenuTitle(memberName)}</Text>
+          </View>
+
+          <View style={styles.summaryCard}>
+            <Text style={styles.summaryLabel}>今月の利用合計</Text>
+            <View style={styles.summaryAmountRow}>
+              <Text style={styles.summarySymbol}>¥</Text>
+              <Text style={styles.summaryAmount}>{monthlyTotal.toLocaleString()}</Text>
+            </View>
+            <View style={styles.summaryDivider} />
+            <AppButton
+              title="統計の詳細を見る ›"
+              onPress={onGoToStats}
+              variant="outline"
+              size="sm"
+              style={styles.summaryLinkButton}
+              textStyle={styles.summaryLinkText}
             />
           </View>
-        )}
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>最近の登録</Text>
-          {loading ? (
-            <ActivityIndicator color={theme.colors.primary} style={{ marginTop: 10 }} />
-          ) : latestReceipt ? (
+          {acceptanceMessage ? (
+            <View style={styles.acceptanceBanner}>
+              <Text style={styles.acceptanceBannerText}>{acceptanceMessage}</Text>
+            </View>
+          ) : null}
+
+          <TouchableOpacity style={styles.captureButton} activeOpacity={0.8} onPress={handleScan}>
+            <View style={styles.iconCircle}>
+              {uploadingCount > 0 ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text style={{ fontSize: 20 }}>📷</Text>
+              )}
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.captureButtonText}>レシートを撮影・解析</Text>
+              {pendingBadgeCount > 0 ? (
+                <Text style={styles.captureSubText}>
+                  解析中 {pendingBadgeCount} 件 — 続けて撮影できます
+                </Text>
+              ) : null}
+            </View>
+            {trayItems.length > 0 ? (
+              <View style={styles.captureCountBadge}>
+                <Text style={styles.captureCountBadgeText}>{trayItems.length}</Text>
+              </View>
+            ) : null}
+          </TouchableOpacity>
+
+          {trayItems.length > 0 ? (
+            <View style={styles.traySection}>
+              <Text style={styles.sectionTitle}>受付一覧</Text>
+              {trayItems.map(renderTrayItem)}
+            </View>
+          ) : null}
+
+          <View style={styles.gridContainer}>
             <AppListItem
               variant="nav"
               onPress={onGoToHistory}
-              title={latestReceipt.storeName || '店名不明'}
-              subtitle={
-                latestReceipt.date
-                  ? new Date(latestReceipt.date).toLocaleDateString('ja-JP')
-                  : '日付不明'
-              }
-              right={
-                <Text style={styles.amountText}>
-                  ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
-                </Text>
-              }
-              style={styles.latestCard}
+              title="履歴一覧"
+              left={<Text style={styles.gridEmoji}>📋</Text>}
+              right={<View />}
+              style={styles.gridCard}
             />
-          ) : (
-            <View style={[styles.latestCard, { justifyContent: 'center' }]}><Text style={styles.dateText}>表示できるデータがありません</Text></View>
-          )}
-        </View>
-      </ScrollView>
-
-      <AppModal
-        visible={showImageSourcePicker}
-        onRequestClose={() => setShowImageSourcePicker(false)}
-        title="レシート画像"
-        description="取得方法を選んでください"
-        footer={
-          <View style={styles.sourcePickerActions}>
-            <AppButton
-              title="カメラ"
-              onPress={() => {
-                setShowImageSourcePicker(false);
-                void pickImageForWeb('camera');
-              }}
+            <AppListItem
+              variant="nav"
+              onPress={onGoToStats}
+              title="支出統計"
+              left={<Text style={styles.gridEmoji}>📊</Text>}
+              right={<View />}
+              style={styles.gridCard}
             />
-            <AppButton
-              title="ギャラリー"
-              variant="secondary"
-              onPress={() => {
-                setShowImageSourcePicker(false);
-                void pickImageForWeb('library');
-              }}
-            />
-            <AppButton
-              title="キャンセル"
-              variant="outline"
-              onPress={() => setShowImageSourcePicker(false)}
-            />
+            {onGoToSettlement && isWide && (
+              <AppListItem
+                variant="nav"
+                onPress={onGoToSettlement}
+                title="精算サマリー"
+                left={<Text style={styles.gridEmoji}>🤝</Text>}
+                right={<View />}
+                style={styles.gridCard}
+              />
+            )}
           </View>
-        }
-      />
 
-    </SafeAreaView>
+          {isAdmin && (
+            <View style={styles.section}>
+              <AppListItem
+                variant="nav"
+                onPress={onGoToAdminMenu}
+                title="管理者メニュー"
+                subtitle="マスタ管理・システム設定"
+                style={{ backgroundColor: theme.colors.semantic.icon.adminSettings }}
+                left={
+                  <View
+                    style={[
+                      styles.settingsIconWrapper,
+                      { backgroundColor: theme.colors.semantic.icon.adminCard },
+                    ]}
+                  >
+                    <Text>🛡️</Text>
+                  </View>
+                }
+              />
+            </View>
+          )}
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>最近の登録</Text>
+            {loading ? (
+              <ActivityIndicator color={theme.colors.primary} style={{ marginTop: 10 }} />
+            ) : latestReceipt ? (
+              <AppListItem
+                variant="nav"
+                onPress={onGoToHistory}
+                title={latestReceipt.storeName || '店名不明'}
+                subtitle={
+                  latestReceipt.date
+                    ? new Date(latestReceipt.date).toLocaleDateString('ja-JP')
+                    : '日付不明'
+                }
+                right={
+                  <Text style={styles.amountText}>
+                    ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
+                  </Text>
+                }
+                style={styles.latestCard}
+              />
+            ) : (
+              <View style={[styles.latestCard, { justifyContent: 'center' }]}>
+                <Text style={styles.dateText}>表示できるデータがありません</Text>
+              </View>
+            )}
+          </View>
+        </ScrollView>
+
+        <AppModal
+          visible={showImageSourcePicker}
+          onRequestClose={() => setShowImageSourcePicker(false)}
+          title="レシート画像"
+          description="取得方法を選んでください"
+          footer={
+            <View style={styles.sourcePickerActions}>
+              <AppButton
+                title="カメラ"
+                onPress={() => {
+                  setShowImageSourcePicker(false);
+                  void pickImageForWeb('camera');
+                }}
+              />
+              <AppButton
+                title="ギャラリー"
+                variant="secondary"
+                onPress={() => {
+                  setShowImageSourcePicker(false);
+                  void pickImageForWeb('library');
+                }}
+              />
+              <AppButton
+                title="キャンセル"
+                variant="outline"
+                onPress={() => setShowImageSourcePicker(false)}
+              />
+            </View>
+          }
+        />
+      </SafeAreaView>
 
       {pendingCropUri ? (
         <ReceiptImageCropModal
@@ -400,7 +495,13 @@ const styles = StyleSheet.create({
   },
   headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, letterSpacing: 0.5 },
   headerTitle: { ...theme.typography.h1, color: theme.colors.text.main, marginTop: theme.spacing.xs },
-  summaryCard: { backgroundColor: theme.colors.primary, borderRadius: theme.borderRadius.lg, padding: theme.spacing.xl, marginBottom: theme.spacing.lg, elevation: 4 },
+  summaryCard: {
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.xl,
+    marginBottom: theme.spacing.lg,
+    elevation: 4,
+  },
   summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, fontWeight: '600' },
   summaryAmountRow: { flexDirection: 'row', alignItems: 'baseline', marginTop: 5 },
   summarySymbol: { color: theme.colors.text.inverse, fontSize: 20, marginRight: 4, fontWeight: 'bold' },
@@ -413,21 +514,105 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.7)',
   },
   summaryLinkText: { color: theme.colors.text.inverse, fontSize: 14, fontWeight: '600' },
-  captureButton: { backgroundColor: theme.colors.surface, borderRadius: theme.borderRadius.lg, padding: theme.spacing.lg, flexDirection: 'row', alignItems: 'center', marginBottom: theme.spacing.lg, borderWidth: 2, borderColor: theme.colors.primary, borderStyle: 'dashed' },
-  captureButtonDisabled: { borderColor: theme.colors.border, backgroundColor: theme.colors.semantic.disabled.bg },
-  iconCircle: { width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.primary, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
+  acceptanceBanner: {
+    backgroundColor: theme.colors.semantic.surplus.bg,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+    borderWidth: 1,
+    borderColor: theme.colors.semantic.surplus.border,
+  },
+  acceptanceBannerText: {
+    color: theme.colors.semantic.surplus.text,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  captureButton: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: theme.spacing.lg,
+    borderWidth: 2,
+    borderColor: theme.colors.primary,
+    borderStyle: 'dashed',
+  },
+  iconCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: theme.colors.primary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: theme.spacing.md,
+  },
   captureButtonText: { ...theme.typography.h2, color: theme.colors.primary },
-  sourcePickerActions: { gap: 10, width: '100%' },
-  jobStatusText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 2 },
-  
-  // ★ メニュー部分を Grid (flexWrap) 対応に変更
-  gridContainer: { flexDirection: 'row', flexWrap: 'wrap', gap: theme.spacing.md, marginBottom: theme.spacing.md },
+  captureSubText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 4 },
+  captureCountBadge: {
+    minWidth: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: theme.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  captureCountBadgeText: { color: theme.colors.text.inverse, fontSize: 12, fontWeight: '700' },
+  traySection: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.md,
+    marginBottom: theme.spacing.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  trayRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    paddingVertical: theme.spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  trayRowMain: { flex: 1 },
+  trayRowTitle: { ...theme.typography.body, color: theme.colors.text.main, fontWeight: '600' },
+  trayRowMeta: { ...theme.typography.caption, color: theme.colors.text.muted, marginTop: 2 },
+  trayBadge: {
+    minWidth: 72,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: theme.borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  trayBadgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: '700' },
+  trayBadgeQueued: { backgroundColor: theme.colors.text.muted },
+  trayBadgeProcessing: { backgroundColor: theme.colors.primary },
+  trayBadgeReady: { backgroundColor: '#059669' },
+  trayBadgeDuplicate: { backgroundColor: '#d97706' },
+  trayBadgeFailed: { backgroundColor: theme.colors.semantic.deficit.text },
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+  },
   gridCard: { flexGrow: 1, minWidth: 100, flexBasis: '30%' },
   gridEmoji: { fontSize: 28 },
   section: { marginTop: theme.spacing.lg },
   sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.sm },
-  settingsIconWrapper: { width: 36, height: 36, borderRadius: 18, backgroundColor: theme.colors.background, justifyContent: 'center', alignItems: 'center', marginRight: theme.spacing.md },
+  settingsIconWrapper: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: theme.colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: theme.spacing.md,
+  },
   latestCard: { marginBottom: 0 },
   amountText: { ...theme.typography.h2, color: theme.colors.primary, fontWeight: 'bold' },
   dateText: { ...theme.typography.caption, color: theme.colors.text.muted },
+  sourcePickerActions: { gap: 10, width: '100%' },
 });

--- a/frontend/src/types/receiptJob.ts
+++ b/frontend/src/types/receiptJob.ts
@@ -1,0 +1,39 @@
+export type ReceiptJobState =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'delayed'
+  | 'paused';
+
+export type ReceiptJobListItem = {
+  id: string;
+  state: ReceiptJobState;
+  imagePath: string | null;
+  createdAt: number;
+  failedReason?: string | null;
+  parsedData?: {
+    storeName: string;
+    purchaseDate: string;
+    totalAmount: number;
+    taxAmount?: number;
+    itemCount: number;
+  };
+  validation?: {
+    isSuspicious: boolean;
+    warnings: string[];
+  };
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number;
+};
+
+/** アップロード失敗など、サーバーにジョブが無いローカル行 */
+export type LocalFailedReceiptJob = {
+  id: string;
+  state: 'failed';
+  createdAt: number;
+  failedReason: string;
+  localOnly: true;
+};
+
+export type ReceiptTrayItem = ReceiptJobListItem | LocalFailedReceiptJob;

--- a/frontend/src/utils/receiptJobDisplay.test.ts
+++ b/frontend/src/utils/receiptJobDisplay.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countActiveReceiptJobs,
+  getReceiptJobDisplay,
+  getReceiptTrayItemTitle,
+  sortReceiptTrayItems,
+} from './receiptJobDisplay';
+import type { ReceiptJobListItem } from '../types/receiptJob';
+
+const baseJob = (overrides: Partial<ReceiptJobListItem>): ReceiptJobListItem => ({
+  id: '1',
+  state: 'waiting',
+  imagePath: null,
+  createdAt: 1000,
+  ...overrides,
+});
+
+describe('getReceiptJobDisplay', () => {
+  it('maps active job to 解析中', () => {
+    expect(getReceiptJobDisplay(baseJob({ state: 'active' }))).toEqual({
+      kind: 'processing',
+      label: '解析中',
+      isActive: true,
+    });
+  });
+
+  it('maps completed duplicate to 重複の疑い', () => {
+    expect(
+      getReceiptJobDisplay(baseJob({ state: 'completed', duplicateSuspected: true }))
+    ).toMatchObject({ kind: 'duplicate_suspected', label: '重複の疑い' });
+  });
+
+  it('maps completed job to 確認待ち', () => {
+    expect(getReceiptJobDisplay(baseJob({ state: 'completed' }))).toMatchObject({
+      kind: 'ready',
+      label: '確認待ち',
+    });
+  });
+});
+
+describe('getReceiptTrayItemTitle', () => {
+  it('uses store name when parsed', () => {
+    expect(
+      getReceiptTrayItemTitle(
+        baseJob({
+          state: 'completed',
+          parsedData: {
+            storeName: 'セブン-イレブン',
+            purchaseDate: '2026-01-01',
+            totalAmount: 500,
+            itemCount: 2,
+          },
+        })
+      )
+    ).toBe('セブン-イレブン');
+  });
+
+  it('labels local upload failure', () => {
+    expect(
+      getReceiptTrayItemTitle({
+        id: 'local-1',
+        state: 'failed',
+        createdAt: 1,
+        failedReason: 'network',
+        localOnly: true,
+      })
+    ).toBe('アップロード失敗');
+  });
+});
+
+describe('countActiveReceiptJobs', () => {
+  it('counts waiting and active only', () => {
+    const jobs = [
+      baseJob({ id: 'a', state: 'waiting' }),
+      baseJob({ id: 'b', state: 'active' }),
+      baseJob({ id: 'c', state: 'completed' }),
+    ];
+    expect(countActiveReceiptJobs(jobs)).toBe(2);
+  });
+});
+
+describe('sortReceiptTrayItems', () => {
+  it('sorts newest first', () => {
+    const sorted = sortReceiptTrayItems([
+      baseJob({ id: 'old', createdAt: 1 }),
+      baseJob({ id: 'new', createdAt: 99 }),
+    ]);
+    expect(sorted.map((j) => j.id)).toEqual(['new', 'old']);
+  });
+});

--- a/frontend/src/utils/receiptJobDisplay.ts
+++ b/frontend/src/utils/receiptJobDisplay.ts
@@ -1,0 +1,53 @@
+import type { ReceiptJobListItem, ReceiptJobState, ReceiptTrayItem } from '../types/receiptJob';
+
+export type ReceiptJobDisplayKind =
+  | 'queued'
+  | 'processing'
+  | 'ready'
+  | 'duplicate_suspected'
+  | 'failed';
+
+export type ReceiptJobDisplay = {
+  kind: ReceiptJobDisplayKind;
+  label: string;
+  isActive: boolean;
+};
+
+const ACTIVE_STATES: ReceiptJobState[] = ['waiting', 'active', 'delayed', 'paused'];
+
+export function getReceiptJobDisplay(job: ReceiptJobListItem): ReceiptJobDisplay {
+  if (job.state === 'failed') {
+    return { kind: 'failed', label: '失敗', isActive: false };
+  }
+
+  if (ACTIVE_STATES.includes(job.state)) {
+    const label = job.state === 'active' ? '解析中' : '待機中';
+    return { kind: job.state === 'active' ? 'processing' : 'queued', label, isActive: true };
+  }
+
+  if (job.duplicateSuspected) {
+    return { kind: 'duplicate_suspected', label: '重複の疑い', isActive: false };
+  }
+
+  return { kind: 'ready', label: '確認待ち', isActive: false };
+}
+
+export function getReceiptTrayItemTitle(item: ReceiptTrayItem): string {
+  if ('localOnly' in item && item.localOnly) {
+    return 'アップロード失敗';
+  }
+
+  const storeName = item.parsedData?.storeName?.trim();
+  if (storeName) return storeName;
+  if (item.state === 'failed') return '解析失敗';
+  if (ACTIVE_STATES.includes(item.state)) return '解析中…';
+  return 'レシート';
+}
+
+export function countActiveReceiptJobs(jobs: ReceiptJobListItem[]): number {
+  return jobs.filter((job) => ACTIVE_STATES.includes(job.state)).length;
+}
+
+export function sortReceiptTrayItems(items: ReceiptTrayItem[]): ReceiptTrayItem[] {
+  return [...items].sort((a, b) => b.createdAt - a.createdAt);
+}


### PR DESCRIPTION
## Summary
- 撮影・アップロード後に **ホームに留まり**、解析完了を待たず **連続撮影** できるように変更
- `GET /api/receipts/jobs` をポーリングし、受付一覧（待機中 / 解析中 / 確認待ち / 重複の疑い / 失敗）を表示
- 受付直後のフィードバック（バナー + 件数バッジ）、アップロード失敗はローカル行として一覧に表示
- 解析完了時の **Scan 画面への自動遷移を廃止**（取り込みは #95-4 で実装）

Closes #334

## Test plan
- [x] `cd frontend && npm test`（27 passed）
- [x] `cd backend && npm test`（32 passed）
- [ ] dev 環境: 1枚目解析中に2枚目を撮影・アップロードできる
- [ ] アップロード後ホームに留まり、受付一覧が更新される
- [ ] アップロード失敗時に一覧へ「失敗」行が出る
- [ ] Expo Go / Web 両方で確認


Made with [Cursor](https://cursor.com)