### PR TITLE
feat(frontend): [Issue #95-3] 確認トレイ UI

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -29,7 +29,8 @@ import { SplitEditorScreen } from './src/screens/SplitEditorScreen';
 import { SettlementSummaryScreen } from './src/screens/SettlementSummaryScreen';
 import { LoginScreen } from './src/screens/LoginScreen';
 import { BiometricLockScreen } from './src/screens/BiometricLockScreen';
-import { TotpSettingsScreen } from './src/screens/TotpSettingsScreen';
+import { ReceiptTrayScreen } from './src/screens/ReceiptTrayScreen';
+import { ReceiptTrayProvider } from './src/contexts/ReceiptTrayContext';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
@@ -41,7 +42,7 @@ import type { LoginResult, StoredSession } from './src/types/auth';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
-type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary' | 'totp_settings';
+type ViewType = 'main' | 'history' | 'stats' | 'category_mgr' | 'product_master' | 'receipt_scan' | 'receipt_tray' | 'prompt_editor' | 'admin_stats' | 'admin_menu' | 'split_editor' | 'settlement_summary' | 'totp_settings';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -267,7 +268,7 @@ export default function App() {
     );
   }
 
-  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary', 'totp_settings'].includes(currentView);
+  const isFullWidth = ['history', 'stats', 'category_mgr', 'product_master', 'receipt_scan', 'receipt_tray', 'prompt_editor', 'admin_stats', 'admin_menu', 'split_editor', 'settlement_summary', 'totp_settings'].includes(currentView);
 
   if (biometricLockActive && pendingSession) {
     return (
@@ -330,6 +331,13 @@ export default function App() {
         return <CategoryManagementScreen onBack={() => { fetchCategories(); setCurrentView('admin_menu'); }} currentMemberId={memberId} />;
       case 'product_master':
         return <ProductMasterScreen onBack={() => setCurrentView('admin_menu')} currentMemberId={memberId} />;
+      case 'receipt_tray':
+        return (
+          <ReceiptTrayScreen
+            enabled={memberId > 0}
+            onBack={() => setCurrentView('main')}
+          />
+        );
       case 'receipt_scan':
         return (
           <ReceiptScanScreen
@@ -396,6 +404,7 @@ export default function App() {
               onAnalysisReady={handleAnalysisReady}
               onGoToHistory={() => setCurrentView('history')}
               onGoToStats={() => setCurrentView('stats')}
+              onGoToReceiptTray={() => setCurrentView('receipt_tray')}
               onGoToSettlement={() => setCurrentView('settlement_summary')}
               onGoToAdminMenu={() => setCurrentView('admin_menu')}
               currentMemberId={memberId}
@@ -407,15 +416,19 @@ export default function App() {
     }
   };
 
+  const appBody = (
+    <ResponsiveContainer fullWidth={isFullWidth}>
+      <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+        {userToken && currentView !== 'main' ? <DevEnvironmentBanner /> : null}
+        {renderMainContent()}
+      </View>
+    </ResponsiveContainer>
+  );
+
   return (
     <SafeAreaProvider>
       <DisplayModeProvider>
-        <ResponsiveContainer fullWidth={isFullWidth}>
-          <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
-            {userToken && currentView !== 'main' ? <DevEnvironmentBanner /> : null}
-            {renderMainContent()}
-          </View>
-        </ResponsiveContainer>
+        {userToken ? <ReceiptTrayProvider>{appBody}</ReceiptTrayProvider> : appBody}
       </DisplayModeProvider>
     </SafeAreaProvider>
   );

--- a/frontend/src/components/ReceiptJobThumbnail.tsx
+++ b/frontend/src/components/ReceiptJobThumbnail.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native';
+import { theme } from '../theme';
+import { useReceiptImageSource } from '../utils/receiptImageSource';
+
+type Props = {
+  imagePath: string | null | undefined;
+  size?: number;
+};
+
+export function ReceiptJobThumbnail({ imagePath, size = 56 }: Props) {
+  const source = useReceiptImageSource(imagePath);
+
+  if (!imagePath) {
+    return (
+      <View style={[styles.placeholder, { width: size, height: size }]}>
+        <Text style={styles.placeholderEmoji}>📄</Text>
+      </View>
+    );
+  }
+
+  if (!source) {
+    return (
+      <View style={[styles.placeholder, { width: size, height: size }]}>
+        <ActivityIndicator size="small" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <Image
+      source={source}
+      style={[styles.image, { width: size, height: size }]}
+      resizeMode="cover"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  placeholder: {
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.semantic.neutral.bg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderEmoji: { fontSize: 22 },
+  image: {
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.semantic.neutral.bg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+});

--- a/frontend/src/components/ReceiptJobTrayRow.tsx
+++ b/frontend/src/components/ReceiptJobTrayRow.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ReceiptJobThumbnail } from './ReceiptJobThumbnail';
+import { theme } from '../theme';
+import type { ReceiptTrayItem } from '../types/receiptJob';
+import {
+  getReceiptTrayItemSubtitle,
+  getReceiptTrayItemTitle,
+  resolveReceiptTrayItemDisplay,
+  type ReceiptJobDisplayKind,
+} from '../utils/receiptJobDisplay';
+
+type Props = {
+  item: ReceiptTrayItem;
+};
+
+function badgeStyle(kind: ReceiptJobDisplayKind) {
+  switch (kind) {
+    case 'failed':
+      return styles.badgeFailed;
+    case 'duplicate_suspected':
+      return styles.badgeDuplicate;
+    case 'ready':
+      return styles.badgeReady;
+    case 'processing':
+      return styles.badgeProcessing;
+    default:
+      return styles.badgeQueued;
+  }
+}
+
+export function ReceiptJobTrayRow({ item }: Props) {
+  const display = resolveReceiptTrayItemDisplay(item);
+  const isDuplicate = display.kind === 'duplicate_suspected';
+  const imagePath = 'imagePath' in item ? item.imagePath : null;
+
+  return (
+    <View
+      style={[
+        styles.row,
+        isDuplicate && styles.rowDuplicate,
+        display.kind === 'failed' && styles.rowFailed,
+      ]}
+    >
+      <ReceiptJobThumbnail imagePath={imagePath} />
+      <View style={styles.main}>
+        <Text style={styles.title} numberOfLines={1}>
+          {getReceiptTrayItemTitle(item)}
+        </Text>
+        <Text style={styles.subtitle} numberOfLines={2}>
+          {getReceiptTrayItemSubtitle(item)}
+        </Text>
+        {isDuplicate ? (
+          <Text style={styles.duplicateHint}>同じ店名・日付・金額のレシートが登録済みの可能性があります</Text>
+        ) : null}
+      </View>
+      <View style={[styles.badge, badgeStyle(display.kind)]}>
+        {display.isActive ? (
+          <ActivityIndicator size="small" color={theme.colors.text.inverse} />
+        ) : (
+          <Text style={styles.badgeText}>{display.label}</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.sm,
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  rowDuplicate: {
+    backgroundColor: theme.colors.semantic.warning.bg,
+    borderColor: theme.colors.semantic.warning.border,
+  },
+  rowFailed: {
+    backgroundColor: theme.colors.semantic.deficit.bg,
+    borderColor: theme.colors.semantic.deficit.border,
+  },
+  main: { flex: 1, minWidth: 0 },
+  title: {
+    ...theme.typography.body,
+    color: theme.colors.text.main,
+    fontWeight: '700',
+  },
+  subtitle: {
+    ...theme.typography.caption,
+    color: theme.colors.text.muted,
+    marginTop: 2,
+  },
+  duplicateHint: {
+    fontSize: 11,
+    color: theme.colors.semantic.warning.text,
+    marginTop: 4,
+  },
+  badge: {
+    minWidth: 72,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: theme.borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: '700' },
+  badgeQueued: { backgroundColor: theme.colors.text.muted },
+  badgeProcessing: { backgroundColor: theme.colors.primary },
+  badgeReady: { backgroundColor: '#059669' },
+  badgeDuplicate: { backgroundColor: '#d97706' },
+  badgeFailed: { backgroundColor: theme.colors.semantic.deficit.text },
+});

--- a/frontend/src/components/ReceiptTrayPanel.tsx
+++ b/frontend/src/components/ReceiptTrayPanel.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { AppButton } from './ui';
+import { ReceiptJobTrayRow } from './ReceiptJobTrayRow';
+import { theme } from '../theme';
+import type { ReceiptTrayItem } from '../types/receiptJob';
+import { groupReceiptTrayItems } from '../utils/receiptJobDisplay';
+
+type Props = {
+  items: ReceiptTrayItem[];
+  emptyTitle?: string;
+  emptyDescription?: string;
+  maxItems?: number;
+  showSectionHeaders?: boolean;
+  onOpenFullTray?: () => void;
+};
+
+export function ReceiptTrayPanel({
+  items,
+  emptyTitle = '確認待ちのレシートはありません',
+  emptyDescription = '撮影したレシートの解析状況がここに表示されます。',
+  maxItems,
+  showSectionHeaders = true,
+  onOpenFullTray,
+}: Props) {
+  const sections = useMemo(() => groupReceiptTrayItems(items), [items]);
+  const totalCount = items.length;
+
+  const visibleSections = useMemo(() => {
+    if (maxItems == null) return sections;
+
+    let remaining = maxItems;
+    return sections
+      .map((section) => {
+        if (remaining <= 0) return { ...section, items: [] as ReceiptTrayItem[] };
+        const slice = section.items.slice(0, remaining);
+        remaining -= slice.length;
+        return { ...section, items: slice };
+      })
+      .filter((section) => section.items.length > 0);
+  }, [sections, maxItems]);
+
+  const hiddenCount = maxItems != null ? Math.max(0, totalCount - maxItems) : 0;
+
+  if (totalCount === 0) {
+    return (
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyEmoji}>📥</Text>
+        <Text style={styles.emptyTitle}>{emptyTitle}</Text>
+        <Text style={styles.emptyDescription}>{emptyDescription}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {visibleSections.map((section) => (
+        <View key={section.kind} style={styles.section}>
+          {showSectionHeaders ? (
+            <Text style={styles.sectionTitle}>
+              {section.title}
+              <Text style={styles.sectionCount}> ({section.items.length})</Text>
+            </Text>
+          ) : null}
+          <View style={styles.sectionItems}>
+            {section.items.map((item) => (
+              <ReceiptJobTrayRow key={item.id} item={item} />
+            ))}
+          </View>
+        </View>
+      ))}
+
+      {hiddenCount > 0 && onOpenFullTray ? (
+        <AppButton
+          title={`確認トレイを開く（他 ${hiddenCount} 件）`}
+          variant="outline"
+          size="sm"
+          onPress={onOpenFullTray}
+          style={styles.openFullButton}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: theme.spacing.md },
+  section: { gap: theme.spacing.sm },
+  sectionTitle: {
+    ...theme.typography.caption,
+    color: theme.colors.text.muted,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  },
+  sectionCount: { fontWeight: '600' },
+  sectionItems: { gap: theme.spacing.sm },
+  emptyState: {
+    alignItems: 'center',
+    paddingVertical: theme.spacing.xl,
+    paddingHorizontal: theme.spacing.lg,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderStyle: 'dashed',
+    backgroundColor: theme.colors.surface,
+  },
+  emptyEmoji: { fontSize: 32, marginBottom: theme.spacing.sm },
+  emptyTitle: {
+    ...theme.typography.h2,
+    color: theme.colors.text.main,
+    textAlign: 'center',
+  },
+  emptyDescription: {
+    ...theme.typography.caption,
+    color: theme.colors.text.muted,
+    textAlign: 'center',
+    marginTop: theme.spacing.xs,
+  },
+  openFullButton: { alignSelf: 'stretch' },
+});

--- a/frontend/src/contexts/ReceiptTrayContext.tsx
+++ b/frontend/src/contexts/ReceiptTrayContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { LocalFailedReceiptJob } from '../types/receiptJob';
+
+type ReceiptTrayContextValue = {
+  localFailedJobs: LocalFailedReceiptJob[];
+  addLocalFailedJob: (reason: string) => void;
+};
+
+const ReceiptTrayContext = createContext<ReceiptTrayContextValue | null>(null);
+
+export function ReceiptTrayProvider({ children }: { children: React.ReactNode }) {
+  const [localFailedJobs, setLocalFailedJobs] = useState<LocalFailedReceiptJob[]>([]);
+
+  const addLocalFailedJob = useCallback((reason: string) => {
+    setLocalFailedJobs((prev) => [
+      {
+        id: `local-failed-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        state: 'failed',
+        createdAt: Date.now(),
+        failedReason: reason,
+        localOnly: true,
+      },
+      ...prev,
+    ]);
+  }, []);
+
+  const value = useMemo(
+    () => ({ localFailedJobs, addLocalFailedJob }),
+    [localFailedJobs, addLocalFailedJob]
+  );
+
+  return <ReceiptTrayContext.Provider value={value}>{children}</ReceiptTrayContext.Provider>;
+}
+
+export function useReceiptTrayLocalFailures(): ReceiptTrayContextValue {
+  const context = useContext(ReceiptTrayContext);
+  if (!context) {
+    throw new Error('useReceiptTrayLocalFailures must be used within ReceiptTrayProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/useReceiptJobs.ts
+++ b/frontend/src/hooks/useReceiptJobs.ts
@@ -5,26 +5,34 @@ import type { ReceiptJobListItem } from '../types/receiptJob';
 
 const POLL_INTERVAL_MS = 2000;
 
+type RefreshOptions = {
+  userInitiated?: boolean;
+};
+
 export function useReceiptJobs(enabled: boolean) {
   const [jobs, setJobs] = useState<ReceiptJobListItem[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const jobsRef = useRef(jobs);
   jobsRef.current = jobs;
 
-  const refresh = useCallback(async () => {
-    if (!enabled) return;
-    setRefreshing(true);
-    try {
-      const res = await apiClient.get('/receipts/jobs');
-      if (res.data?.success && Array.isArray(res.data.data)) {
-        setJobs(res.data.data as ReceiptJobListItem[]);
+  const refresh = useCallback(
+    async (options?: RefreshOptions) => {
+      if (!enabled) return;
+      const userInitiated = options?.userInitiated ?? false;
+      if (userInitiated) setRefreshing(true);
+      try {
+        const res = await apiClient.get('/receipts/jobs');
+        if (res.data?.success && Array.isArray(res.data.data)) {
+          setJobs(res.data.data as ReceiptJobListItem[]);
+        }
+      } catch (error) {
+        console.error('[ReceiptJobs] refresh failed:', error);
+      } finally {
+        if (userInitiated) setRefreshing(false);
       }
-    } catch (error) {
-      console.error('[ReceiptJobs] refresh failed:', error);
-    } finally {
-      setRefreshing(false);
-    }
-  }, [enabled]);
+    },
+    [enabled]
+  );
 
   useEffect(() => {
     if (!enabled) {

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -13,10 +13,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
 import { AppButton, AppListItem, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
+import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
 import { getAppDisplayName, getMemberMenuTitle, isDevAppEnv } from '../config/appEnv';
+import { useReceiptTrayLocalFailures } from '../contexts/ReceiptTrayContext';
 import { useReceiptJobs } from '../hooks/useReceiptJobs';
 import { theme } from '../theme';
-import type { LocalFailedReceiptJob, ReceiptTrayItem } from '../types/receiptJob';
 import apiClient from '../utils/apiClient';
 import { buildReceiptUploadFormData } from '../utils/receiptUploadFormData';
 import {
@@ -26,11 +27,7 @@ import {
   clearPendingCropUri,
 } from '../utils/webImageFileRegistry';
 import { showAlert } from '../utils/alertMessage';
-import {
-  getReceiptJobDisplay,
-  getReceiptTrayItemTitle,
-  sortReceiptTrayItems,
-} from '../utils/receiptJobDisplay';
+import { countReceiptTrayItems, sortReceiptTrayItems } from '../utils/receiptJobDisplay';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 
@@ -38,6 +35,7 @@ interface HomeScreenProps {
   onAnalysisReady: (data: any) => void;
   onGoToHistory: () => void;
   onGoToStats: () => void;
+  onGoToReceiptTray: () => void;
   onGoToSettlement?: () => void;
   onGoToAdminMenu?: () => void;
   currentMemberId: number;
@@ -46,28 +44,7 @@ interface HomeScreenProps {
 }
 
 const ACCEPTANCE_MESSAGE_MS = 3000;
-
-function formatTrayTime(createdAt: number): string {
-  return new Date(createdAt).toLocaleTimeString('ja-JP', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-function trayBadgeStyle(kind: ReturnType<typeof getReceiptJobDisplay>['kind']) {
-  switch (kind) {
-    case 'failed':
-      return styles.trayBadgeFailed;
-    case 'duplicate_suspected':
-      return styles.trayBadgeDuplicate;
-    case 'ready':
-      return styles.trayBadgeReady;
-    case 'processing':
-      return styles.trayBadgeProcessing;
-    default:
-      return styles.trayBadgeQueued;
-  }
-}
+const HOME_TRAY_PREVIEW_LIMIT = 2;
 
 /**
  * ホーム画面（ダッシュボード）
@@ -76,6 +53,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   onAnalysisReady: _onAnalysisReady,
   onGoToHistory,
   onGoToStats,
+  onGoToReceiptTray,
   onGoToSettlement,
   onGoToAdminMenu,
   currentMemberId,
@@ -86,19 +64,19 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const [monthlyTotal, setMonthlyTotal] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [uploadingCount, setUploadingCount] = useState(0);
-  const [localFailedJobs, setLocalFailedJobs] = useState<LocalFailedReceiptJob[]>([]);
   const [acceptanceMessage, setAcceptanceMessage] = useState<string | null>(null);
   const [pendingCropUri, setPendingCropUri] = useState<string | null>(null);
   const [showImageSourcePicker, setShowImageSourcePicker] = useState(false);
 
   const { jobs, activeCount, refresh: refreshJobs } = useReceiptJobs(currentMemberId > 0);
+  const { localFailedJobs, addLocalFailedJob } = useReceiptTrayLocalFailures();
 
   const trayItems = useMemo(
     () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
     [jobs, localFailedJobs]
   );
 
-  const pendingBadgeCount = activeCount + uploadingCount;
+  const trayItemCount = countReceiptTrayItems(trayItems);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -146,18 +124,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     setAcceptanceMessage(message);
   }, []);
 
-  const registerLocalUploadFailure = useCallback((reason: string) => {
-    setLocalFailedJobs((prev) => [
-      {
-        id: `local-failed-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-        state: 'failed',
-        createdAt: Date.now(),
-        failedReason: reason,
-        localOnly: true,
-      },
-      ...prev,
-    ]);
-  }, []);
+  const registerLocalUploadFailure = useCallback(
+    (reason: string) => {
+      addLocalFailedJob(reason);
+    },
+    [addLocalFailedJob]
+  );
 
   const uploadReceiptImage = async (imageUri: string) => {
     setUploadingCount((count) => count + 1);
@@ -260,41 +232,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     setPendingCropUri(null);
   };
 
-  const renderTrayItem = (item: ReceiptTrayItem) => {
-    const display =
-      'localOnly' in item && item.localOnly
-        ? { kind: 'failed' as const, label: '失敗', isActive: false }
-        : getReceiptJobDisplay(item);
-    const subtitle =
-      'localOnly' in item && item.localOnly
-        ? item.failedReason
-        : item.state === 'failed'
-          ? item.failedReason || '解析に失敗しました'
-          : item.parsedData
-            ? `¥${Math.round(item.parsedData.totalAmount || 0).toLocaleString()}`
-            : display.label;
-
-    return (
-      <View key={item.id} style={styles.trayRow}>
-        <View style={styles.trayRowMain}>
-          <Text style={styles.trayRowTitle} numberOfLines={1}>
-            {getReceiptTrayItemTitle(item)}
-          </Text>
-          <Text style={styles.trayRowMeta} numberOfLines={1}>
-            {formatTrayTime(item.createdAt)} · {subtitle}
-          </Text>
-        </View>
-        <View style={[styles.trayBadge, trayBadgeStyle(display.kind)]}>
-          {display.isActive ? (
-            <ActivityIndicator size="small" color={theme.colors.text.inverse} />
-          ) : (
-            <Text style={styles.trayBadgeText}>{display.label}</Text>
-          )}
-        </View>
-      </View>
-    );
-  };
-
+  const pendingBadgeCount = activeCount + uploadingCount;
   const isWide = useIsWideHomeMenu();
   const isAdmin = userRole === 'ADMIN';
 
@@ -346,21 +284,50 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                 </Text>
               ) : null}
             </View>
-            {trayItems.length > 0 ? (
+            {trayItemCount > 0 ? (
               <View style={styles.captureCountBadge}>
-                <Text style={styles.captureCountBadgeText}>{trayItems.length}</Text>
+                <Text style={styles.captureCountBadgeText}>{trayItemCount}</Text>
               </View>
             ) : null}
           </TouchableOpacity>
 
-          {trayItems.length > 0 ? (
-            <View style={styles.traySection}>
-              <Text style={styles.sectionTitle}>受付一覧</Text>
-              {trayItems.map(renderTrayItem)}
+          <View style={styles.traySection}>
+            <View style={styles.traySectionHeader}>
+              <Text style={styles.sectionTitle}>確認トレイ</Text>
+              {trayItemCount > 0 ? (
+                <TouchableOpacity onPress={onGoToReceiptTray}>
+                  <Text style={styles.trayOpenLink}>すべて見る</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
-          ) : null}
+            <ReceiptTrayPanel
+              items={trayItems}
+              maxItems={HOME_TRAY_PREVIEW_LIMIT}
+              showSectionHeaders={trayItemCount > 0}
+              onOpenFullTray={onGoToReceiptTray}
+              emptyTitle="確認待ちのレシートはありません"
+              emptyDescription="撮影したレシートの解析状況がここに表示されます。"
+            />
+          </View>
 
           <View style={styles.gridContainer}>
+            <AppListItem
+              variant="nav"
+              onPress={onGoToReceiptTray}
+              title="確認トレイ"
+              subtitle={trayItemCount > 0 ? `${trayItemCount} 件の受付` : '解析状況を確認'}
+              left={<Text style={styles.gridEmoji}>📥</Text>}
+              right={
+                trayItemCount > 0 ? (
+                  <View style={styles.gridCountBadge}>
+                    <Text style={styles.gridCountBadgeText}>{trayItemCount}</Text>
+                  </View>
+                ) : (
+                  <View />
+                )
+              }
+              style={styles.gridCard}
+            />
             <AppListItem
               variant="nav"
               onPress={onGoToHistory}
@@ -567,31 +534,27 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: theme.colors.border,
   },
-  trayRow: {
+  traySectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: theme.spacing.sm,
-    paddingVertical: theme.spacing.sm,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
+    justifyContent: 'space-between',
+    marginBottom: theme.spacing.sm,
   },
-  trayRowMain: { flex: 1 },
-  trayRowTitle: { ...theme.typography.body, color: theme.colors.text.main, fontWeight: '600' },
-  trayRowMeta: { ...theme.typography.caption, color: theme.colors.text.muted, marginTop: 2 },
-  trayBadge: {
-    minWidth: 72,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
-    borderRadius: theme.borderRadius.sm,
+  trayOpenLink: {
+    color: theme.colors.primary,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  gridCountBadge: {
+    minWidth: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: theme.colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: 6,
   },
-  trayBadgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: '700' },
-  trayBadgeQueued: { backgroundColor: theme.colors.text.muted },
-  trayBadgeProcessing: { backgroundColor: theme.colors.primary },
-  trayBadgeReady: { backgroundColor: '#059669' },
-  trayBadgeDuplicate: { backgroundColor: '#d97706' },
-  trayBadgeFailed: { backgroundColor: theme.colors.semantic.deficit.text },
+  gridCountBadgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: '700' },
   gridContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/frontend/src/screens/ReceiptTrayScreen.tsx
+++ b/frontend/src/screens/ReceiptTrayScreen.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { AppBackButton } from '../components/ui';
+import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
+import { useReceiptTrayLocalFailures } from '../contexts/ReceiptTrayContext';
+import { useReceiptJobs } from '../hooks/useReceiptJobs';
+import { theme } from '../theme';
+import { countReceiptTrayItems, sortReceiptTrayItems } from '../utils/receiptJobDisplay';
+
+type Props = {
+  onBack: () => void;
+  enabled: boolean;
+};
+
+export function ReceiptTrayScreen({ onBack, enabled }: Props) {
+  const { jobs, refreshing, refresh } = useReceiptJobs(enabled);
+  const { localFailedJobs } = useReceiptTrayLocalFailures();
+
+  const trayItems = useMemo(
+    () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
+    [jobs, localFailedJobs]
+  );
+
+  const totalCount = countReceiptTrayItems(trayItems);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
+      <View style={styles.header}>
+        <AppBackButton onPress={onBack} />
+        <View style={styles.headerText}>
+          <Text style={styles.title}>確認トレイ</Text>
+          <Text style={styles.subtitle}>
+            {totalCount > 0 ? `${totalCount} 件の受付` : '受付中のレシートはありません'}
+          </Text>
+        </View>
+        {totalCount > 0 ? (
+          <View style={styles.countBadge}>
+            <Text style={styles.countBadgeText}>{totalCount}</Text>
+          </View>
+        ) : (
+          <View style={styles.headerSpacer} />
+        )}
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => void refresh({ userInitiated: true })}
+            colors={[theme.colors.primary]}
+            tintColor={theme.colors.primary}
+          />
+        }
+      >
+        <ReceiptTrayPanel
+          items={trayItems}
+          showSectionHeaders
+          emptyTitle="確認待ちのレシートはありません"
+          emptyDescription="ホームからレシートを撮影すると、解析状況がここに表示されます。"
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.background },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  headerText: { flex: 1 },
+  title: { ...theme.typography.h1, color: theme.colors.text.main, fontSize: 22 },
+  subtitle: { ...theme.typography.caption, color: theme.colors.text.muted, marginTop: 2 },
+  countBadge: {
+    minWidth: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: theme.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 10,
+  },
+  countBadgeText: { color: theme.colors.text.inverse, fontWeight: '700' },
+  headerSpacer: { width: 32 },
+  scrollContent: {
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+});

--- a/frontend/src/utils/receiptJobDisplay.test.ts
+++ b/frontend/src/utils/receiptJobDisplay.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   countActiveReceiptJobs,
+  countReceiptTrayItems,
+  formatReceiptTrayDateTime,
   getReceiptJobDisplay,
+  getReceiptTrayItemSubtitle,
   getReceiptTrayItemTitle,
+  groupReceiptTrayItems,
   sortReceiptTrayItems,
 } from './receiptJobDisplay';
 import type { ReceiptJobListItem } from '../types/receiptJob';
@@ -86,5 +90,57 @@ describe('sortReceiptTrayItems', () => {
       baseJob({ id: 'new', createdAt: 99 }),
     ]);
     expect(sorted.map((j) => j.id)).toEqual(['new', 'old']);
+  });
+});
+
+describe('groupReceiptTrayItems', () => {
+  it('groups by display kind in fixed order', () => {
+    const sections = groupReceiptTrayItems([
+      baseJob({ id: 'ready', state: 'completed', createdAt: 3 }),
+      baseJob({ id: 'active', state: 'active', createdAt: 2 }),
+      baseJob({
+        id: 'dup',
+        state: 'completed',
+        duplicateSuspected: true,
+        createdAt: 1,
+      }),
+    ]);
+
+    expect(sections.map((s) => s.kind)).toEqual(['processing', 'ready', 'duplicate_suspected']);
+    expect(sections[0].items.map((i) => i.id)).toEqual(['active']);
+    expect(sections[2].items.map((i) => i.id)).toEqual(['dup']);
+  });
+});
+
+describe('getReceiptTrayItemSubtitle', () => {
+  it('includes amount and existing receipt id for duplicate', () => {
+    const subtitle = getReceiptTrayItemSubtitle(
+      baseJob({
+        state: 'completed',
+        createdAt: new Date('2026-06-04T12:00:00').getTime(),
+        duplicateSuspected: true,
+        existingReceiptId: 42,
+        parsedData: {
+          storeName: 'テスト店',
+          purchaseDate: '2026-06-04',
+          totalAmount: 980,
+          itemCount: 1,
+        },
+      })
+    );
+    expect(subtitle).toContain('¥980');
+    expect(subtitle).toContain('既存 #42');
+  });
+});
+
+describe('countReceiptTrayItems', () => {
+  it('returns item count', () => {
+    expect(countReceiptTrayItems([baseJob({ id: 'a' }), baseJob({ id: 'b' })])).toBe(2);
+  });
+});
+
+describe('formatReceiptTrayDateTime', () => {
+  it('formats ja-JP date time', () => {
+    expect(formatReceiptTrayDateTime(new Date('2026-06-04T15:30:00').getTime())).toMatch(/6\/4/);
   });
 });

--- a/frontend/src/utils/receiptJobDisplay.ts
+++ b/frontend/src/utils/receiptJobDisplay.ts
@@ -51,3 +51,76 @@ export function countActiveReceiptJobs(jobs: ReceiptJobListItem[]): number {
 export function sortReceiptTrayItems(items: ReceiptTrayItem[]): ReceiptTrayItem[] {
   return [...items].sort((a, b) => b.createdAt - a.createdAt);
 }
+
+export function formatReceiptTrayDateTime(createdAt: number): string {
+  return new Date(createdAt).toLocaleString('ja-JP', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function getReceiptTrayItemSubtitle(item: ReceiptTrayItem): string {
+  if ('localOnly' in item && item.localOnly) {
+    return item.failedReason;
+  }
+
+  if (item.state === 'failed') {
+    return item.failedReason || '解析に失敗しました';
+  }
+
+  const parts: string[] = [formatReceiptTrayDateTime(item.createdAt)];
+
+  if (item.parsedData?.totalAmount != null) {
+    parts.push(`¥${Math.round(item.parsedData.totalAmount).toLocaleString()}`);
+  }
+
+  if ('existingReceiptId' in item && item.existingReceiptId) {
+    parts.push(`既存 #${item.existingReceiptId}`);
+  }
+
+  return parts.join(' · ');
+}
+
+export function resolveReceiptTrayItemDisplay(item: ReceiptTrayItem): ReceiptJobDisplay {
+  if ('localOnly' in item && item.localOnly) {
+    return { kind: 'failed', label: '失敗', isActive: false };
+  }
+  return getReceiptJobDisplay(item);
+}
+
+export type ReceiptTraySection = {
+  title: string;
+  kind: ReceiptJobDisplayKind;
+  items: ReceiptTrayItem[];
+};
+
+const TRAY_SECTIONS: { kind: ReceiptJobDisplayKind; title: string }[] = [
+  { kind: 'processing', title: '解析中' },
+  { kind: 'queued', title: '待機中' },
+  { kind: 'ready', title: '確認待ち' },
+  { kind: 'duplicate_suspected', title: '重複の疑い' },
+  { kind: 'failed', title: '失敗' },
+];
+
+/** 状態別セクション（表示順固定） */
+export function groupReceiptTrayItems(items: ReceiptTrayItem[]): ReceiptTraySection[] {
+  const buckets = new Map<ReceiptJobDisplayKind, ReceiptTrayItem[]>(
+    TRAY_SECTIONS.map((section) => [section.kind, []])
+  );
+
+  for (const item of sortReceiptTrayItems(items)) {
+    const display = resolveReceiptTrayItemDisplay(item);
+    buckets.get(display.kind)?.push(item);
+  }
+
+  return TRAY_SECTIONS.map((section) => ({
+    ...section,
+    items: buckets.get(section.kind) ?? [],
+  })).filter((section) => section.items.length > 0);
+}
+
+export function countReceiptTrayItems(items: ReceiptTrayItem[]): number {
+  return items.length;
+}


### PR DESCRIPTION
## Summary
- **確認トレイ画面**（`ReceiptTrayScreen`）を追加 — プルリフレッシュ + 自動ポーリング
- 各項目に **サムネ・店名・金額・受付時刻・状態バッジ** を表示（`ReceiptJobTrayRow`）
- **状態別セクション**（解析中 / 待機中 / 確認待ち / 重複の疑い / 失敗）
- **重複の疑い** は警告色の行背景 + 説明文 + 既存レシート ID 表示
- ホームに **確認トレイプレビュー**（最大2件）・件数バッジ・「すべて見る」導線
- アップロード失敗のローカル行を `ReceiptTrayContext` でトレイ画面と共有

Closes #335

## Test plan
- [x] `cd frontend && npm test`（31 passed）
- [ ] dev: 複数ジョブが状態別に一覧表示される
- [ ] 解析完了後に一覧が自動更新される
- [ ] 重複候補行が通常行と視覚的に区別できる
- [ ] プルリフレッシュで最新状態を取得できる
- [ ] 空状態が表示される（ジョブなし時）
- [ ] Expo Go / Web 両方で確認


Made with [Cursor](https://cursor.com)