### PR TITLE
refactor(types): [Issue #98-2] レシートドメイン型定義と any 排除

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -11,6 +11,7 @@ import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
 import { calcItemLineTotal } from '../utils/itemLineTotal';
 import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
 import { getRouteParam } from '../utils/routeParams';
+import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
 
 /**
  * [Issue #43] ジョブステータス取得
@@ -133,7 +134,7 @@ export const commitReceipt = async (req: Request, res: Response, next: NextFunct
     const result = await saveConfirmedReceipt(
       memberId,
       familyGroupId,
-      parsedData,
+      parsedData as ReceiptCommitPayload,
       imagePath,
       validation?.isSuspicious || false,
       validation?.warnings || []
@@ -169,7 +170,8 @@ export const createReceipt = async (req: Request, res: Response, next: NextFunct
     const { date, storeName, items, imagePath } = req.body;
 
     // 単価×数量の合計を算出し、四捨五入して整数にする
-    const calculatedTotal = items.reduce((sum: number, i: any) => {
+    const typedItems = items as ReceiptCreateItemInput[];
+    const calculatedTotal = typedItems.reduce((sum: number, i) => {
       return sum + (Number(i.price || 0) * Number(i.quantity || 0));
     }, 0);
 
@@ -180,10 +182,10 @@ export const createReceipt = async (req: Request, res: Response, next: NextFunct
         storeName,
         purchaseDate: date,
         totalAmount: Math.round(calculatedTotal), // 合計は整数
-        items: items.map((i: any) => ({
+        items: typedItems.map((i) => ({
           name: i.name,
-          price: parseFloat(i.price), 
-          quantity: parseFloat(i.quantity || 1),
+          price: parseFloat(String(i.price)), 
+          quantity: parseFloat(String(i.quantity || 1)),
           categoryId: i.categoryId ? Number(i.categoryId) : null
         }))
       },

--- a/backend/src/services/duplicateReceiptService.ts
+++ b/backend/src/services/duplicateReceiptService.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../utils/prismaClient';
 import { getCleanText, normalizeStoreName } from '../utils/normalizer';
+import type { ReceiptDuplicateCheckInput } from '../types/receipt';
 
 export type DuplicateCheckResult = {
   duplicateSuspected: boolean;
@@ -25,20 +26,13 @@ export function parseReceiptDate(dateStr: string | null | undefined): Date {
   return isNaN(fallback.getTime()) ? new Date() : fallback;
 }
 
-type ParsedLike = {
-  storeName?: string | null;
-  purchaseDate?: string | null;
-  date?: string | null;
-  totalAmount?: number | null;
-};
-
 /**
  * commit 前の read-only 重複候補判定（店名・日付・金額）。
  * saveParsedReceipt と同一ロジック。
  */
 export async function checkDuplicateReceipt(
   familyGroupId: number,
-  parsedData: ParsedLike,
+  parsedData: ReceiptDuplicateCheckInput,
   imagePath?: string | null
 ): Promise<DuplicateCheckResult> {
   const normalizedImage = imagePath?.replace(/\\/g, '/');

--- a/backend/src/services/geminiService.ts
+++ b/backend/src/services/geminiService.ts
@@ -3,22 +3,9 @@ import * as fs from "fs";
 import * as path from "path";
 import prisma from "../utils/prismaClient"; 
 import logger from "../utils/logger";
+import type { ParsedReceipt } from "../types/receipt";
 
-export interface ParsedItem {
-  name: string;
-  price: number;
-  quantity: number;
-  inferredCategory?: string; 
-}
-
-export interface ParsedReceipt {
-  storeName: string;
-  purchaseDate: string; 
-  totalAmount: number;
-  taxAmount?: number;
-  items: ParsedItem[];
-  usageLogId?: number; // [Issue #63] ログ紐付け用
-}
+export type { ParsedItem, ParsedReceipt } from "../types/receipt";
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
 

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
-import { analyzeReceiptImage, ParsedReceipt } from './geminiService';
+import { analyzeReceiptImage } from './geminiService';
+import type { ParsedItem, ReceiptCommitPayload } from '../types/receipt';
 import { estimateCategoryId } from './categoryService';
 import { validateReceiptItems } from './validationService';
 import { checkDuplicateReceipt, parseReceiptDate } from './duplicateReceiptService';
@@ -67,7 +68,7 @@ export const analyzeOnly = async (memberId: number, imagePath: string) => {
 export const saveParsedReceipt = async (
   memberId: number, 
   familyGroupId: number,
-  parsedData: any,
+  parsedData: ReceiptCommitPayload,
   imagePath: string,
   isSuspicious: boolean, 
   warnings: string[] 
@@ -117,7 +118,7 @@ export const saveParsedReceipt = async (
     }
 
     const savedId = await prisma.$transaction(async (tx) => {
-      const itemsToCreate = await Promise.all(parsedData.items.map(async (item: any) => {
+      const itemsToCreate = await Promise.all(parsedData.items.map(async (item: ParsedItem) => {
         const cleanName = getCleanText(item.name);
         const finalCategoryId = item.categoryId ? Number(item.categoryId) : null;
 
@@ -185,7 +186,7 @@ export const saveParsedReceipt = async (
 export const saveConfirmedReceipt = async (
   memberId: number,
   familyGroupId: number,
-  parsedData: any,
+  parsedData: ReceiptCommitPayload,
   imagePath: string,
   isSuspicious: boolean,
   warnings: string[]

--- a/backend/src/services/validationService.ts
+++ b/backend/src/services/validationService.ts
@@ -1,11 +1,12 @@
 import { VALIDATION_THRESHOLDS } from '../config/validationThresholds';
+import type { ParsedItem } from '../types/receipt';
 
 export interface ValidationResult {
   isSuspicious: boolean;
   warnings: string[];
 }
 
-export const validateReceiptItems = (items: any[]): ValidationResult => {
+export const validateReceiptItems = (items: ParsedItem[]): ValidationResult => {
   const warnings: string[] = [];
 
   items.forEach((item, index) => {

--- a/backend/src/types/receipt.ts
+++ b/backend/src/types/receipt.ts
@@ -1,0 +1,49 @@
+/**
+ * レシートドメイン型（Issue #98-2）
+ * Gemini 解析出力・commit/save 経路の共通型。api-spec §5.3 と整合。
+ */
+
+/** Gemini 解析出力の明細 */
+export interface ParsedItem {
+  name: string;
+  price: number;
+  quantity: number;
+  inferredCategory?: string;
+  /** analyzeOnly 後に付与 */
+  categoryId?: number | null;
+  /** validationService 用（Gemini 生出力の category キー） */
+  category?: string;
+  /** 行合計（OCR 由来、任意） */
+  amount?: number;
+}
+
+/** Gemini 解析出力 */
+export interface ParsedReceipt {
+  storeName: string;
+  purchaseDate: string;
+  totalAmount: number;
+  taxAmount?: number;
+  items: ParsedItem[];
+  usageLogId?: number;
+  /** 手動登録ルートの legacy alias（purchaseDate と同義） */
+  date?: string;
+}
+
+/** commit / saveParsedReceipt 入力 */
+export type ReceiptCommitPayload = ParsedReceipt;
+
+/** 重複チェック read-only 判定用（部分データを許容） */
+export type ReceiptDuplicateCheckInput = {
+  storeName?: string | null;
+  purchaseDate?: string | null;
+  date?: string | null;
+  totalAmount?: number | null;
+};
+
+/** POST /receipts 手動登録の明細入力 */
+export interface ReceiptCreateItemInput {
+  name: string;
+  price: number | string;
+  quantity?: number | string;
+  categoryId?: number | null;
+}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -32,6 +32,7 @@ import { BiometricLockScreen } from './src/screens/BiometricLockScreen';
 import { ReceiptTrayScreen } from './src/screens/ReceiptTrayScreen';
 import { ReceiptTrayProvider } from './src/contexts/ReceiptTrayContext';
 import type { ReceiptScanInitialData } from './src/types/receiptScan';
+import type { ReceiptForSplitEditor } from './src/types/settlement';
 
 import { theme } from './src/theme';
 import { ResponsiveContainer } from './src/components/ResponsiveContainer';
@@ -61,12 +62,12 @@ export default function App() {
   const [biometricEnabled, setBiometricEnabled] = useState(false);
   const [totpEnabled, setTotpEnabled] = useState(false);
 
-  const [resultData, setResultData] = useState<any>(null);
+  const [resultData, setResultData] = useState<ReceiptScanInitialData | null>(null);
   const [categories, setCategories] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<ViewType>('main');
   const [scanReturnView, setScanReturnView] = useState<ViewType>('main');
 
-  const [targetReceipt, setTargetReceipt] = useState<any>(null);
+  const [targetReceipt, setTargetReceipt] = useState<ReceiptForSplitEditor | null>(null);
   const refreshTrayRef = useRef<(() => Promise<void>) | null>(null);
 
   const applySession = useCallback((session: StoredSession) => {
@@ -258,7 +259,7 @@ export default function App() {
     saveState();
   }, [currentView, resultData, isReady, userToken]);
 
-  const handleAnalysisReady = (data: any) => {
+  const handleAnalysisReady = (data: ReceiptScanInitialData) => {
     setScanReturnView('main');
     setResultData(data);
     setCurrentView('receipt_scan');
@@ -334,7 +335,7 @@ export default function App() {
           />
         );
       case 'split_editor':
-        return (
+        return targetReceipt ? (
           <SplitEditorScreen
             receipt={targetReceipt}
             onBack={() => {
@@ -342,7 +343,7 @@ export default function App() {
               setCurrentView('history');
             }}
           />
-        );
+        ) : null;
       case 'settlement_summary':
         return (
           <SettlementSummaryScreen
@@ -358,14 +359,14 @@ export default function App() {
       case 'receipt_tray':
         return <ReceiptTrayScreen onBack={() => setCurrentView('main')} />;
       case 'receipt_scan':
-        return (
+        return resultData ? (
           <ReceiptScanScreen
             initialData={resultData}
             categories={categories}
             onSuccess={() => handleScanClose({ refreshTray: true })}
             onCancel={() => handleScanClose()}
           />
-        );
+        ) : null;
       case 'prompt_editor':
         return <PromptEditorScreen onBack={() => setCurrentView('admin_menu')} />;
       case 'admin_stats':

--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -14,15 +14,17 @@ import { theme } from '../theme';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import apiClient from '../utils/apiClient';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
+import type { CategorySummary, ReceiptDetail, ReceiptItemDetail } from '../types/receipt';
+import type { ReceiptForSplitEditor } from '../types/settlement';
 
 interface ReceiptDetailComponentProps {
-  receipt: any;
-  categories: any[];
+  receipt: ReceiptDetail | null | undefined;
+  categories: CategorySummary[];
   onCategoryChange: (itemId: number, categoryId: number | null) => void;
   baseUrl: string;
   fullWidth?: boolean; 
   onSaveSuccess?: () => void;
-  onGoToSplitEditor?: (receipt: any) => void; // ★ [Issue #79] 按分エディタへの遷移
+  onGoToSplitEditor?: (receipt: ReceiptForSplitEditor) => void;
 }
 
 /**
@@ -43,7 +45,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
 
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [editData, setEditData] = useState<any>(null);
+  const [editData, setEditData] = useState<ReceiptDetail | null>(null);
 
   const cacheKey = useMemo(() => Date.now(), []);
   const imageSource = useReceiptImageSource(receipt?.imagePath);
@@ -68,18 +70,18 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
   }, [receipt]);
 
   const displayTotal = useMemo(() => {
-    if (!editData) return 0;
+    if (!editData || !receipt) return 0;
     const items = isEditing ? editData.items : receipt.items;
     const tax = isEditing ? parseFloat(String(editData.taxAmount)) || 0 : receipt.taxAmount || 0;
 
-    const itemsSum = items.reduce((s: number, i: any) => {
+    const itemsSum = items.reduce((s: number, i: ReceiptItemDetail) => {
       const p = parseFloat(String(i.price)) || 0;
       const q = parseFloat(String(i.quantity)) || 0;
       return s + (p * q);
     }, 0);
 
     return Math.round(itemsSum + tax); 
-  }, [isEditing, editData?.items, editData?.taxAmount, receipt.items, receipt.taxAmount]);
+  }, [isEditing, editData, receipt]);
 
   if (!receipt || !editData) {
     return (
@@ -89,13 +91,13 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
     );
   }
 
-  const updateEditField = (key: string, value: any) => {
-    setEditData({ ...editData, [key]: value });
+  const updateEditField = (key: keyof ReceiptDetail, value: ReceiptDetail[keyof ReceiptDetail] | string) => {
+    setEditData({ ...editData, [key]: value } as ReceiptDetail);
   };
 
-  const updateEditItem = (index: number, key: string, value: any) => {
+  const updateEditItem = (index: number, key: keyof ReceiptItemDetail, value: ReceiptItemDetail[keyof ReceiptItemDetail] | string) => {
     const newItems = [...editData.items];
-    newItems[index] = { ...newItems[index], [key]: value };
+    newItems[index] = { ...newItems[index], [key]: value } as ReceiptItemDetail;
     setEditData({ ...editData, items: newItems });
   };
 
@@ -107,7 +109,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
         date: editData.date,
         taxAmount: parseFloat(String(editData.taxAmount)) || 0,
         totalAmount: displayTotal, 
-        items: editData.items.map((item: any) => ({
+        items: editData.items.map((item) => ({
           ...item,
           price: parseFloat(String(item.price)) || 0,
           quantity: parseFloat(String(item.quantity)) || 0,
@@ -171,10 +173,19 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
           ) : (
             <>
               {/* ★ [Issue #81] スマホ非表示化 ＆ 文言変更 */}
-              {onGoToSplitEditor && isWide && (
+              {onGoToSplitEditor && isWide && receipt.memberId != null && (
                 <AppButton
                   title="➗ 割り勘"
-                  onPress={() => onGoToSplitEditor(receipt)}
+                  onPress={() => {
+                    const memberId = receipt.memberId!;
+                    onGoToSplitEditor({
+                      id: receipt.id,
+                      memberId,
+                      imagePath: receipt.imagePath,
+                      storeName: receipt.storeName,
+                      items: receipt.items,
+                    });
+                  }}
                   variant="outline"
                   size="sm"
                   style={styles.splitButtonOverride}
@@ -228,7 +239,7 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
 
         <View style={styles.itemsSection}>
           <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
-          {(isEditing ? editData.items : receipt.items)?.map((item: any, idx: number) => (
+          {(isEditing ? editData.items : receipt.items)?.map((item: ReceiptItemDetail, idx: number) => (
             <View key={item.id || idx} style={styles.detailItemRow}>
               <View style={styles.detailItemTop}>
                 {isEditing ? (

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -16,11 +16,13 @@ import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
+import type { CategorySummary, ReceiptDetail } from '../types/receipt';
+import type { FamilyMemberSummary, ReceiptForSplitEditor } from '../types/settlement';
 
 interface HistoryScreenProps {
   onBack: () => void;
   currentMemberId: number; 
-  onGoToSplitEditor?: (receipt: any) => void; // ★ [Issue #79] App.tsxからの遷移ハンドラを受け取る
+  onGoToSplitEditor?: (receipt: ReceiptForSplitEditor) => void;
 }
 
 /**
@@ -30,10 +32,10 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
   const isWide = useIsWideLayout();
 
   const [loading, setLoading] = useState(true);
-  const [receipts, setReceipts] = useState<any[]>([]);
-  const [categories, setCategories] = useState<any[]>([]);
-  const [members, setMembers] = useState<any[]>([]); // ★ Issue #64: 動的世帯メンバー用ステート
-  const [selectedReceipt, setSelectedReceipt] = useState<any | null>(null);
+  const [receipts, setReceipts] = useState<ReceiptDetail[]>([]);
+  const [categories, setCategories] = useState<CategorySummary[]>([]);
+  const [members, setMembers] = useState<FamilyMemberSummary[]>([]);
+  const [selectedReceipt, setSelectedReceipt] = useState<ReceiptDetail | null>(null);
   
   const [selectedMonth, setSelectedMonth] = useState('');
   const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
@@ -95,7 +97,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
         
         // 編集・保存後に選択中データの参照を最新に更新
         if (selectedReceipt) {
-          const updated = data.find((r: any) => r.id === selectedReceipt.id);
+          const updated = data.find((r: ReceiptDetail) => r.id === selectedReceipt.id);
           if (updated) setSelectedReceipt(updated);
         } else if (isWide && data.length > 0) {
           // 初回ロード時は1件目を選択
@@ -131,15 +133,15 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
       
       if (response.data?.success) {
         const updatedItem = response.data.data;
-        const mapper = (r: any) => ({
+        const mapper = (r: ReceiptDetail): ReceiptDetail => ({
           ...r,
-          items: r.items.map((item: any) =>
+          items: r.items.map((item) =>
             item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
           ),
         });
 
         setReceipts(prev => prev.map(mapper));
-        if (selectedReceipt) setSelectedReceipt((prev: any) => mapper(prev));
+        if (selectedReceipt) setSelectedReceipt((prev) => (prev ? mapper(prev) : null));
       }
     } catch (err) {
       console.error('カテゴリー更新失敗', err);
@@ -149,7 +151,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
     }
   };
 
-  const renderItem = ({ item }: { item: any }) => {
+  const renderItem = ({ item }: { item: ReceiptDetail }) => {
     const isSelected = selectedReceipt?.id === item.id;
     const displayAmount = Math.round(item.totalAmount || 0);
 

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -28,9 +28,10 @@ import {
 import { showAlert } from '../utils/alertMessage';
 import { getCurrentYearMonth } from '../utils/monthSelectOptions';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
+import type { ReceiptScanInitialData } from '../types/receiptScan';
 
 interface HomeScreenProps {
-  onAnalysisReady: (data: any) => void;
+  onAnalysisReady: (data: ReceiptScanInitialData) => void;
   onGoToHistory: () => void;
   onGoToStats: () => void;
   onGoToReceiptTray: () => void;

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -19,16 +19,10 @@ import { theme } from '../theme';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 import { showAlert } from '../utils/alertMessage';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
+import type { ParsedReceiptItemInput } from '../types/receipt';
 
 const c = theme.colors;
 const s = theme.colors.semantic.scan;
-
-interface ReceiptItem {
-  name: string;
-  price: number | string; // 入力中は文字列を許容
-  quantity: number | string; // 入力中は文字列を許容
-  categoryId: number | null;
-}
 
 interface ReceiptScanScreenProps {
   initialData: ReceiptScanInitialData;
@@ -76,7 +70,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
     return Math.round(itemsTotal + tax);
   }, [receiptData.items, receiptData.taxAmount]);
 
-  const updateItem = (index: number, key: keyof ReceiptItem, value: any) => {
+  const updateItem = (index: number, key: keyof ParsedReceiptItemInput, value: ParsedReceiptItemInput[keyof ParsedReceiptItemInput]) => {
     const newItems = [...receiptData.items];
     newItems[index] = { ...newItems[index], [key]: value };
     setReceiptData({ ...receiptData, items: newItems });

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -19,6 +19,7 @@ import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
+import type { ReceiptDetail } from '../types/receipt';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 
 // --- interface 定義 ---
@@ -288,7 +289,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         title="解析レシート詳細"
       >
         <ReceiptDetailComponent
-          receipt={data?.latestReceipt}
+          receipt={data?.latestReceipt as ReceiptDetail | null | undefined}
           categories={allCategories}
           onCategoryChange={handleCategoryChange}
           baseUrl={BASE_URL}

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -29,3 +29,59 @@ export interface ReceiptInput {
     categoryId?: number | null;
   }[];
 }
+
+/** GET /categories レスポンス要素 */
+export interface CategorySummary {
+  id: number;
+  name: string;
+  color?: string | null;
+}
+
+/** 按分レコード（履歴 API に含まれる） */
+export interface ItemSplitSummary {
+  id: number;
+  itemId: number;
+  familyMemberId: number;
+  amount: number;
+}
+
+/** GET /receipts 明細 */
+export interface ReceiptItemDetail {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+  categoryId: number | null;
+  category?: CategorySummary | null;
+  splits?: ItemSplitSummary[];
+}
+
+/** GET /receipts レスポンス要素（統計 API の latestReceipt 等も包含） */
+export interface ReceiptDetail {
+  id: number;
+  storeName: string;
+  date?: string;
+  totalAmount: number;
+  taxAmount?: number;
+  imagePath?: string | null;
+  memberId?: number;
+  items: ReceiptItemDetail[];
+}
+
+/** commit 前の編集用明細（UI 入力中は string 許容） */
+export interface ParsedReceiptItemInput {
+  name: string;
+  price: number | string;
+  quantity: number | string;
+  categoryId: number | null;
+}
+
+/** commit 前の parsedData（api-spec §5.3） */
+export interface ParsedReceiptData {
+  storeName: string;
+  purchaseDate: string;
+  totalAmount: number;
+  taxAmount?: number | string;
+  items: ParsedReceiptItemInput[];
+  usageLogId?: number;
+}

--- a/frontend/src/types/receiptScan.ts
+++ b/frontend/src/types/receiptScan.ts
@@ -1,17 +1,7 @@
+import type { ParsedReceiptData } from './receipt';
+
 export type ReceiptScanInitialData = {
-  parsedData: {
-    storeName: string;
-    purchaseDate: string;
-    totalAmount: number;
-    taxAmount?: number | string;
-    items: Array<{
-      name: string;
-      price: number | string;
-      quantity: number | string;
-      categoryId: number | null;
-    }>;
-    usageLogId?: number;
-  };
+  parsedData: ParsedReceiptData;
   imagePath: string;
   validation: {
     isSuspicious: boolean;
@@ -26,7 +16,7 @@ export type ReceiptScanInitialData = {
 type JobStatusResponse = {
   state: string;
   result?: {
-    parsedData?: ReceiptScanInitialData['parsedData'];
+    parsedData?: ParsedReceiptData;
     imagePath?: string;
     validation?: ReceiptScanInitialData['validation'];
   };


### PR DESCRIPTION
## Summary

- `backend/src/types/receipt.ts` を新設し、`ParsedReceipt` / `ReceiptCommitPayload` 等のドメイン型を集約
- `saveParsedReceipt` / `saveConfirmedReceipt` / `commitReceipt` 経路の `parsedData: any` を排除
- Frontend の履歴・解析確認 UI（`HistoryScreen`, `ReceiptDetailComponent`, `ReceiptScanScreen` 等）を `ReceiptDetail` / `ParsedReceiptData` に接続

Epic: #370 / 計画: `docs/refactor/plan.md`

Closes #372

## Test plan

- [x] `cd backend && npm test` — 32 passed
- [x] `cd frontend && npm test` — 33 passed
- [ ] レシート解析 → 確認 → commit が正常に動作する
- [ ] 履歴画面で明細表示・カテゴリ変更・編集保存が動作する


Made with [Cursor](https://cursor.com)