### PR TITLE
docs: [Issue #90-7] README を現行実装に合わせて現行化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,206 @@
-# Receipt AI Classifier (Tentative)
-## AI-Driven Expense Orchestration for Family Finance
+# RecAIpt（receipt-ai-app）
 
-30年超のエンタープライズ開発（Java/RDB）で培った堅牢な設計思想をベースに、最新の **React Native × Google Gemini (LLM)** を活用して「いかに爆速で実用的なプロダクトを構築できるか」を検証するプロトタイピング・プロジェクトです。
+世帯単位のレシート管理・AI 解析・月次精算を行う Web / モバイルアプリです。  
+自宅サーバー（Dell PowerEdge T320 / Ubuntu）上の Docker Compose で **dev** / **stable** の二重環境を運用しています。
 
----
-
-## 🚀 Concept & Philosophy
-
-本プロジェクトは、単なる家計簿アプリではなく、以下の **「AIネイティブな開発戦略」** を具現化することを目的としています。
-
-* **Prompt Engineering over Manual Coding**: **Google Gemini** を「ペアプログラマ」としてフル活用し、実装速度を極限まで高める。
-* **Senior Insight**: AIが生成するコードに対し、長年の経験に基づいた「データ整合性」や「保守性」の観点から検収（Code Review）を行う。
-* **Rapid Prototyping**: 手書きのコメント整備よりも、AIによる高速なイテレーションと、Supabase を活用したサーバーレス・アーキテクチャの検証を優先。
+設計資料の全体計画: [docs/design/plan.md](docs/design/plan.md)（Issue #90）
 
 ---
 
-## 🛠 Technical Stack
+## 概要
 
-| Category | Technology |
-| :--- | :--- |
-| **Frontend** | React Native (Expo), TypeScript |
-| **Backend** | Supabase (Postgres, Auth, Storage, Edge Functions) |
-| **Infrastructure** | **Docker** (Home Server: Dell PowerEdge T320 / Ubuntu) |
-| **AI / OCR** | **Google Gemini API (Gemini 1.5 Pro / Flash)** |
-| **Monitoring** | **Discord Webhook Alert System** |
+- **テナント**: `FamilyGroup`（世帯）。招待コードで参加し、データは世帯 ID で分離
+- **AI**: Google Gemini API によるレシート OCR・構造化
+- **非同期処理**: BullMQ + Redis でレシート画像解析をキューイング
+- **画像**: `backend/uploads/` に WebP 変換後のファイルを保存（クラウドストレージは未使用）
 
 ---
 
-## 💡 Key Features
+## 技術スタック
 
-* **AI Receipt Parsing**: レシート画像から品目・金額・日付を **Gemini** で高精度に抽出。
-* **Multi-Family Classification**: 「自分の家庭」と「その他の家庭」の経費を分けて管理。
-* **Hybrid Deployment**: 自宅サーバー上の Docker 環境とクラウドサービスを適材適所で組み合わせた構成。
-
----
-
-## ⚙️ Development Setup
-
-本プロジェクトは、開発効率を最大化するために Docker 環境での構築を前提としています。
-
-### 1. 開発用アセットの配置
-プライバシー保護およびリポジトリ軽量化のため、サンプル画像は Git 管理対象外としています。
-
- プロジェクトルートに test-assets/ ディレクトリを作成
-mkdir test-assets
+| レイヤー | 技術 |
+|----------|------|
+| Frontend | Expo ~54, React 19, React Native 0.81, TypeScript, Axios |
+| Backend | Node.js 20, Express 5, TypeScript, Prisma 6 |
+| DB | PostgreSQL 18 |
+| Queue | BullMQ 5 + Redis 7 |
+| AI | `@google/generative-ai`（Gemini） |
+| 画像 | sharp（WebP 変換）, multer（アップロード） |
+| 認証 | JWT, bcrypt, otplib（TOTP）, AES-256-GCM |
+| コンテナ | Docker Compose |
+| CI | GitHub Actions（`test.yml` / `deploy.yml`） |
 
 ---
 
-・環境構築（Docker）
+## 主な機能
 
-###  1. リポジトリのクローン
-git clone [https://github.com/your-username/receipt-ai-classifier.git](https://github.com/your-username/receipt-ai-classifier.git)
-cd receipt-ai-classifier
-
-###  2. 環境変数の設定
-cp .env.example .env
-※ .env 内に Gemini API Key および Supabase の接続情報を記述してください
+- **AI レシート解析**: レシート画像から品目・金額・日付を Gemini で抽出
+- **世帯別管理**: 複数世帯の経費を分離して管理
+- **按分・精算**: 明細単位の按分と月次精算サマリー
+- **マスタ学習**: 店舗・商品マスタの AI 学習データ管理
 
 ---
 
-### 🛠️ Operation & Maintenance
+## 開発環境の構築
 
-プロジェクトの継続的な運用を担保するため、以下の管理体制を構築しています。
-1. バックアップ戦略 (Backup Strategy)
-    対象:
-        データベース (PostgreSQL): .sql.gz 形式
-        ユーザーアップロード画像: .tar.gz 形式
-    世代管理: 過去7日分をローテーション保持
-2. 監視・アラート (Monitoring)
-    通知先: Discord Webhook (#alerts チャンネル)
-    通知タイミング:
-        バックアップスクリプト実行時のエラー検知
-        データベースコンテナの停止
-        その他、運用上のクリティカルな例外発生時
+### 前提
+
+- Docker / Docker Compose
+- Node.js 20（ローカルでテストを走らせる場合）
+- Git
+
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/yama180sx/receipt-ai-app.git
+cd receipt-ai-app
+```
+
+### 2. 秘密情報の設定（`.env.secret`）
+
+リポジトリルートに `.env.secret` を作成します（**git 管理外**）。`setup-env.sh` がこのファイルを読み込み、各 `.env` を生成します。
+
+```bash
+# .env.secret の例（値は各自で設定）
+DB_PASS=your-db-password
+JWT_SECRET=your-jwt-secret
+GEMINI_API_KEY=your-gemini-api-key
+API_TOKEN=your-api-token
+```
+
+### 3. 環境ファイルの生成
+
+```bash
+./setup-env.sh dev    # 開発環境（stable の場合は stable）
+```
+
+`setup-env.sh` が行うこと:
+
+1. `.env.secret` から秘密情報を読み込み
+2. ルート / `frontend` / `backend` の `.env` を環境別に生成
+3. バックアップ用 cron の登録（`scripts/backup.sh`）
+4. `logs/` ディレクトリの作成
+
+| 項目 | dev | stable |
+|------|-----|--------|
+| Backend ポート | 3001 | 3000 |
+| Web ポート | 8080 | 80 |
+| Expo Dev ポート | 8081 | 8082 |
+| DB ポート | 5433 | 5432 |
+| Redis ポート | 6380 | 6379 |
+
+ポート・CORS 等の詳細は [docs/design/architecture.md §8.1](docs/design/architecture.md) を参照。
+
+### 4. コンテナの起動
+
+```bash
+docker compose up -d --build
+```
+
+### 5. データベースの初期化（初回のみ）
+
+```bash
+docker compose exec backend npx prisma migrate deploy
+docker compose exec backend npm run prisma:seed
+```
+
+> `prisma:seed` は**全データを削除して再投入**します。開発環境の初回構築・リセット時のみ実行してください。詳細は [docs/design/operations.md §4](docs/design/operations.md) を参照。
+
+### 6. アクセス
+
+| 用途 | dev の例 |
+|------|----------|
+| Web UI | `http://<HOST_IP>:8080` |
+| Expo Dev | `http://<HOST_IP>:8081` |
+| Backend API | `http://<HOST_IP>:3001/api` |
+
+`HOST_IP` は `setup-env.sh` 内の設定（デフォルト `192.168.1.32`）に従います。
+
+### テスト用アセット（任意）
+
+プライバシー保護のため、サンプル画像は Git 管理対象外です。必要に応じてプロジェクトルートに `test-assets/` を作成してください。
 
 ---
 
-## 📝 Developer's Note
+## テスト
 
-    「30年前、Javaで最初のシステムを組んだ時と比べ、開発の『手触り』は劇的に変わりました。
+### ローカル実行
 
-    かつては一文字ずつコードを綴ることがエンジニアの証明でしたが、今は Geminiのような強力なAIエンジンを、長年の経験というハンドルでどう制御し、最短距離で価値を届けるか が介在価値だと考えています。
+```bash
+# Backend 単体テスト（Vitest）
+cd backend && npm ci && npx prisma generate && npm test
 
-    本リポジトリのコードは、あえてAIによる高速生成を優先し、人間はその『設計の妥当性』を担保することに注力しています。見栄えの良さ以上に、アーキテクチャの合理性と解決の速度を優先しています。」
+# Frontend 単体テスト（Vitest）
+cd frontend && npm ci && npm test
+
+# Backend API 結合テスト（Postgres が必要）
+cd backend
+export DATABASE_URL="postgresql://cntadm:<password>@localhost:5433/receipt_db?schema=public"
+export JWT_SECRET="test-jwt-secret"
+npm run test:integration
+```
+
+### CI（GitHub Actions）
+
+`develop` への PR で [`.github/workflows/test.yml`](.github/workflows/test.yml) が実行されます。
+
+1. Backend unit（Vitest）
+2. Frontend unit（Vitest）
+3. Backend integration（Postgres service + `prisma migrate deploy` + seed）
+
+テスト戦略の詳細: [docs/testing/plan.md](docs/testing/plan.md)（Issue #91）
+
+---
+
+## ドキュメント
+
+### 設計資料（Issue #90）
+
+| 資料 | 内容 |
+|------|------|
+| [docs/design/plan.md](docs/design/plan.md) | 設計資料全体の計画 |
+| [docs/design/architecture.md](docs/design/architecture.md) | アーキテクチャ概要 |
+| [docs/design/domain-model.md](docs/design/domain-model.md) | ドメインモル・業務ルール |
+| [docs/design/api-spec.md](docs/design/api-spec.md) | API 仕様 |
+| [docs/design/ai-pipeline.md](docs/design/ai-pipeline.md) | 3層正規化・AI パイプライン |
+| [docs/design/frontend-screens.md](docs/design/frontend-screens.md) | 画面遷移・フロント |
+| [docs/design/operations.md](docs/design/operations.md) | 運用・障害対応 |
+
+索引: [docs/design/README.md](docs/design/README.md)
+
+### テスト・運用
+
+| 資料 | 内容 |
+|------|------|
+| [docs/testing/plan.md](docs/testing/plan.md) | テスト戦略（Issue #91） |
+| [docs/db-operations.md](docs/db-operations.md) | DB マスタ運用の詳細手順 |
+| [docs/restore-manual.md](docs/restore-manual.md) | バックアップ・リストア手順 |
+| [docs/reviews/issue-87/README.md](docs/reviews/issue-87/README.md) | 精算ドメイン詳細レビュー |
+
+---
+
+## 運用・保守
+
+| 項目 | 内容 |
+|------|------|
+| バックアップ | `scripts/backup.sh {dev\|stable}` — DB（`.sql.gz`）と画像（`.tar.gz`）を 7 日分ローテーション |
+| 監視 | Discord Webhook によるバックアップ失敗・障害通知 |
+| デプロイ | `main` push → self-hosted runner で stable へ rsync + migrate + compose up |
+
+運用の詳細: [docs/design/operations.md](docs/design/operations.md)
+
+---
+
+## リポジトリ構成
+
+```
+receipt-ai-app/
+├── backend/          # Express API + BullMQ Worker
+├── frontend/         # Expo アプリ
+├── scripts/          # backup.sh, notify.sh
+├── docs/             # 設計・運用ドキュメント
+├── docker-compose.yml
+└── setup-env.sh      # dev / stable 環境生成
+```
+
+詳細: [docs/design/architecture.md §3](docs/design/architecture.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,7 +13,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | #90-4 | [#295](https://github.com/yama180sx/receipt-ai-app/issues/295) | [ai-pipeline.md](./ai-pipeline.md) | 完了 |
 | #90-5 | [#296](https://github.com/yama180sx/receipt-ai-app/issues/296) | [frontend-screens.md](./frontend-screens.md) | 完了 |
 | #90-6 | [#297](https://github.com/yama180sx/receipt-ai-app/issues/297) | [operations.md](./operations.md) | 完了 |
-| #90-7 | [#298](https://github.com/yama180sx/receipt-ai-app/issues/298) | ルート `README.md` | 未着手 |
+| #90-7 | [#298](https://github.com/yama180sx/receipt-ai-app/issues/298) | ルート `README.md` | 完了 |
 
 ## 関連
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -76,8 +76,6 @@ flowchart TB
 | コンテナ | Docker Compose |
 | CI | GitHub Actions（`test.yml` / `deploy.yml`） |
 
-> ルート `README.md` の技術スタック記載（Supabase 等）は歴史的なものであり、**現行実装は上表が正**である（#90-7 で README 現行化予定）。
-
 ---
 
 ## 3. リポジトリ構成

--- a/docs/design/operations.md
+++ b/docs/design/operations.md
@@ -230,4 +230,4 @@ flowchart LR
 
 - [architecture.md](./architecture.md) — 環境・デプロイ・外部連携
 - [plan.md](./plan.md) — 設計資料 Epic 計画
-- [README.md](../../README.md) — バックアップ・監視の概要（#90-7 で現行化予定）
+- [README.md](../../README.md) — バックアップ・監視の概要

--- a/docs/design/plan.md
+++ b/docs/design/plan.md
@@ -36,7 +36,7 @@ docs/
 
 | ファイル | 扱い |
 |----------|------|
-| `README.md` | #90-7 で現行化（技術スタック・セットアップ） |
+| `README.md` | 現行化済み（技術スタック・セットアップ） — [README.md](../../README.md) |
 | `docs/MILESTONE_PHASE1.md` | 3層正規化の起源として参照。#90-4 で再整理 |
 | `docs/db-operations.md` | #90-6 に統合または相互リンク |
 | `docs/restore-manual.md` | #90-6 に統合または相互リンク |


### PR DESCRIPTION
## Summary

- ルート `README.md` を as-built の技術スタック・開発環境構築手順・テスト実行方法に更新（Supabase 等の旧記述を削除）
- 設計資料（`docs/design/`）とテスト計画（`docs/testing/plan.md`）への索引を追加
- `docs/design/` 内の #90-7 関連注記を完了状態に更新

Closes #298

## Test plan

- [x] README のセットアップ手順が `setup-env.sh` / `docker-compose.yml` / 設計資料と整合していることを確認
- [x] 設計・テストドキュメントへのリンクが網羅されていることを確認
- [ ] CI（`test.yml`）が PR で通過すること


Made with [Cursor](https://cursor.com)