### PR TITLE
docs(refactor): [Issue #98-1] リファクタ計画と ChatGPT 案

### DIFF
--- a/docs/refactor/plan.md
+++ b/docs/refactor/plan.md
@@ -1,0 +1,73 @@
+# Issue #98 — リファクタリング・実装計画
+
+Epic: [#370 Issue #98](https://github.com/yama180sx/receipt-ai-app/issues/370)
+
+本ドキュメントは **Issue #98** の成果物です。#98-1 以降のリファクタ実装で共通参照してください。
+
+## 1. 方針サマリー
+
+| 項目 | 決定内容 |
+|------|----------|
+| 入力ソース | [ChatGPT リファクタ案](../specs/chatgpt/ChatGPT_リファクタリング案.txt)（develop 解析）+ `docs/design/`（as-built 正本）+ コード突合 |
+| 基本方針 | **DDD やり過ぎない**。Controller → Application/Domain Service → Prisma の現行構造を維持 |
+| スコープ外 | 精算ドメインの再リファクタ（[#87 Epic](../reviews/issue-87/README.md) 完了済み）、React Navigation 導入、Supabase/クラウド移行 |
+| テスト | 各 Must/Should 子 Issue で `npm test` 維持。[#91 テスト計画](../testing/plan.md) に準拠 |
+
+## 2. ChatGPT 案の triage 結果
+
+| ChatGPT 提案 | 判定 | 対応 Issue |
+|--------------|------|------------|
+| Issue1 Repository 全面導入 | **Later** | #98-8（Prisma `$extends` テナント注入と衝突。Drizzle 移行予定なし） |
+| Issue2 ReceiptService 分割 | **Must**（修正） | #98-3（`duplicateReceiptService` / `categoryService` は既存。Controller 601行も対象） |
+| Issue3 Transaction 境界 | **Should** | #98-4 |
+| Issue4 型定義（`any` 排除） | **Must** | #98-2 |
+| Issue5 Context 明示渡し | **Later** | #98-8 |
+| Issue6 AI Provider 抽象化 | **Later** | #98-8（#91-7 と役割近接。Gemini 単一のため当面不要） |
+| Issue7 Frontend `features/` | **Later** | #98-8（#87 R-F005 含む） |
+| Issue8 Frontend API 統一 | **Should** | #98-7 |
+| （追加）エラー統一 R-B006 | **Should** | #98-5 |
+| （追加）statsController → Service | **Should** | #98-6 |
+
+### ChatGPT 解析で判明した誤り（記録）
+
+| 誤り | 正（as-built） |
+|------|----------------|
+| `receiptService` が最大 | `receiptController.ts` が **601行**、`receiptService` は 214行 |
+| 重複チェックが receiptService 内 | `duplicateReceiptService.ts` **既に分離** |
+| Worker 即 DB 保存（Phase5 仕様書） | `analyzeOnly` → 確認 → `commit` |
+
+## 3. 着手順（Sprint）
+
+```
+#98-1（plan）→ #98-2（型）→ #98-3（Receipt）
+    → #98-4（Transaction）→ #98-5 / #98-6 / #98-7（Should）
+    → #98-8（Later バックログ）
+```
+
+| Sprint | 内容 | 子 Issue |
+|--------|------|----------|
+| 1 | 型定義強化 | #98-2 |
+| 2 | Receipt パイプライン + Controller 薄型化 | #98-3 |
+| 3 | Transaction 統一 | #98-4 |
+| 4 | エラー / 精算 Service / FE API | #98-5, #98-6, #98-7 |
+| — | Later バックログ | #98-8 |
+
+## 4. 子 Issue 対応表
+
+| 命名 | GitHub | 優先度 |
+|------|--------|--------|
+| #98-1 | [#371](https://github.com/yama180sx/receipt-ai-app/issues/371) | Must |
+| #98-2 | [#372](https://github.com/yama180sx/receipt-ai-app/issues/372) | Must |
+| #98-3 | [#373](https://github.com/yama180sx/receipt-ai-app/issues/373) | Must |
+| #98-4 | [#374](https://github.com/yama180sx/receipt-ai-app/issues/374) | Should |
+| #98-5 | [#375](https://github.com/yama180sx/receipt-ai-app/issues/375) | Should |
+| #98-6 | [#376](https://github.com/yama180sx/receipt-ai-app/issues/376) | Should |
+| #98-7 | [#377](https://github.com/yama180sx/receipt-ai-app/issues/377) | Should |
+| #98-8 | [#378](https://github.com/yama180sx/receipt-ai-app/issues/378) | Later |
+
+## 5. 関連資料
+
+- [docs/design/](../design/) — 完成版仕様書（正本）
+- [docs/specs/chatgpt/ChatGPT_リファクタリング案.txt](../specs/chatgpt/ChatGPT_リファクタリング案.txt)
+- [docs/reviews/issue-87/should-backlog.md](../reviews/issue-87/should-backlog.md)
+- [docs/testing/plan.md](../testing/plan.md)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,8 +4,12 @@
 
 | 資料 | 内容 |
 |------|------|
-| [chatgpt/](./chatgpt/) | ChatGPT による ZIP 解析出力（Phase1–5、**原文保管・変更しない**） |
+| [chatgpt/](./chatgpt/) | ChatGPT 解析出力（Phase1–5 仕様書、リファクタ案。**原文保管・変更しない**） |
 | [comparison-chatgpt-vs-design.md](./comparison-chatgpt-vs-design.md) | ChatGPT 仕様と `docs/design/` の差分表・統合記録 |
+
+## 関連
+
+- リファクタ計画: [docs/refactor/plan.md](../refactor/plan.md)（Issue #98）
 
 ## 正本への導線
 

--- a/docs/specs/chatgpt/ChatGPT_リファクタリング案.txt
+++ b/docs/specs/chatgpt/ChatGPT_リファクタリング案.txt
@@ -1,0 +1,453 @@
+このプロジェクトは
+
+Frontend：React Native / Expo + TypeScript
+Backend：Express 5 + TypeScript
+ORM：Prisma 6
+DB：PostgreSQL
+非同期：BullMQ + Redis
+AI：Gemini
+認証：JWT + TOTP
+Docker Compose運用
+
+という構成で、個人開発としてはかなり整理されています。
+
+一方で、将来的な保守性という観点では、現在は
+
+Controller → Service → Prisma
+
+のシンプルな構造に寄っており、機能増加時にサービス層の肥大化が起き始めています。
+
+実際に確認したコードでは、
+
+receiptService.ts
+receiptController.ts
+
+あたりが既に大きくなり始めています。
+
+現在のアーキテクチャ評価
+良い点
+
+既に以下はできています。
+
+レイヤ分離
+routes
+ ↓
+controllers
+ ↓
+services
+ ↓
+prisma
+テスト可能な構造
+
+architecture.mdにも記載されていますが
+
+app.ts
+server.ts
+
+分離済みです。
+
+これは非常に良いです。
+
+非同期処理分離
+upload
+ ↓
+BullMQ
+ ↓
+Worker
+ ↓
+Gemini
+
+になっているので、
+
+AI処理がAPIレスポンス時間に影響しない
+
+設計になっています。
+
+これは維持すべきです。
+
+最大の課題
+
+私が見た限りでは
+
+receiptService がドメインサービス化している
+
+例えば
+
+saveParsedReceipt()
+
+の中で
+
+重複チェック
+店舗正規化
+商品マスタ学習
+カテゴリ推定
+Receipt保存
+Item保存
+UsageLog更新
+
+を全部やっています。
+
+つまり
+
+Receipt
+ProductMaster
+Category
+UsageLog
+
+複数の責務を持っています。
+
+今後かなり辛くなる可能性があります。
+
+推奨リファクタリング方針
+
+私は
+
+DDDをやり過ぎない
+
+を推奨します。
+
+この規模なら
+
+Controller
+Application Service
+Domain Service
+Repository
+
+までで十分です。
+
+Issue1
+Prisma直接参照をRepository化
+
+現状
+
+prisma.receipt.create()
+prisma.receipt.findMany()
+
+が各Serviceに散らばっています。
+
+追加
+
+repositories/
+  receiptRepository.ts
+  categoryRepository.ts
+  productMasterRepository.ts
+  memberRepository.ts
+
+例
+
+class ReceiptRepository {
+  create()
+  findById()
+  findByImagePath()
+}
+
+効果
+
+Prisma変更時
+
+Prisma
+↓
+Drizzle
+
+への移行コスト激減
+
+優先度
+
+★★★★★
+
+Issue2
+ReceiptService分割
+
+現在
+
+receiptService.ts
+
+が大きいです。
+
+分割推奨
+
+services/
+
+receipt/
+  receiptPersistenceService.ts
+  receiptDuplicateService.ts
+  receiptCategoryService.ts
+  receiptAnalysisService.ts
+
+例
+
+現在
+
+saveParsedReceipt()
+
+↓
+
+duplicateService.check()
+
+categoryService.assign()
+
+receiptPersistenceService.save()
+
+効果
+
+機能追加時の影響範囲縮小
+
+優先度
+
+★★★★★
+
+Issue3
+Transaction境界統一
+
+現在
+
+prisma.$transaction()
+
+がサービス内部にあります。
+
+今後
+
+Receipt
+Settlement
+ProductMaster
+
+が絡むと事故ります。
+
+推奨
+
+Application Service側で
+
+prisma.$transaction(async tx => {})
+
+管理
+
+Repositoryへtx渡し
+
+repository.save(tx)
+
+形式
+
+優先度
+
+★★★★☆
+
+Issue4
+Domainモデル導入
+
+現在
+
+parsedData
+
+が
+
+any
+
+で流れています。
+
+実際に
+
+saveParsedReceipt(
+  parsedData: any
+)
+
+を確認しました。
+
+推奨
+
+ReceiptDraft
+ReceiptItem
+ReceiptAnalysisResult
+
+など型を作る
+
+例
+
+interface ReceiptDraft {
+  storeName: string
+  purchaseDate: Date
+  totalAmount: number
+}
+
+優先度
+
+★★★★★
+
+Issue5
+Context依存の整理
+
+現在
+
+getFamilyGroupId()
+getMemberId()
+
+を
+
+AsyncLocalStorage
+
+経由で取得しています。
+
+これは便利ですが、
+
+テスト時に追跡が難しくなります。
+
+推奨
+
+Controller
+
+const ctx = {
+  memberId,
+  familyGroupId
+}
+
+↓
+
+Serviceへ明示的に渡す
+
+優先度
+
+★★★☆☆
+
+Issue6
+AI層独立
+
+現在
+
+geminiService.ts
+
+が直接呼ばれています。
+
+将来的に
+
+Gemini
+OpenAI
+Claude
+
+切替したくなる可能性があります。
+
+推奨
+
+ai/
+
+AiProvider.ts
+
+GeminiProvider.ts
+OpenAiProvider.ts
+
+利用側
+
+aiProvider.analyzeReceipt()
+
+のみ
+
+優先度
+
+★★★★☆
+
+Issue7
+Frontend Screen肥大化対策
+
+構成を見ると
+
+screens/
+  ReceiptScanScreen
+  SplitEditorScreen
+  StatisticsScreen
+
+があります。
+
+今後確実に大きくなります。
+
+推奨
+
+features/
+
+receipt/
+  components/
+  hooks/
+  services/
+
+settlement/
+
+構成へ移行
+
+優先度
+
+★★★☆☆
+
+Issue8
+APIクライアント統一
+
+現在
+
+services/
+utils/apiClient.ts
+
+に分散しています。
+
+推奨
+
+frontend/src/api
+
+authApi.ts
+receiptApi.ts
+statsApi.ts
+
+に統一
+
+BackendのRoute単位と揃える
+
+優先度
+
+★★★☆☆
+
+私ならこう切る
+
+工数と効果のバランスを考えると
+
+Sprint1（安全）
+
+Issue1 Repository化
+
+Issue4 型定義強化
+
+Sprint2（効果大）
+
+Issue2 ReceiptService分割
+
+Issue3 Transaction整理
+
+Sprint3（将来投資）
+
+Issue6 AI Provider抽象化
+
+Issue8 Front API整理
+
+Sprint4（大型）
+
+Issue7 Feature単位構成
+
+Context整理
+
+結論
+
+このプロジェクトは「作り直しが必要な状態」では全くありません。
+
+むしろ、
+
+Docker化済み
+CIあり
+Prisma migration管理済み
+Worker分離済み
+テスト導入済み
+
+なので基盤はかなり良好です。
+
+保守性を上げるなら、最優先は
+
+① Repository導入
+→ ② ReceiptService分割
+→ ③ 型(any)排除
+
+です。
+
+この3つだけでも、今後Issueが100件→500件規模になったときの開発効率がかなり変わると思います。


### PR DESCRIPTION
## Summary

- `docs/refactor/plan.md` — Issue #98 リファクタ計画（ChatGPT 案 triage、Must/Should/Later、着手順）
- `docs/specs/chatgpt/ChatGPT_リファクタリング案.txt` — 監査ログ（`docs/chatgpt/` から移動）
- `docs/specs/README.md` — refactor plan へのリンク追加

Epic: #370

Closes #371

## Test plan

- [x] plan.md の子 Issue リンク（#371〜#378）が有効
- [x] ChatGPT 案の triage 表が前回合意内容と一致


Made with [Cursor](https://cursor.com)