### PR TITLE
feat: [Issue #95-4] トレイ Scan 連携・破棄

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -465,6 +465,43 @@ describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {
     expect(res.body.data.existingReceiptId).toBeGreaterThan(0);
   });
 
+  it('DELETE /receipts/jobs/:jobId removes owned job', async () => {
+    clearMockReceiptJobs();
+    registerMockReceiptJob('discard-me', {
+      memberId: 1,
+      familyGroupId: 1,
+      imagePath: 'uploads/discard-me.webp',
+    });
+
+    const token = await loginAsTestMember(app, 1);
+    const del = await request(app)
+      .delete('/api/receipts/jobs/discard-me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(del.status).toBe(200);
+    expect(del.body.success).toBe(true);
+
+    const list = await request(app)
+      .get('/api/receipts/jobs')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(list.body.data.find((j: { id: string }) => j.id === 'discard-me')).toBeUndefined();
+  });
+
+  it('DELETE /receipts/jobs rejects cross-member job', async () => {
+    registerMockReceiptJob('other-member-job', {
+      memberId: 2,
+      familyGroupId: 1,
+    });
+
+    const token = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .delete('/api/receipts/jobs/other-member-job')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
   it('rejects unauthenticated upload image access', async () => {
     const res = await request(app).get('/api/uploads/tenant-isolation-fixture.webp');
     expect(res.status).toBe(401);

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -5,7 +5,7 @@ import { AppError } from '../utils/appError';
 import { getCleanText } from '../utils/normalizer';
 import { receiptQueue } from '../queues/receiptQueue';
 import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService';
-import { enrichCompletedJobPayload, listReceiptJobsForMember } from '../services/receiptJobService'; 
+import { enrichCompletedJobPayload, listReceiptJobsForMember, discardReceiptJobForMember, removeReceiptJobAfterCommit } from '../services/receiptJobService'; 
 import { getFamilyGroupId, getMemberId } from '../utils/context';
 import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
 import { calcItemLineTotal } from '../utils/itemLineTotal';
@@ -59,6 +59,27 @@ export const getReceiptJobs = async (_req: Request, res: Response, next: NextFun
 };
 
 /**
+ * [Issue #95-4] 未取り込み解析ジョブの破棄
+ */
+export const discardReceiptJob = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
+  try {
+    const familyGroupId = getFamilyGroupId();
+    const memberId = getMemberId();
+    if (!memberId) {
+      throw new AppError('メンバーIDが指定されていません。', 400);
+    }
+
+    await discardReceiptJobForMember(
+      getRouteParam(req, 'jobId'),
+      familyGroupId,
+      Number(memberId)
+    );
+
+    res.status(200).json({ success: true, message: 'Discarded' });
+  } catch (error) { next(error); }
+};
+
+/**
  * カテゴリ一覧取得
  */
 export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
@@ -98,7 +119,7 @@ export const commitReceipt = async (req: Request, res: Response, next: NextFunct
   try {
     const memberId = getMemberId();
     const familyGroupId = getFamilyGroupId();
-    const { parsedData, imagePath, validation } = req.body;
+    const { parsedData, imagePath, validation, jobId } = req.body;
 
     if (!parsedData || !imagePath) {
       throw new AppError('必要なデータが不足しています。', 400);
@@ -117,6 +138,12 @@ export const commitReceipt = async (req: Request, res: Response, next: NextFunct
       validation?.isSuspicious || false,
       validation?.warnings || []
     );
+
+    if (jobId) {
+      await removeReceiptJobAfterCommit(String(jobId), familyGroupId, Number(memberId)).catch(() => {
+        // 既に破棄済み等は無視（保存は成功している）
+      });
+    }
 
     res.status(201).json({ success: true, data: result });
   } catch (error: any) { 

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -21,6 +21,7 @@ import {
   getMonthlyStats,
   getJobStatus,
   getReceiptJobs,
+  discardReceiptJob,
   getAdvancedStats,
   commitReceipt,
   getFamilyMembers,
@@ -97,6 +98,7 @@ router.get('/uploads/:filename', serveReceiptImage);
 
 router.get('/receipts', getReceipts);
 router.get('/receipts/jobs', getReceiptJobs);
+router.delete('/receipts/jobs/:jobId', discardReceiptJob);
 router.get('/receipts/latest', getLatestReceipt);
 router.get('/receipts/status/:jobId', getJobStatus);
 router.get('/stats/monthly', getMonthlyStats);

--- a/backend/src/services/receiptJobService.ts
+++ b/backend/src/services/receiptJobService.ts
@@ -1,6 +1,10 @@
 import type { Job } from 'bullmq';
+import fs from 'fs/promises';
+import path from 'path';
 import { receiptQueue } from '../queues/receiptQueue';
 import { checkDuplicateReceipt } from './duplicateReceiptService';
+import { prisma } from '../utils/prismaClient';
+import { AppError } from '../utils/appError';
 
 const LIST_JOB_STATES = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused'] as const;
 
@@ -140,4 +144,69 @@ export async function enrichCompletedJobPayload(
     duplicateSuspected: duplicate.duplicateSuspected,
     existingReceiptId: duplicate.existingReceiptId,
   };
+}
+
+async function getOwnedReceiptJob(
+  jobId: string,
+  familyGroupId: number,
+  memberId: number
+): Promise<Job> {
+  const job = await receiptQueue.getJob(jobId);
+  if (!job) {
+    throw new AppError('ジョブが見つかりません。', 404);
+  }
+
+  const jobFamilyGroupId = Number(job.data?.familyGroupId);
+  const jobMemberId = Number(job.data?.memberId);
+  if (
+    !jobFamilyGroupId ||
+    jobFamilyGroupId !== familyGroupId ||
+    jobMemberId !== memberId
+  ) {
+    throw new AppError('ジョブが見つかりません。', 404);
+  }
+
+  return job;
+}
+
+async function deletePendingJobImage(
+  imagePath: string | undefined,
+  familyGroupId: number
+): Promise<void> {
+  if (!imagePath || typeof imagePath !== 'string') return;
+
+  const normalized = imagePath.replace(/\\/g, '/');
+  const saved = await prisma.receipt.findFirst({
+    where: { familyGroupId, imagePath: normalized },
+    select: { id: true },
+  });
+  if (saved) return;
+
+  try {
+    await fs.unlink(path.resolve(normalized));
+  } catch {
+    // ファイルが無い場合は無視
+  }
+}
+
+/** commit 成功後: キューから除去（画像は保存済みのため残す） */
+export async function removeReceiptJobAfterCommit(
+  jobId: string,
+  familyGroupId: number,
+  memberId: number
+): Promise<void> {
+  const job = await getOwnedReceiptJob(jobId, familyGroupId, memberId);
+  await job.remove();
+}
+
+/** 未取り込みジョブの破棄（キュー除去 + 未保存画像の削除） */
+export async function discardReceiptJobForMember(
+  jobId: string,
+  familyGroupId: number,
+  memberId: number
+): Promise<void> {
+  const job = await getOwnedReceiptJob(jobId, familyGroupId, memberId);
+  const imagePath = job.data?.imagePath;
+  await job.remove();
+  await deletePendingJobImage(imagePath, familyGroupId);
 }

--- a/backend/src/test/mockJobStore.ts
+++ b/backend/src/test/mockJobStore.ts
@@ -5,6 +5,7 @@ export type MockReceiptJob = {
   failedReason: string | null;
   timestamp: number;
   getState: () => Promise<string>;
+  remove: () => Promise<void>;
 };
 
 export const mockReceiptJobs = new Map<string, MockReceiptJob>();
@@ -27,6 +28,9 @@ export function registerMockReceiptJob(
     failedReason: options?.failedReason ?? null,
     timestamp: options?.timestamp ?? Date.now(),
     getState: async () => state,
+    remove: async () => {
+      mockReceiptJobs.delete(id);
+    },
   });
 }
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   StyleSheet,
   View,
@@ -31,6 +31,7 @@ import { LoginScreen } from './src/screens/LoginScreen';
 import { BiometricLockScreen } from './src/screens/BiometricLockScreen';
 import { ReceiptTrayScreen } from './src/screens/ReceiptTrayScreen';
 import { ReceiptTrayProvider } from './src/contexts/ReceiptTrayContext';
+import type { ReceiptScanInitialData } from './src/types/receiptScan';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
@@ -63,8 +64,10 @@ export default function App() {
   const [resultData, setResultData] = useState<any>(null);
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
+  const [scanReturnView, setScanReturnView] = useState<ViewType>('main');
 
   const [targetReceipt, setTargetReceipt] = useState<any>(null);
+  const refreshTrayRef = useRef<(() => Promise<void>) | null>(null);
 
   const applySession = useCallback((session: StoredSession) => {
     setUserToken(session.token);
@@ -256,9 +259,30 @@ export default function App() {
   }, [currentView, resultData, isReady, userToken]);
 
   const handleAnalysisReady = (data: any) => {
+    setScanReturnView('main');
     setResultData(data);
     setCurrentView('receipt_scan');
   };
+
+  const handleOpenScanFromTray = useCallback(
+    (data: ReceiptScanInitialData) => {
+      setScanReturnView(currentView === 'receipt_tray' ? 'receipt_tray' : 'main');
+      setResultData(data);
+      setCurrentView('receipt_scan');
+    },
+    [currentView]
+  );
+
+  const handleScanClose = useCallback(
+    (options?: { refreshTray?: boolean }) => {
+      if (options?.refreshTray) {
+        void refreshTrayRef.current?.();
+      }
+      setResultData(null);
+      setCurrentView(scanReturnView);
+    },
+    [scanReturnView]
+  );
 
   if (!isReady) {
     return (
@@ -332,25 +356,14 @@ export default function App() {
       case 'product_master':
         return <ProductMasterScreen onBack={() => setCurrentView('admin_menu')} currentMemberId={memberId} />;
       case 'receipt_tray':
-        return (
-          <ReceiptTrayScreen
-            enabled={memberId > 0}
-            onBack={() => setCurrentView('main')}
-          />
-        );
+        return <ReceiptTrayScreen onBack={() => setCurrentView('main')} />;
       case 'receipt_scan':
         return (
           <ReceiptScanScreen
             initialData={resultData}
             categories={categories}
-            onSuccess={() => {
-              setResultData(null);
-              setCurrentView('main');
-            }}
-            onCancel={() => {
-              setResultData(null);
-              setCurrentView('main');
-            }}
+            onSuccess={() => handleScanClose({ refreshTray: true })}
+            onCancel={() => handleScanClose()}
           />
         );
       case 'prompt_editor':
@@ -428,7 +441,19 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <DisplayModeProvider>
-        {userToken ? <ReceiptTrayProvider>{appBody}</ReceiptTrayProvider> : appBody}
+        {userToken && currentMemberId ? (
+          <ReceiptTrayProvider
+            enabled
+            onOpenScan={handleOpenScanFromTray}
+            onRegisterRefresh={(refresh) => {
+              refreshTrayRef.current = () => refresh();
+            }}
+          >
+            {appBody}
+          </ReceiptTrayProvider>
+        ) : (
+          appBody
+        )}
       </DisplayModeProvider>
     </SafeAreaProvider>
   );

--- a/frontend/src/components/ReceiptJobTrayRow.tsx
+++ b/frontend/src/components/ReceiptJobTrayRow.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { ReceiptJobThumbnail } from './ReceiptJobThumbnail';
+import { AppButton } from './ui';
 import { theme } from '../theme';
 import type { ReceiptTrayItem } from '../types/receiptJob';
 import {
@@ -12,6 +20,10 @@ import {
 
 type Props = {
   item: ReceiptTrayItem;
+  onPress?: () => void;
+  onDiscard?: () => void;
+  canOpen?: boolean;
+  canDiscard?: boolean;
 };
 
 function badgeStyle(kind: ReceiptJobDisplayKind) {
@@ -29,19 +41,19 @@ function badgeStyle(kind: ReceiptJobDisplayKind) {
   }
 }
 
-export function ReceiptJobTrayRow({ item }: Props) {
+export function ReceiptJobTrayRow({
+  item,
+  onPress,
+  onDiscard,
+  canOpen = false,
+  canDiscard = false,
+}: Props) {
   const display = resolveReceiptTrayItemDisplay(item);
   const isDuplicate = display.kind === 'duplicate_suspected';
   const imagePath = 'imagePath' in item ? item.imagePath : null;
 
-  return (
-    <View
-      style={[
-        styles.row,
-        isDuplicate && styles.rowDuplicate,
-        display.kind === 'failed' && styles.rowFailed,
-      ]}
-    >
+  const content = (
+    <>
       <ReceiptJobThumbnail imagePath={imagePath} />
       <View style={styles.main}>
         <Text style={styles.title} numberOfLines={1}>
@@ -51,8 +63,11 @@ export function ReceiptJobTrayRow({ item }: Props) {
           {getReceiptTrayItemSubtitle(item)}
         </Text>
         {isDuplicate ? (
-          <Text style={styles.duplicateHint}>同じ店名・日付・金額のレシートが登録済みの可能性があります</Text>
+          <Text style={styles.duplicateHint}>
+            同じ店名・日付・金額のレシートが登録済みの可能性があります
+          </Text>
         ) : null}
+        {canOpen ? <Text style={styles.openHint}>タップして内容を確認</Text> : null}
       </View>
       <View style={[styles.badge, badgeStyle(display.kind)]}>
         {display.isActive ? (
@@ -61,30 +76,61 @@ export function ReceiptJobTrayRow({ item }: Props) {
           <Text style={styles.badgeText}>{display.label}</Text>
         )}
       </View>
+    </>
+  );
+
+  return (
+    <View
+      style={[
+        styles.wrapper,
+        isDuplicate && styles.wrapperDuplicate,
+        display.kind === 'failed' && styles.wrapperFailed,
+      ]}
+    >
+      {canOpen && onPress ? (
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={onPress}
+        >
+          {content}
+        </Pressable>
+      ) : (
+        <View style={styles.row}>{content}</View>
+      )}
+
+      {canDiscard && onDiscard ? (
+        <View style={styles.actions}>
+          <AppButton title="破棄" variant="outline" size="sm" onPress={onDiscard} />
+        </View>
+      ) : null}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    overflow: 'hidden',
+  },
+  wrapperDuplicate: {
+    backgroundColor: theme.colors.semantic.warning.bg,
+    borderColor: theme.colors.semantic.warning.border,
+  },
+  wrapperFailed: {
+    backgroundColor: theme.colors.semantic.deficit.bg,
+    borderColor: theme.colors.semantic.deficit.border,
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: theme.spacing.sm,
     paddingVertical: theme.spacing.sm,
     paddingHorizontal: theme.spacing.sm,
-    borderRadius: theme.borderRadius.md,
-    backgroundColor: theme.colors.surface,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
   },
-  rowDuplicate: {
-    backgroundColor: theme.colors.semantic.warning.bg,
-    borderColor: theme.colors.semantic.warning.border,
-  },
-  rowFailed: {
-    backgroundColor: theme.colors.semantic.deficit.bg,
-    borderColor: theme.colors.semantic.deficit.border,
-  },
+  rowPressed: { opacity: 0.85 },
   main: { flex: 1, minWidth: 0 },
   title: {
     ...theme.typography.body,
@@ -101,6 +147,12 @@ const styles = StyleSheet.create({
     color: theme.colors.semantic.warning.text,
     marginTop: 4,
   },
+  openHint: {
+    fontSize: 11,
+    color: theme.colors.primary,
+    marginTop: 4,
+    fontWeight: '600',
+  },
   badge: {
     minWidth: 72,
     paddingHorizontal: 8,
@@ -115,4 +167,9 @@ const styles = StyleSheet.create({
   badgeReady: { backgroundColor: '#059669' },
   badgeDuplicate: { backgroundColor: '#d97706' },
   badgeFailed: { backgroundColor: theme.colors.semantic.deficit.text },
+  actions: {
+    paddingHorizontal: theme.spacing.sm,
+    paddingBottom: theme.spacing.sm,
+    alignItems: 'flex-end',
+  },
 });

--- a/frontend/src/components/ReceiptTrayPanel.tsx
+++ b/frontend/src/components/ReceiptTrayPanel.tsx
@@ -13,6 +13,10 @@ type Props = {
   maxItems?: number;
   showSectionHeaders?: boolean;
   onOpenFullTray?: () => void;
+  onItemPress?: (item: ReceiptTrayItem) => void;
+  onItemDiscard?: (item: ReceiptTrayItem) => void;
+  canOpenItem?: (item: ReceiptTrayItem) => boolean;
+  canDiscardItem?: (item: ReceiptTrayItem) => boolean;
 };
 
 export function ReceiptTrayPanel({
@@ -22,6 +26,10 @@ export function ReceiptTrayPanel({
   maxItems,
   showSectionHeaders = true,
   onOpenFullTray,
+  onItemPress,
+  onItemDiscard,
+  canOpenItem,
+  canDiscardItem,
 }: Props) {
   const sections = useMemo(() => groupReceiptTrayItems(items), [items]);
   const totalCount = items.length;
@@ -64,7 +72,14 @@ export function ReceiptTrayPanel({
           ) : null}
           <View style={styles.sectionItems}>
             {section.items.map((item) => (
-              <ReceiptJobTrayRow key={item.id} item={item} />
+              <ReceiptJobTrayRow
+                key={item.id}
+                item={item}
+                canOpen={canOpenItem?.(item) ?? false}
+                canDiscard={canDiscardItem?.(item) ?? false}
+                onPress={onItemPress ? () => onItemPress(item) : undefined}
+                onDiscard={onItemDiscard ? () => onItemDiscard(item) : undefined}
+              />
             ))}
           </View>
         </View>

--- a/frontend/src/contexts/ReceiptTrayContext.tsx
+++ b/frontend/src/contexts/ReceiptTrayContext.tsx
@@ -1,14 +1,47 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
-import type { LocalFailedReceiptJob } from '../types/receiptJob';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useReceiptJobs } from '../hooks/useReceiptJobs';
+import type { ReceiptScanInitialData } from '../types/receiptScan';
+import type { LocalFailedReceiptJob, ReceiptJobListItem, ReceiptTrayItem } from '../types/receiptJob';
+import { showAlert } from '../utils/alertMessage';
+import { showConfirmDialog } from '../utils/confirmDialog';
+import { discardReceiptJob, fetchReceiptScanInitialData } from '../utils/receiptJobActions';
+import {
+  countReceiptTrayItems,
+  resolveReceiptTrayItemDisplay,
+  sortReceiptTrayItems,
+} from '../utils/receiptJobDisplay';
 
 type ReceiptTrayContextValue = {
+  jobs: ReceiptJobListItem[];
+  activeCount: number;
+  refreshing: boolean;
+  refresh: (options?: { userInitiated?: boolean }) => Promise<void>;
+  trayItems: ReceiptTrayItem[];
+  trayItemCount: number;
   localFailedJobs: LocalFailedReceiptJob[];
   addLocalFailedJob: (reason: string) => void;
+  openTrayItem: (item: ReceiptTrayItem) => Promise<void>;
+  discardTrayItem: (item: ReceiptTrayItem) => Promise<void>;
+  canOpenTrayItem: (item: ReceiptTrayItem) => boolean;
+  canDiscardTrayItem: (item: ReceiptTrayItem) => boolean;
 };
 
 const ReceiptTrayContext = createContext<ReceiptTrayContextValue | null>(null);
 
-export function ReceiptTrayProvider({ children }: { children: React.ReactNode }) {
+type ReceiptTrayProviderProps = {
+  children: React.ReactNode;
+  enabled: boolean;
+  onOpenScan: (data: ReceiptScanInitialData) => void;
+  onRegisterRefresh?: (refresh: () => Promise<void>) => void;
+};
+
+export function ReceiptTrayProvider({
+  children,
+  enabled,
+  onOpenScan,
+  onRegisterRefresh,
+}: ReceiptTrayProviderProps) {
+  const { jobs, activeCount, refreshing, refresh } = useReceiptJobs(enabled);
   const [localFailedJobs, setLocalFailedJobs] = useState<LocalFailedReceiptJob[]>([]);
 
   const addLocalFailedJob = useCallback((reason: string) => {
@@ -24,18 +57,146 @@ export function ReceiptTrayProvider({ children }: { children: React.ReactNode })
     ]);
   }, []);
 
+  const trayItems = useMemo(
+    () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
+    [jobs, localFailedJobs]
+  );
+
+  const trayItemCount = countReceiptTrayItems(trayItems);
+
+  useEffect(() => {
+    onRegisterRefresh?.((options) => refresh(options));
+  }, [onRegisterRefresh, refresh]);
+
+  const canOpenTrayItem = useCallback((item: ReceiptTrayItem): boolean => {
+    if ('localOnly' in item && item.localOnly) return false;
+    const display = resolveReceiptTrayItemDisplay(item);
+    return !display.isActive && display.kind !== 'failed';
+  }, []);
+
+  const canDiscardTrayItem = useCallback((_item: ReceiptTrayItem): boolean => true, []);
+
+  const proceedOpenTrayItem = useCallback(
+    async (item: ReceiptJobListItem) => {
+      const scanData = await fetchReceiptScanInitialData(item.id);
+      if (!scanData) {
+        showAlert('利用できません', '解析結果を取得できませんでした。一覧を更新して再度お試しください。');
+        await refresh();
+        return;
+      }
+
+      onOpenScan({
+        ...scanData,
+        duplicateSuspected: scanData.duplicateSuspected ?? item.duplicateSuspected,
+        existingReceiptId: scanData.existingReceiptId ?? item.existingReceiptId ?? null,
+        warnedDuplicateFromTray: Boolean(scanData.duplicateSuspected ?? item.duplicateSuspected),
+      });
+    },
+    [onOpenScan, refresh]
+  );
+
+  const openTrayItem = useCallback(
+    async (item: ReceiptTrayItem) => {
+      if ('localOnly' in item && item.localOnly) return;
+
+      const display = resolveReceiptTrayItemDisplay(item);
+      if (display.isActive) {
+        showAlert('解析中', '解析が完了するまでお待ちください。');
+        return;
+      }
+
+      if (display.kind === 'failed') {
+        showAlert('解析失敗', item.failedReason || 'このレシートは確認できません。破棄して再度撮影してください。');
+        return;
+      }
+
+      if (item.duplicateSuspected) {
+        showConfirmDialog(
+          '重複の疑い',
+          '同じ店名・日付・金額のレシートが既に登録されている可能性があります。内容を確認しますか？',
+          [
+            { text: 'キャンセル', style: 'cancel' },
+            {
+              text: '確認する',
+              onPress: () => proceedOpenTrayItem(item),
+            },
+          ]
+        );
+        return;
+      }
+
+      await proceedOpenTrayItem(item);
+    },
+    [proceedOpenTrayItem]
+  );
+
+  const discardTrayItem = useCallback(
+    async (item: ReceiptTrayItem) => {
+      const runDiscard = async () => {
+        if ('localOnly' in item && item.localOnly) {
+          setLocalFailedJobs((prev) => prev.filter((job) => job.id !== item.id));
+          return;
+        }
+
+        await discardReceiptJob(item.id);
+        await refresh();
+      };
+
+      showConfirmDialog('破棄の確認', 'この受付項目を破棄しますか？', [
+        { text: 'キャンセル', style: 'cancel' },
+        { text: '破棄', style: 'destructive', onPress: runDiscard },
+      ]);
+    },
+    [refresh]
+  );
+
   const value = useMemo(
-    () => ({ localFailedJobs, addLocalFailedJob }),
-    [localFailedJobs, addLocalFailedJob]
+    () => ({
+      jobs,
+      activeCount,
+      refreshing,
+      refresh,
+      trayItems,
+      trayItemCount,
+      localFailedJobs,
+      addLocalFailedJob,
+      openTrayItem,
+      discardTrayItem,
+      canOpenTrayItem,
+      canDiscardTrayItem,
+    }),
+    [
+      jobs,
+      activeCount,
+      refreshing,
+      refresh,
+      trayItems,
+      trayItemCount,
+      localFailedJobs,
+      addLocalFailedJob,
+      openTrayItem,
+      discardTrayItem,
+      canOpenTrayItem,
+      canDiscardTrayItem,
+    ]
   );
 
   return <ReceiptTrayContext.Provider value={value}>{children}</ReceiptTrayContext.Provider>;
 }
 
-export function useReceiptTrayLocalFailures(): ReceiptTrayContextValue {
+export function useReceiptTray(): ReceiptTrayContextValue {
   const context = useContext(ReceiptTrayContext);
   if (!context) {
-    throw new Error('useReceiptTrayLocalFailures must be used within ReceiptTrayProvider');
+    throw new Error('useReceiptTray must be used within ReceiptTrayProvider');
   }
   return context;
+}
+
+/** ローカル失敗行の追加のみ（Provider 外では使わない） */
+export function useReceiptTrayLocalFailures(): Pick<
+  ReceiptTrayContextValue,
+  'localFailedJobs' | 'addLocalFailedJob'
+> {
+  const { localFailedJobs, addLocalFailedJob } = useReceiptTray();
+  return { localFailedJobs, addLocalFailedJob };
 }

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -15,8 +15,7 @@ import { AppButton, AppListItem, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
 import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
 import { getAppDisplayName, getMemberMenuTitle, isDevAppEnv } from '../config/appEnv';
-import { useReceiptTrayLocalFailures } from '../contexts/ReceiptTrayContext';
-import { useReceiptJobs } from '../hooks/useReceiptJobs';
+import { useReceiptTray } from '../contexts/ReceiptTrayContext';
 import { theme } from '../theme';
 import apiClient from '../utils/apiClient';
 import { buildReceiptUploadFormData } from '../utils/receiptUploadFormData';
@@ -27,7 +26,6 @@ import {
   clearPendingCropUri,
 } from '../utils/webImageFileRegistry';
 import { showAlert } from '../utils/alertMessage';
-import { countReceiptTrayItems, sortReceiptTrayItems } from '../utils/receiptJobDisplay';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 
@@ -68,15 +66,17 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const [pendingCropUri, setPendingCropUri] = useState<string | null>(null);
   const [showImageSourcePicker, setShowImageSourcePicker] = useState(false);
 
-  const { jobs, activeCount, refresh: refreshJobs } = useReceiptJobs(currentMemberId > 0);
-  const { localFailedJobs, addLocalFailedJob } = useReceiptTrayLocalFailures();
-
-  const trayItems = useMemo(
-    () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
-    [jobs, localFailedJobs]
-  );
-
-  const trayItemCount = countReceiptTrayItems(trayItems);
+  const {
+    activeCount,
+    refresh: refreshJobs,
+    trayItems,
+    trayItemCount,
+    addLocalFailedJob,
+    openTrayItem,
+    discardTrayItem,
+    canOpenTrayItem,
+    canDiscardTrayItem,
+  } = useReceiptTray();
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -305,6 +305,10 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
               maxItems={HOME_TRAY_PREVIEW_LIMIT}
               showSectionHeaders={trayItemCount > 0}
               onOpenFullTray={onGoToReceiptTray}
+              onItemPress={(item) => void openTrayItem(item)}
+              onItemDiscard={(item) => void discardTrayItem(item)}
+              canOpenItem={canOpenTrayItem}
+              canDiscardItem={canDiscardTrayItem}
               emptyTitle="確認待ちのレシートはありません"
               emptyDescription="撮影したレシートの解析状況がここに表示されます。"
             />

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -18,6 +18,7 @@ import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 import { showAlert } from '../utils/alertMessage';
+import type { ReceiptScanInitialData } from '../types/receiptScan';
 
 const c = theme.colors;
 const s = theme.colors.semantic.scan;
@@ -30,22 +31,7 @@ interface ReceiptItem {
 }
 
 interface ReceiptScanScreenProps {
-  initialData: {
-    parsedData: {
-      storeName: string;
-      purchaseDate: string;
-      totalAmount: number;
-      taxAmount?: number | string; 
-      items: ReceiptItem[];
-      usageLogId?: number; // ★ Issue #63: ログIDの型定義を追加して引き回しを保証
-    };
-    imagePath: string;
-    validation: {
-      isSuspicious: boolean;
-      warnings: string[];
-    };
-    jobId?: string;
-  };
+  initialData: ReceiptScanInitialData;
   categories: Array<{ id: number; name: string }>;
   onSuccess: () => void;
   onCancel: () => void;
@@ -137,11 +123,10 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
       const message = apiError?.message || err.message;
 
       if (message === 'DUPLICATE') {
-        showAlert(
-          '既に登録済みです',
-          '同じ店名・日付・金額のレシートが世帯内に存在します。履歴画面で確認してください。',
-          { onOk: onCancel }
-        );
+        const duplicateMessage = initialData.warnedDuplicateFromTray
+          ? '確認トレイで重複の疑いが表示されていました。同じ内容のレシートは保存できません。トレイから破棄するか、履歴で既存レシートを確認してください。'
+          : '同じ店名・日付・金額のレシートが世帯内に存在します。履歴画面で確認してください。';
+        showAlert('既に登録済みです', duplicateMessage, { onOk: onCancel });
         return;
       }
 
@@ -168,6 +153,19 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
         </View>
 
         <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+          {initialData.duplicateSuspected ? (
+            <View style={styles.duplicateBanner}>
+              <Text style={styles.duplicateBannerTitle}>重複の疑い</Text>
+              <Text style={styles.duplicateBannerText}>
+                同じ店名・日付・金額のレシートが登録済みの可能性があります。
+                {initialData.existingReceiptId
+                  ? `（既存レシート ID: ${initialData.existingReceiptId}）`
+                  : ''}
+                {' '}内容を確認のうえ、問題なければ保存できます。
+              </Text>
+            </View>
+          ) : null}
+
           {imageSource && (
             <View style={styles.imageContainer}>
               <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
@@ -289,6 +287,27 @@ const styles = StyleSheet.create({
   },
   headerTitle: { fontSize: 17, fontWeight: 'bold', color: s.textTitle },
   headerBack: { minWidth: 50 },
+  duplicateBanner: {
+    marginHorizontal: theme.spacing.md,
+    marginTop: theme.spacing.md,
+    marginBottom: theme.spacing.sm,
+    padding: theme.spacing.md,
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.semantic.warning.bg,
+    borderWidth: 1,
+    borderColor: theme.colors.semantic.warning.border,
+  },
+  duplicateBannerTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: theme.colors.semantic.warning.text,
+    marginBottom: 4,
+  },
+  duplicateBannerText: {
+    fontSize: 13,
+    color: theme.colors.semantic.warning.text,
+    lineHeight: 20,
+  },
   scrollView: { flex: 1 },
   imageContainer: { width: '100%', height: 260, backgroundColor: s.imageBg, marginBottom: theme.spacing.md, position: 'relative' },
   receiptImage: { width: '100%', height: '100%' },

--- a/frontend/src/screens/ReceiptTrayScreen.tsx
+++ b/frontend/src/screens/ReceiptTrayScreen.tsx
@@ -1,28 +1,26 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { AppBackButton } from '../components/ui';
 import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
-import { useReceiptTrayLocalFailures } from '../contexts/ReceiptTrayContext';
-import { useReceiptJobs } from '../hooks/useReceiptJobs';
+import { useReceiptTray } from '../contexts/ReceiptTrayContext';
 import { theme } from '../theme';
-import { countReceiptTrayItems, sortReceiptTrayItems } from '../utils/receiptJobDisplay';
 
 type Props = {
   onBack: () => void;
-  enabled: boolean;
 };
 
-export function ReceiptTrayScreen({ onBack, enabled }: Props) {
-  const { jobs, refreshing, refresh } = useReceiptJobs(enabled);
-  const { localFailedJobs } = useReceiptTrayLocalFailures();
-
-  const trayItems = useMemo(
-    () => sortReceiptTrayItems([...jobs, ...localFailedJobs]),
-    [jobs, localFailedJobs]
-  );
-
-  const totalCount = countReceiptTrayItems(trayItems);
+export function ReceiptTrayScreen({ onBack }: Props) {
+  const {
+    trayItems,
+    trayItemCount,
+    refreshing,
+    refresh,
+    openTrayItem,
+    discardTrayItem,
+    canOpenTrayItem,
+    canDiscardTrayItem,
+  } = useReceiptTray();
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
@@ -31,12 +29,12 @@ export function ReceiptTrayScreen({ onBack, enabled }: Props) {
         <View style={styles.headerText}>
           <Text style={styles.title}>確認トレイ</Text>
           <Text style={styles.subtitle}>
-            {totalCount > 0 ? `${totalCount} 件の受付` : '受付中のレシートはありません'}
+            {trayItemCount > 0 ? `${trayItemCount} 件の受付` : '受付中のレシートはありません'}
           </Text>
         </View>
-        {totalCount > 0 ? (
+        {trayItemCount > 0 ? (
           <View style={styles.countBadge}>
-            <Text style={styles.countBadgeText}>{totalCount}</Text>
+            <Text style={styles.countBadgeText}>{trayItemCount}</Text>
           </View>
         ) : (
           <View style={styles.headerSpacer} />
@@ -57,6 +55,10 @@ export function ReceiptTrayScreen({ onBack, enabled }: Props) {
         <ReceiptTrayPanel
           items={trayItems}
           showSectionHeaders
+          onItemPress={(item) => void openTrayItem(item)}
+          onItemDiscard={(item) => void discardTrayItem(item)}
+          canOpenItem={canOpenTrayItem}
+          canDiscardItem={canDiscardTrayItem}
           emptyTitle="確認待ちのレシートはありません"
           emptyDescription="ホームからレシートを撮影すると、解析状況がここに表示されます。"
         />

--- a/frontend/src/types/receiptScan.test.ts
+++ b/frontend/src/types/receiptScan.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildScanInitialDataFromJobStatus } from '../types/receiptScan';
+
+describe('buildScanInitialDataFromJobStatus', () => {
+  it('returns null for non-completed jobs', () => {
+    expect(
+      buildScanInitialDataFromJobStatus('job-1', { state: 'active' })
+    ).toBeNull();
+  });
+
+  it('maps completed job result to scan initial data', () => {
+    const data = buildScanInitialDataFromJobStatus('job-1', {
+      state: 'completed',
+      duplicateSuspected: true,
+      existingReceiptId: 99,
+      result: {
+        parsedData: {
+          storeName: 'テスト店',
+          purchaseDate: '2026-01-01',
+          totalAmount: 500,
+          items: [{ name: '商品', price: 500, quantity: 1, categoryId: 1 }],
+        },
+        imagePath: 'uploads/test.webp',
+        validation: { isSuspicious: false, warnings: [] },
+      },
+    });
+
+    expect(data).toMatchObject({
+      jobId: 'job-1',
+      imagePath: 'uploads/test.webp',
+      duplicateSuspected: true,
+      existingReceiptId: 99,
+      warnedDuplicateFromTray: true,
+    });
+  });
+});

--- a/frontend/src/types/receiptScan.ts
+++ b/frontend/src/types/receiptScan.ts
@@ -1,0 +1,54 @@
+export type ReceiptScanInitialData = {
+  parsedData: {
+    storeName: string;
+    purchaseDate: string;
+    totalAmount: number;
+    taxAmount?: number | string;
+    items: Array<{
+      name: string;
+      price: number | string;
+      quantity: number | string;
+      categoryId: number | null;
+    }>;
+    usageLogId?: number;
+  };
+  imagePath: string;
+  validation: {
+    isSuspicious: boolean;
+    warnings: string[];
+  };
+  jobId?: string;
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number | null;
+  warnedDuplicateFromTray?: boolean;
+};
+
+type JobStatusResponse = {
+  state: string;
+  result?: {
+    parsedData?: ReceiptScanInitialData['parsedData'];
+    imagePath?: string;
+    validation?: ReceiptScanInitialData['validation'];
+  };
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number | null;
+};
+
+export function buildScanInitialDataFromJobStatus(
+  jobId: string,
+  payload: JobStatusResponse
+): ReceiptScanInitialData | null {
+  if (payload.state !== 'completed' || !payload.result?.parsedData || !payload.result.imagePath) {
+    return null;
+  }
+
+  return {
+    parsedData: payload.result.parsedData,
+    imagePath: payload.result.imagePath,
+    validation: payload.result.validation ?? { isSuspicious: false, warnings: [] },
+    jobId,
+    duplicateSuspected: Boolean(payload.duplicateSuspected),
+    existingReceiptId: payload.existingReceiptId ?? null,
+    warnedDuplicateFromTray: Boolean(payload.duplicateSuspected),
+  };
+}

--- a/frontend/src/utils/receiptJobActions.ts
+++ b/frontend/src/utils/receiptJobActions.ts
@@ -1,0 +1,15 @@
+import apiClient from './apiClient';
+import type { ReceiptScanInitialData } from '../types/receiptScan';
+import { buildScanInitialDataFromJobStatus } from '../types/receiptScan';
+
+export async function fetchReceiptScanInitialData(
+  jobId: string
+): Promise<ReceiptScanInitialData | null> {
+  const res = await apiClient.get(`/receipts/status/${jobId}`);
+  if (!res.data?.success) return null;
+  return buildScanInitialDataFromJobStatus(jobId, res.data.data);
+}
+
+export async function discardReceiptJob(jobId: string): Promise<void> {
+  await apiClient.delete(`/receipts/jobs/${jobId}`);
+}


### PR DESCRIPTION
## Summary
- トレイ項目タップ → `GET /receipts/status/:jobId` で解析結果取得 → `ReceiptScanScreen` へ遷移
- **重複の疑い** はタップ前に確認ダイアログ + Scan 画面の警告バナー
- **破棄**: `DELETE /api/receipts/jobs/:jobId`（未保存画像も削除、保存済み画像は残す）
- **commit 成功後**: `jobId` 付き commit で BullMQ ジョブを自動除去
- 409 DUPLICATE 時はトレイ警告済み向けメッセージに統一

Closes #336

## Backend
- `DELETE /api/receipts/jobs/:jobId`
- `commitReceipt` が `jobId` 受信時にキューから除去

## Frontend
- `ReceiptTrayContext` に open / discard / 共有 refresh を集約
- トレイ行にタップ（確認）・破棄ボタン
- Scan 画面からトレイ/ホームへ戻る導線

## Test plan
- [x] `cd frontend && npm test`（33 passed）
- [x] `cd backend && npm test`（32 passed）
- [ ] トレイ → 編集 → 取り込みが動作する
- [ ] 破棄後トレイから消える
- [ ] 重複候補は一覧段階で判断できる（警告 + 破棄）
- [ ] Expo Go / Web


Made with [Cursor](https://cursor.com)