### PR TITLE
refactor(receipt): [Issue #98-3] パイプライン整理と Controller 薄型化

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,21 +1,44 @@
 import { Request, Response, NextFunction } from 'express';
-import logger from '../utils/logger';
-import { prisma } from '../utils/prismaClient'; 
+import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
-import { getCleanText } from '../utils/normalizer';
 import { receiptQueue } from '../queues/receiptQueue';
-import { saveParsedReceipt, saveConfirmedReceipt } from '../services/receiptService';
-import { enrichCompletedJobPayload, listReceiptJobsForMember, discardReceiptJobForMember, removeReceiptJobAfterCommit } from '../services/receiptJobService'; 
+import {
+  enrichCompletedJobPayload,
+  listReceiptJobsForMember,
+  discardReceiptJobForMember,
+} from '../services/receiptJobService';
 import { getFamilyGroupId, getMemberId } from '../utils/context';
-import { allocateItemSplits, SplitInput } from '../utils/itemSplitAllocation';
-import { calcItemLineTotal } from '../utils/itemLineTotal';
-import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
 import { getRouteParam } from '../utils/routeParams';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
+import { isDuplicateReceiptError, getDuplicateExistingId } from '../services/receipt/receiptDuplicateError';
+import { commitReceipt as commitReceiptService } from '../services/receipt/receiptCommitService';
+import { createManualReceipt } from '../services/receipt/receiptUpdateService';
+import {
+  listReceipts,
+  getLatestReceipt as fetchLatestReceipt,
+  deleteReceiptById,
+  listFamilyMembers,
+} from '../services/receipt/receiptQueryService';
+import { updateReceiptById, updateItemCategoryById } from '../services/receipt/receiptUpdateService';
+import { updateItemSplitsById } from '../services/receipt/receiptSplitService';
+import {
+  getMonthlyStats as fetchMonthlyStats,
+  getAdvancedStats as fetchAdvancedStats,
+} from '../services/receipt/receiptStatsService';
+import { SplitInput } from '../utils/itemSplitAllocation';
 
-/**
- * [Issue #43] ジョブステータス取得
- */
+function handleDuplicateOrNext(error: unknown, res: Response, next: NextFunction): void {
+  if (isDuplicateReceiptError(error)) {
+    res.status(409).json({
+      success: false,
+      message: 'DUPLICATE',
+      existingId: getDuplicateExistingId(error),
+    });
+    return;
+  }
+  next(error);
+}
+
 export const getJobStatus = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
     const familyGroupId = getFamilyGroupId();
@@ -36,63 +59,47 @@ export const getJobStatus = async (req: Request<{ jobId: string }>, res: Respons
     };
     data = await enrichCompletedJobPayload(job, familyGroupId, data);
 
-    res.status(200).json({
-      success: true,
-      data,
-    });
-  } catch (error) { next(error); }
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #95-1] ログインメンバー本人の解析ジョブ一覧（確認トレイ用）
- */
 export const getReceiptJobs = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const familyGroupId = getFamilyGroupId();
     const memberId = getMemberId();
-    if (!memberId) {
-      throw new AppError('メンバーIDが指定されていません。', 400);
-    }
+    if (!memberId) throw new AppError('メンバーIDが指定されていません。', 400);
 
     const jobs = await listReceiptJobsForMember(familyGroupId, Number(memberId));
     res.status(200).json({ success: true, data: jobs });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #95-4] 未取り込み解析ジョブの破棄
- */
 export const discardReceiptJob = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
     const familyGroupId = getFamilyGroupId();
     const memberId = getMemberId();
-    if (!memberId) {
-      throw new AppError('メンバーIDが指定されていません。', 400);
-    }
+    if (!memberId) throw new AppError('メンバーIDが指定されていません。', 400);
 
-    await discardReceiptJobForMember(
-      getRouteParam(req, 'jobId'),
-      familyGroupId,
-      Number(memberId)
-    );
-
+    await discardReceiptJobForMember(getRouteParam(req, 'jobId'), familyGroupId, Number(memberId));
     res.status(200).json({ success: true, message: 'Discarded' });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * カテゴリ一覧取得
- */
 export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } });
     res.json({ success: true, data: categories });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * レシートアップロード (AI解析ジョブ投入)
- */
 export const uploadReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const memberId = getMemberId();
@@ -109,496 +116,164 @@ export const uploadReceipt = async (req: Request, res: Response, next: NextFunct
     });
 
     res.status(202).json({ success: true, data: { jobId: job.id } });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #49-8 / #63] 解析結果の確定保存
- * フロントエンドから送還される parsedData 内の usageLogId を欠落させずにサービス層へ引き渡します。
- */
 export const commitReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const memberId = getMemberId();
     const familyGroupId = getFamilyGroupId();
     const { parsedData, imagePath, validation, jobId } = req.body;
 
-    if (!parsedData || !imagePath) {
-      throw new AppError('必要なデータが不足しています。', 400);
-    }
+    if (!parsedData || !imagePath) throw new AppError('必要なデータが不足しています。', 400);
+    if (!memberId || !familyGroupId) throw new AppError('認証情報または世帯情報が取得できません。', 401);
 
-    if (!memberId || !familyGroupId) {
-      throw new AppError('認証情報または世帯情報が取得できません。', 401);
-    }
-
-    // parsedData オブジェクト内に含まれる usageLogId がそのまま引き渡されます
-    const result = await saveConfirmedReceipt(
+    const result = await commitReceiptService({
       memberId,
       familyGroupId,
-      parsedData as ReceiptCommitPayload,
+      parsedData: parsedData as ReceiptCommitPayload,
       imagePath,
-      validation?.isSuspicious || false,
-      validation?.warnings || []
-    );
-
-    if (jobId) {
-      await removeReceiptJobAfterCommit(String(jobId), familyGroupId, Number(memberId)).catch(() => {
-        // 既に破棄済み等は無視（保存は成功している）
-      });
-    }
+      isSuspicious: validation?.isSuspicious || false,
+      warnings: validation?.warnings || [],
+      jobId,
+    });
 
     res.status(201).json({ success: true, data: result });
-  } catch (error: any) { 
-    if (error.statusCode === 409) {
-      return res.status(409).json({
-        success: false,
-        message: 'DUPLICATE',
-        existingId: error.existingId ?? null,
-      });
-    }
-    next(error); 
+  } catch (error) {
+    handleDuplicateOrNext(error, res, next);
   }
 };
 
-/**
- * 手動登録 (Issue #67: Float対応 & 合計額自動算出)
- * ※手動登録ルートのため、解析用トークンログ（usageLogId）の紐付け処理は対象外
- */
 export const createReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const memberId = getMemberId();
     const familyGroupId = getFamilyGroupId();
     const { date, storeName, items, imagePath } = req.body;
 
-    // 単価×数量の合計を算出し、四捨五入して整数にする
-    const typedItems = items as ReceiptCreateItemInput[];
-    const calculatedTotal = typedItems.reduce((sum: number, i) => {
-      return sum + (Number(i.price || 0) * Number(i.quantity || 0));
-    }, 0);
-
-    const newReceipt = await saveParsedReceipt(
-      Number(memberId),
-      familyGroupId,
-      {
-        storeName,
-        purchaseDate: date,
-        totalAmount: Math.round(calculatedTotal), // 合計は整数
-        items: typedItems.map((i) => ({
-          name: i.name,
-          price: parseFloat(String(i.price)), 
-          quantity: parseFloat(String(i.quantity || 1)),
-          categoryId: i.categoryId ? Number(i.categoryId) : null
-        }))
-      },
-      imagePath || "",
-      false, 
-      []
-    );
+    const newReceipt = await createManualReceipt(Number(memberId), familyGroupId, {
+      date,
+      storeName,
+      items: items as ReceiptCreateItemInput[],
+      imagePath,
+    });
 
     res.status(201).json({ success: true, data: newReceipt });
-  } catch (error: any) { 
-    if (error.statusCode === 409) {
-      return res.status(409).json({
-        success: false,
-        message: 'DUPLICATE',
-        existingId: error.existingId ?? null,
-      });
-    }
-    next(error); 
+  } catch (error) {
+    handleDuplicateOrNext(error, res, next);
   }
 };
 
-/**
- * [Issue #67] 保存済みレシートの完全編集
- */
 export const updateReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
-  const { date, storeName, items } = req.body;
-  const familyGroupId = getFamilyGroupId();
-
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      // 1. 存在確認
-      const existing = await tx.receipt.findUnique({
-        where: { id: Number(id) },
-      });
-      if (!existing || existing.familyGroupId !== familyGroupId) {
-        throw new AppError('ReceiptNotFound', 404);
-      }
-
-      // 2. 合計金額の再計算（小数点対応後の整合性確保）
-      const calculatedTotal = items.reduce((sum: number, i: any) => {
-        return sum + (Number(i.price || 0) * Number(i.quantity || 0));
-      }, 0);
-      const finalTotal = Math.round(calculatedTotal);
-
-      // 3. レシート基本情報の更新
-      await tx.receipt.update({
-        where: { id: Number(id) },
-        data: {
-          date: date ? new Date(date) : undefined,
-          storeName: storeName || undefined,
-          totalAmount: finalTotal, // 四捨五入した整数値を保存
-        }
-      });
-
-      // 4. 明細（Item）の差し替え
-      await tx.item.deleteMany({ where: { receiptId: Number(id) } });
-      
-      if (items && Array.isArray(items)) {
-        await tx.item.createMany({
-          data: items.map((i: any) => ({
-            receiptId: Number(id),
-            name: i.name,
-            price: parseFloat(i.price) || 0,
-            quantity: parseFloat(i.quantity) || 0,
-            categoryId: i.categoryId ? Number(i.categoryId) : null,
-          }))
-        });
-
-        // 5. 学習マスタへのフィードバック
-        for (const item of items) {
-          if (item.categoryId) {
-            await tx.productMaster.upsert({
-              where: {
-                name_storeName_familyGroupId: {
-                  name: getCleanText(item.name),
-                  storeName: getCleanText(storeName || existing.storeName),
-                  familyGroupId
-                }
-              },
-              update: { categoryId: Number(item.categoryId) },
-              create: {
-                name: getCleanText(item.name),
-                storeName: getCleanText(storeName || existing.storeName),
-                categoryId: Number(item.categoryId),
-                familyGroupId
-              }
-            });
-          }
-        }
-      }
-
-      return await tx.receipt.findUnique({
-        where: { id: Number(id) },
-        include: { items: { include: { category: true } } }
-      });
-    });
-
-    res.json({ success: true, data: result });
-  } catch (error) { next(error); }
-};
-
-/**
- * カテゴリ更新 ＋ 学習マスタ反映
- */
-export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
-  const { categoryId } = req.body;
-  const familyGroupId = getFamilyGroupId();
-
-  try {
-    const result = await prisma.$transaction(async (tx) => {
-      const currentItem = await tx.item.findUnique({
-        where: { id: Number(id) },
-        include: { receipt: true }
-      });
-
-      if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
-        throw new AppError('ItemNotFound', 404);
-      }
-
-      if (categoryId) {
-        const category = await tx.category.findFirst({
-          where: { id: Number(categoryId), familyGroupId },
-        });
-        if (!category) throw new AppError('CategoryNotFound', 404);
-      }
-
-      const updatedItem = await tx.item.update({
-        where: { id: Number(id) },
-        data: { categoryId: categoryId ? Number(categoryId) : null },
-        include: { category: true }
-      });
-
-      if (categoryId) {
-        await tx.productMaster.upsert({
-          where: {
-            name_storeName_familyGroupId: {
-              name: getCleanText(currentItem.name),
-              storeName: getCleanText(currentItem.receipt.storeName),
-              familyGroupId
-            }
-          },
-          update: { categoryId: Number(categoryId) },
-          create: {
-            name: getCleanText(currentItem.name),
-            storeName: getCleanText(currentItem.receipt.storeName),
-            categoryId: Number(categoryId),
-            familyGroupId
-          }
-        });
-      }
-      return updatedItem;
-    });
-    res.json({ success: true, data: result });
-  } catch (error) { next(error); }
-};
-
-/**
- * レシート一覧取得
- */
-export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { month } = req.query;
+    const id = getRouteParam(req, 'id');
+    const { date, storeName, items } = req.body;
     const familyGroupId = getFamilyGroupId();
 
-    const where: any = { familyGroupId };
+    const result = await updateReceiptById(Number(id), familyGroupId, {
+      date,
+      storeName,
+      items: items as ReceiptCreateItemInput[],
+    });
 
-    // 「世帯全体」は memberId="" → 世帯全件。空文字を x-member-id にフォールバックしない
-    const rawMemberId = req.query.memberId;
-    if (
-      rawMemberId !== undefined &&
-      rawMemberId !== null &&
-      String(rawMemberId).trim() !== ''
-    ) {
-      const filterMemberId = Number(rawMemberId);
-      if (!Number.isNaN(filterMemberId)) {
-        where.memberId = filterMemberId;
-      }
-    }
+    res.json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+};
 
-    const normalizedMonth = normalizeYearMonth(
-      typeof month === 'string' ? month : undefined
-    );
-    if (normalizedMonth) {
-      const { start, end } = getLocalMonthDateRange(normalizedMonth);
-      where.date = { gte: start, lt: end };
-    }
+export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = getRouteParam(req, 'id');
+    const { categoryId } = req.body;
+    const familyGroupId = getFamilyGroupId();
 
-    const receipts = await prisma.receipt.findMany({
-      where,
-      include: { items: { include: { category: true, splits: true } } }, // ★ Issue #78: splitsも一緒に取得するよう変更
-      orderBy: { date: 'desc' }
+    const result = await updateItemCategoryById(Number(id), familyGroupId, categoryId);
+    res.json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { month, memberId } = req.query;
+    const receipts = await listReceipts({
+      familyGroupId: getFamilyGroupId(),
+      memberId: typeof memberId === 'string' ? memberId : undefined,
+      month: typeof month === 'string' ? month : undefined,
     });
     res.json({ success: true, data: receipts });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * 最新1件取得
- */
 export const getLatestReceipt = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const receipt = await prisma.receipt.findFirst({
-      where: { familyGroupId: getFamilyGroupId() },
-      orderBy: { createdAt: 'desc' },
-      include: { items: { include: { category: true, splits: true } } } // ★ Issue #78
-    });
+    const receipt = await fetchLatestReceipt(getFamilyGroupId());
     res.json({ success: true, data: receipt });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * 削除
- */
 export const deleteReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    await prisma.receipt.delete({ 
-      where: { id: Number(getRouteParam(req, 'id')) } 
-    });
+    await deleteReceiptById(Number(getRouteParam(req, 'id')));
     res.json({ success: true, message: 'Deleted' });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #49-8] 月別統計
- */
 export const getMonthlyStats = async (req: Request, res: Response, next: NextFunction) => {
-  const familyGroupId = getFamilyGroupId();
-  const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
-
   try {
-    const totalRes = await prisma.$queryRaw<any[]>`
-      SELECT SUM("totalAmount")::double precision as total
-      FROM "Receipt"
-      WHERE "familyGroupId" = ${familyGroupId}
-      AND TO_CHAR(date, 'YYYY-MM') = ${month}
-    `;
-    const totalAmount = totalRes[0]?.total || 0;
-
-    const categoryStats = await prisma.$queryRaw<any[]>`
-      SELECT 
-        c.id as "categoryId",
-        c.name as "categoryName",
-        c.color as "color",
-        SUM(i.price * i.quantity)::double precision as "totalAmount"
-      FROM "Item" i
-      JOIN "Receipt" r ON i."receiptId" = r.id
-      LEFT JOIN "Category" c ON i."categoryId" = c.id
-      WHERE r."familyGroupId" = ${familyGroupId}
-      AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
-      GROUP BY c.id, c.name, c.color
-      ORDER BY "totalAmount" DESC
-    `;
-
-    const latestReceipt = await prisma.receipt.findFirst({
-      where: { 
-        familyGroupId, 
-        date: { 
-          gte: new Date(`${month}-01`), 
-          lt: new Date(new Date(`${month}-01`).setMonth(new Date(`${month}-01`).getMonth() + 1)) 
-        } 
-      },
-      orderBy: { date: 'desc' },
-      include: { items: { include: { category: true } } }
-    });
-
-    res.json({ 
-      success: true, 
-      data: {
-        month,
-        totalAmount,
-        stats: categoryStats.map(s => ({
-          ...s,
-          categoryName: s.categoryName || '未分類'
-        })),
-        latestReceipt
-      }
-    });
-  } catch (error) { next(error); }
+    const familyGroupId = getFamilyGroupId();
+    const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
+    const data = await fetchMonthlyStats(familyGroupId, month);
+    res.json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #49-8] 高度な統計
- */
 export const getAdvancedStats = async (_req: Request, res: Response, next: NextFunction) => {
-  const fId = getFamilyGroupId();
   try {
-    const trend = await prisma.$queryRaw<any[]>`
-      SELECT 
-        TO_CHAR(date, 'YYYY-MM') as period, 
-        SUM("totalAmount")::double precision as total 
-      FROM "Receipt" 
-      WHERE "familyGroupId" = ${fId} 
-      GROUP BY period 
-      ORDER BY period DESC 
-      LIMIT 6
-    `;
-
-    const month = new Date().toISOString().slice(0, 7);
-    const paretoRaw = await prisma.$queryRaw<any[]>`
-      SELECT 
-        COALESCE(c.name, '未分類') as name,
-        SUM(i.price * i.quantity)::double precision as amount
-      FROM "Item" i
-      JOIN "Receipt" r ON i."receiptId" = r.id
-      LEFT JOIN "Category" c ON i."categoryId" = c.id
-      WHERE r."familyGroupId" = ${fId}
-      AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
-      GROUP BY c.name
-      ORDER BY amount DESC
-    `;
-
-    const total = paretoRaw.reduce((sum, item) => sum + (item.amount || 0), 0);
-    let cumulative = 0;
-    const pareto = paretoRaw.map(item => {
-      const ratio = total > 0 ? Math.round((item.amount / total) * 100) : 0;
-      cumulative += ratio;
-      return {
-        ...item,
-        ratio,
-        cumulative_ratio: cumulative > 100 ? 100 : cumulative
-      };
-    });
-
-    res.json({ success: true, data: { trend, pareto } });
-  } catch (error) { next(error); }
+    const data = await fetchAdvancedStats(getFamilyGroupId());
+    res.json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * [Issue #64] 所属世帯のメンバー一覧取得
- */
 export const getFamilyMembers = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const familyGroupId = getFamilyGroupId();
-    if (!familyGroupId) {
-      throw new AppError('世帯情報が取得できません。', 400);
-    }
+    if (!familyGroupId) throw new AppError('世帯情報が取得できません。', 400);
 
-    const members = await prisma.familyMember.findMany({
-      where: { familyGroupId },
-      select: {
-        id: true,
-        name: true,
-      },
-      orderBy: { id: 'asc' }
-    });
-
+    const members = await listFamilyMembers(familyGroupId);
     res.json({ success: true, data: members });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };
 
-/**
- * ★ [Issue #78] 明細（Item）の負担内訳（ItemSplit）を更新・保存する
- * 要求されるデータ形式:
- * { splits: [{ familyMemberId: 1, ratio: 0.5 }, { familyMemberId: 2, amount: 500 }] }
- * 配列が空の場合は「按分なし」とみなし、既存のSplitを全削除します。
- */
 export const updateItemSplits = async (req: Request, res: Response, next: NextFunction) => {
-  const itemId = getRouteParam(req, 'itemId');
-  const { splits } = req.body;
-  const familyGroupId = getFamilyGroupId();
-
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      // 1. 対象明細の存在とテナント権限の確認
-      const item = await tx.item.findUnique({
-        where: { id: Number(itemId) },
-        include: { receipt: true }
-      });
+    const itemId = getRouteParam(req, 'itemId');
+    const { splits } = req.body;
+    const familyGroupId = getFamilyGroupId();
 
-      if (!item || item.receipt.familyGroupId !== familyGroupId) {
-        throw new AppError('ItemNotFound', 404);
-      }
-
-      // 2. 空配列が送られてきた場合は、暗黙的デフォルト（按分なし）とみなして削除のみ行う
-      if (!splits || !Array.isArray(splits) || splits.length === 0) {
-        await tx.itemSplit.deleteMany({ where: { itemId: Number(itemId) } });
-        return { message: 'Splits cleared (Fallback to default payer)' };
-      }
-
-      const totalAmount = calcItemLineTotal(item.price, item.quantity);
-      const splitInputs: SplitInput[] = splits.map((split: SplitInput) => ({
-        familyMemberId: Number(split.familyMemberId),
-        ratio: split.ratio,
-        amount: split.amount,
-      }));
-
-      const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
-      const validMembers = await tx.familyMember.findMany({
-        where: { id: { in: memberIds }, familyGroupId },
-        select: { id: true },
-      });
-      if (validMembers.length !== memberIds.length) {
-        throw new AppError('Invalid familyMemberId in splits', 403);
-      }
-
-      const finalSplits = allocateItemSplits(totalAmount, splitInputs);
-
-      // DBの洗い替え（Delete & Insert）
-      await tx.itemSplit.deleteMany({ where: { itemId: Number(itemId) } });
-      await tx.itemSplit.createMany({
-        data: finalSplits.map(fs => ({
-          itemId: Number(itemId),
-          familyMemberId: fs.familyMemberId,
-          amount: fs.amount,
-        }))
-      });
-
-      // 更新後のSplitリストを返す
-      return await tx.itemSplit.findMany({ where: { itemId: Number(itemId) } });
-    });
+    const result = await updateItemSplitsById(
+      Number(itemId),
+      familyGroupId,
+      splits as SplitInput[] | undefined
+    );
 
     res.json({ success: true, data: result });
-  } catch (error) { next(error); }
+  } catch (error) {
+    next(error);
+  }
 };

--- a/backend/src/services/receipt/receiptAnalysisService.ts
+++ b/backend/src/services/receipt/receiptAnalysisService.ts
@@ -1,0 +1,61 @@
+import { prisma } from '../../utils/prismaClient';
+import logger from '../../utils/logger';
+import { getCleanText } from '../../utils/normalizer';
+import { analyzeReceiptImage } from '../geminiService';
+import { estimateCategoryId } from '../categoryService';
+import { validateReceiptItems } from '../validationService';
+
+/**
+ * [Issue #49-8 / #72 / #63] 解析のみを実行し、推論カテゴリを付与して返す
+ * 戻り値に usageLogId を含める。DB 永続化は行わない（commit 時に実施）。
+ */
+export async function analyzeOnly(memberId: number, imagePath: string) {
+  logger.info(`[Analyze] 解析開始: ${imagePath} (Member: ${memberId})`);
+
+  const member = await prisma.familyMember.findUnique({
+    where: { id: memberId },
+    select: { familyGroupId: true },
+  });
+  const familyGroupId = member?.familyGroupId;
+
+  const parsedData = await analyzeReceiptImage(imagePath, memberId);
+  const cleanStore = getCleanText(parsedData.storeName || '');
+
+  const itemsWithCategories = await Promise.all(
+    parsedData.items.map(async (item) => {
+      const cleanName = getCleanText(item.name);
+      let initialCategoryId = null;
+
+      if (familyGroupId) {
+        const mastered = await prisma.productMaster.findUnique({
+          where: {
+            name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId },
+          },
+        });
+        initialCategoryId = mastered
+          ? mastered.categoryId
+          : await estimateCategoryId(cleanName, cleanStore, familyGroupId, prisma);
+      }
+
+      return {
+        ...item,
+        price: parseFloat(String(item.price || 0)),
+        quantity: parseFloat(String(item.quantity || 1)),
+        categoryId: initialCategoryId,
+      };
+    })
+  );
+
+  parsedData.items = itemsWithCategories;
+  parsedData.taxAmount = parsedData.taxAmount
+    ? parseFloat(String(parsedData.taxAmount))
+    : undefined;
+
+  const validation = validateReceiptItems(parsedData.items);
+
+  return {
+    parsedData,
+    imagePath,
+    validation,
+  };
+}

--- a/backend/src/services/receipt/receiptCommitService.ts
+++ b/backend/src/services/receipt/receiptCommitService.ts
@@ -1,0 +1,35 @@
+import { saveConfirmedReceipt } from './receiptPersistenceService';
+import { removeReceiptJobAfterCommit } from '../receiptJobService';
+import type { ReceiptCommitPayload } from '../../types/receipt';
+
+export type CommitReceiptInput = {
+  memberId: number;
+  familyGroupId: number;
+  parsedData: ReceiptCommitPayload;
+  imagePath: string;
+  isSuspicious: boolean;
+  warnings: string[];
+  jobId?: string;
+};
+
+/** 解析結果の確定保存（必要に応じてジョブ削除） */
+export async function commitReceipt(input: CommitReceiptInput) {
+  const result = await saveConfirmedReceipt(
+    input.memberId,
+    input.familyGroupId,
+    input.parsedData,
+    input.imagePath,
+    input.isSuspicious,
+    input.warnings
+  );
+
+  if (input.jobId) {
+    await removeReceiptJobAfterCommit(String(input.jobId), input.familyGroupId, input.memberId).catch(
+      () => {
+        // 既に破棄済み等は無視（保存は成功している）
+      }
+    );
+  }
+
+  return result;
+}

--- a/backend/src/services/receipt/receiptDuplicateError.ts
+++ b/backend/src/services/receipt/receiptDuplicateError.ts
@@ -1,0 +1,30 @@
+/** commit / 手動登録時の重複レシート検出 */
+export class DuplicateReceiptError extends Error {
+  readonly statusCode = 409;
+  readonly existingId: number | null;
+
+  constructor(existingId?: number | null) {
+    super('DUPLICATE_RECEIPT_DETECTED');
+    this.name = 'DuplicateReceiptError';
+    this.existingId = existingId ?? null;
+  }
+}
+
+export function isDuplicateReceiptError(error: unknown): error is DuplicateReceiptError {
+  return (
+    error instanceof DuplicateReceiptError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'statusCode' in error &&
+      (error as { statusCode: number }).statusCode === 409)
+  );
+}
+
+export function getDuplicateExistingId(error: unknown): number | null {
+  if (error instanceof DuplicateReceiptError) return error.existingId;
+  if (typeof error === 'object' && error !== null && 'existingId' in error) {
+    const id = (error as { existingId?: number | null }).existingId;
+    return id ?? null;
+  }
+  return null;
+}

--- a/backend/src/services/receipt/receiptPersistenceService.ts
+++ b/backend/src/services/receipt/receiptPersistenceService.ts
@@ -1,0 +1,122 @@
+import { prisma } from '../../utils/prismaClient';
+import logger from '../../utils/logger';
+import { normalizeStoreName, getCleanText } from '../../utils/normalizer';
+import { checkDuplicateReceipt, parseReceiptDate } from '../duplicateReceiptService';
+import type { ParsedItem, ReceiptCommitPayload } from '../../types/receipt';
+import { DuplicateReceiptError } from './receiptDuplicateError';
+
+/**
+ * パース済みデータを DB に永続化（重複チェック ＋ 世帯別学習）
+ * [Issue #63 / #72] ApiUsageLog 紐付けをトランザクション内で実行
+ */
+export async function saveParsedReceipt(
+  memberId: number,
+  familyGroupId: number,
+  parsedData: ReceiptCommitPayload,
+  imagePath: string,
+  isSuspicious: boolean,
+  warnings: string[]
+) {
+  const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
+  const cleanStore = getCleanText(officialStoreName);
+  const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
+
+  const totalAmount = Math.round(Number(parsedData.totalAmount || 0));
+  const taxAmount = parsedData.taxAmount ? parseFloat(String(parsedData.taxAmount)) : 0;
+
+  const usageLogIdStr = parsedData.usageLogId !== undefined ? String(parsedData.usageLogId) : null;
+  const usageLogId = usageLogIdStr ? parseInt(usageLogIdStr, 10) : null;
+
+  if (imagePath) {
+    const existingByImage = await prisma.receipt.findFirst({
+      where: { familyGroupId, imagePath },
+      include: { items: { include: { category: true } } },
+    });
+    if (existingByImage) {
+      logger.info(`[Idempotent] imagePath 一致のため既存レシートを返却: ID ${existingByImage.id}`);
+      return {
+        ...JSON.parse(JSON.stringify(existingByImage)),
+        isSuspicious,
+        warnings,
+      };
+    }
+  }
+
+  const duplicate = await checkDuplicateReceipt(familyGroupId, parsedData, imagePath);
+  if (duplicate.duplicateSuspected) {
+    throw new DuplicateReceiptError(duplicate.existingReceiptId);
+  }
+
+  const savedId = await prisma.$transaction(
+    async (tx) => {
+      const itemsToCreate = await Promise.all(
+        parsedData.items.map(async (item: ParsedItem) => {
+          const cleanName = getCleanText(item.name);
+          const finalCategoryId = item.categoryId ? Number(item.categoryId) : null;
+
+          if (finalCategoryId) {
+            await tx.productMaster.upsert({
+              where: {
+                name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId },
+              },
+              update: { categoryId: finalCategoryId },
+              create: { name: cleanName, storeName: cleanStore, categoryId: finalCategoryId, familyGroupId },
+            });
+          }
+
+          return {
+            name: item.name,
+            price: parseFloat(String(item.price || 0)),
+            quantity: parseFloat(String(item.quantity || 1)),
+            categoryId: finalCategoryId,
+          };
+        })
+      );
+
+      const created = await tx.receipt.create({
+        data: {
+          memberId,
+          familyGroupId,
+          storeName: officialStoreName,
+          date: jstDate,
+          totalAmount,
+          taxAmount,
+          imagePath,
+          items: { create: itemsToCreate },
+          rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
+        },
+        select: { id: true },
+      });
+
+      if (usageLogId && !isNaN(usageLogId)) {
+        await tx.apiUsageLog.update({
+          where: { id: usageLogId },
+          data: { receiptId: created.id },
+        });
+        logger.info(`[Link_Log] ApiUsageLog(ID: ${usageLogId}) を Receipt(ID: ${created.id}) に紐付けました。`);
+      }
+
+      return created.id;
+    },
+    { timeout: 15000 }
+  );
+
+  const final = await prisma.receipt.findUnique({
+    where: { id: savedId },
+    include: { items: { include: { category: true } } },
+  });
+
+  return { ...JSON.parse(JSON.stringify(final)), isSuspicious, warnings };
+}
+
+/** ユーザー確認済みデータの永続化 */
+export async function saveConfirmedReceipt(
+  memberId: number,
+  familyGroupId: number,
+  parsedData: ReceiptCommitPayload,
+  imagePath: string,
+  isSuspicious: boolean,
+  warnings: string[]
+) {
+  return saveParsedReceipt(memberId, familyGroupId, parsedData, imagePath, isSuspicious, warnings);
+}

--- a/backend/src/services/receipt/receiptQueryService.ts
+++ b/backend/src/services/receipt/receiptQueryService.ts
@@ -1,0 +1,55 @@
+import { prisma } from '../../utils/prismaClient';
+import { getLocalMonthDateRange, normalizeYearMonth } from '../../utils/yearMonth';
+
+export type ListReceiptsParams = {
+  familyGroupId: number;
+  memberId?: string;
+  month?: string;
+};
+
+export async function listReceipts(params: ListReceiptsParams) {
+  const { familyGroupId, memberId, month } = params;
+
+  const where: { familyGroupId: number; memberId?: number; date?: { gte: Date; lt: Date } } = {
+    familyGroupId,
+  };
+
+  if (memberId !== undefined && memberId !== null && String(memberId).trim() !== '') {
+    const filterMemberId = Number(memberId);
+    if (!Number.isNaN(filterMemberId)) {
+      where.memberId = filterMemberId;
+    }
+  }
+
+  const normalizedMonth = normalizeYearMonth(typeof month === 'string' ? month : undefined);
+  if (normalizedMonth) {
+    const { start, end } = getLocalMonthDateRange(normalizedMonth);
+    where.date = { gte: start, lt: end };
+  }
+
+  return prisma.receipt.findMany({
+    where,
+    include: { items: { include: { category: true, splits: true } } },
+    orderBy: { date: 'desc' },
+  });
+}
+
+export async function getLatestReceipt(familyGroupId: number) {
+  return prisma.receipt.findFirst({
+    where: { familyGroupId },
+    orderBy: { createdAt: 'desc' },
+    include: { items: { include: { category: true, splits: true } } },
+  });
+}
+
+export async function deleteReceiptById(receiptId: number) {
+  await prisma.receipt.delete({ where: { id: receiptId } });
+}
+
+export async function listFamilyMembers(familyGroupId: number) {
+  return prisma.familyMember.findMany({
+    where: { familyGroupId },
+    select: { id: true, name: true },
+    orderBy: { id: 'asc' },
+  });
+}

--- a/backend/src/services/receipt/receiptSplitService.ts
+++ b/backend/src/services/receipt/receiptSplitService.ts
@@ -1,0 +1,56 @@
+import { prisma } from '../../utils/prismaClient';
+import { AppError } from '../../utils/appError';
+import { allocateItemSplits, SplitInput } from '../../utils/itemSplitAllocation';
+import { calcItemLineTotal } from '../../utils/itemLineTotal';
+
+/** 明細（Item）の負担内訳（ItemSplit）を更新・保存 */
+export async function updateItemSplitsById(
+  itemId: number,
+  familyGroupId: number,
+  splits: SplitInput[] | undefined | null
+) {
+  return prisma.$transaction(async (tx) => {
+    const item = await tx.item.findUnique({
+      where: { id: itemId },
+      include: { receipt: true },
+    });
+
+    if (!item || item.receipt.familyGroupId !== familyGroupId) {
+      throw new AppError('ItemNotFound', 404);
+    }
+
+    if (!splits || !Array.isArray(splits) || splits.length === 0) {
+      await tx.itemSplit.deleteMany({ where: { itemId } });
+      return { message: 'Splits cleared (Fallback to default payer)' };
+    }
+
+    const totalAmount = calcItemLineTotal(item.price, item.quantity);
+    const splitInputs: SplitInput[] = splits.map((split) => ({
+      familyMemberId: Number(split.familyMemberId),
+      ratio: split.ratio,
+      amount: split.amount,
+    }));
+
+    const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
+    const validMembers = await tx.familyMember.findMany({
+      where: { id: { in: memberIds }, familyGroupId },
+      select: { id: true },
+    });
+    if (validMembers.length !== memberIds.length) {
+      throw new AppError('Invalid familyMemberId in splits', 403);
+    }
+
+    const finalSplits = allocateItemSplits(totalAmount, splitInputs);
+
+    await tx.itemSplit.deleteMany({ where: { itemId } });
+    await tx.itemSplit.createMany({
+      data: finalSplits.map((fs) => ({
+        itemId,
+        familyMemberId: fs.familyMemberId,
+        amount: fs.amount,
+      })),
+    });
+
+    return tx.itemSplit.findMany({ where: { itemId } });
+  });
+}

--- a/backend/src/services/receipt/receiptStatsService.ts
+++ b/backend/src/services/receipt/receiptStatsService.ts
@@ -1,0 +1,93 @@
+import { prisma } from '../../utils/prismaClient';
+
+/** 月別統計 */
+export async function getMonthlyStats(familyGroupId: number, month: string) {
+  const totalRes = await prisma.$queryRaw<{ total: number | null }[]>`
+    SELECT SUM("totalAmount")::double precision as total
+    FROM "Receipt"
+    WHERE "familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(date, 'YYYY-MM') = ${month}
+  `;
+  const totalAmount = totalRes[0]?.total || 0;
+
+  const categoryStats = await prisma.$queryRaw<
+    { categoryId: number | null; categoryName: string | null; color: string | null; totalAmount: number }[]
+  >`
+    SELECT 
+      c.id as "categoryId",
+      c.name as "categoryName",
+      c.color as "color",
+      SUM(i.price * i.quantity)::double precision as "totalAmount"
+    FROM "Item" i
+    JOIN "Receipt" r ON i."receiptId" = r.id
+    LEFT JOIN "Category" c ON i."categoryId" = c.id
+    WHERE r."familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
+    GROUP BY c.id, c.name, c.color
+    ORDER BY "totalAmount" DESC
+  `;
+
+  const latestReceipt = await prisma.receipt.findFirst({
+    where: {
+      familyGroupId,
+      date: {
+        gte: new Date(`${month}-01`),
+        lt: new Date(new Date(`${month}-01`).setMonth(new Date(`${month}-01`).getMonth() + 1)),
+      },
+    },
+    orderBy: { date: 'desc' },
+    include: { items: { include: { category: true } } },
+  });
+
+  return {
+    month,
+    totalAmount,
+    stats: categoryStats.map((s) => ({
+      ...s,
+      categoryName: s.categoryName || '未分類',
+    })),
+    latestReceipt,
+  };
+}
+
+/** 高度な統計（トレンド・パレート） */
+export async function getAdvancedStats(familyGroupId: number) {
+  const trend = await prisma.$queryRaw<{ period: string; total: number }[]>`
+    SELECT 
+      TO_CHAR(date, 'YYYY-MM') as period, 
+      SUM("totalAmount")::double precision as total 
+    FROM "Receipt" 
+    WHERE "familyGroupId" = ${familyGroupId} 
+    GROUP BY period 
+    ORDER BY period DESC 
+    LIMIT 6
+  `;
+
+  const month = new Date().toISOString().slice(0, 7);
+  const paretoRaw = await prisma.$queryRaw<{ name: string; amount: number }[]>`
+    SELECT 
+      COALESCE(c.name, '未分類') as name,
+      SUM(i.price * i.quantity)::double precision as amount
+    FROM "Item" i
+    JOIN "Receipt" r ON i."receiptId" = r.id
+    LEFT JOIN "Category" c ON i."categoryId" = c.id
+    WHERE r."familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
+    GROUP BY c.name
+    ORDER BY amount DESC
+  `;
+
+  const total = paretoRaw.reduce((sum, item) => sum + (item.amount || 0), 0);
+  let cumulative = 0;
+  const pareto = paretoRaw.map((item) => {
+    const ratio = total > 0 ? Math.round((item.amount / total) * 100) : 0;
+    cumulative += ratio;
+    return {
+      ...item,
+      ratio,
+      cumulative_ratio: cumulative > 100 ? 100 : cumulative,
+    };
+  });
+
+  return { trend, pareto };
+}

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -1,0 +1,179 @@
+import { prisma } from '../../utils/prismaClient';
+import { AppError } from '../../utils/appError';
+import { getCleanText } from '../../utils/normalizer';
+import type { ReceiptCreateItemInput } from '../../types/receipt';
+import { saveParsedReceipt } from './receiptPersistenceService';
+
+export type ManualReceiptInput = {
+  date: string;
+  storeName: string;
+  items: ReceiptCreateItemInput[];
+  imagePath?: string;
+};
+
+function buildCommitPayload(input: ManualReceiptInput) {
+  const typedItems = input.items;
+  const calculatedTotal = typedItems.reduce((sum, i) => {
+    return sum + Number(i.price || 0) * Number(i.quantity || 0);
+  }, 0);
+
+  return {
+    storeName: input.storeName,
+    purchaseDate: input.date,
+    totalAmount: Math.round(calculatedTotal),
+    items: typedItems.map((i) => ({
+      name: i.name,
+      price: parseFloat(String(i.price)),
+      quantity: parseFloat(String(i.quantity || 1)),
+      categoryId: i.categoryId ? Number(i.categoryId) : null,
+    })),
+  };
+}
+
+/** 手動登録（解析 usageLogId 紐付けなし） */
+export async function createManualReceipt(
+  memberId: number,
+  familyGroupId: number,
+  input: ManualReceiptInput
+) {
+  const payload = buildCommitPayload(input);
+  return saveParsedReceipt(
+    memberId,
+    familyGroupId,
+    payload,
+    input.imagePath || '',
+    false,
+    []
+  );
+}
+
+export type UpdateReceiptInput = {
+  date?: string;
+  storeName?: string;
+  items?: ReceiptCreateItemInput[];
+};
+
+/** 保存済みレシートの完全編集 */
+export async function updateReceiptById(
+  receiptId: number,
+  familyGroupId: number,
+  input: UpdateReceiptInput
+) {
+  const { date, storeName, items } = input;
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.receipt.findUnique({
+      where: { id: receiptId },
+    });
+    if (!existing || existing.familyGroupId !== familyGroupId) {
+      throw new AppError('ReceiptNotFound', 404);
+    }
+
+    const itemList = items ?? [];
+    const calculatedTotal = itemList.reduce((sum, i) => {
+      return sum + Number(i.price || 0) * Number(i.quantity || 0);
+    }, 0);
+    const finalTotal = Math.round(calculatedTotal);
+
+    await tx.receipt.update({
+      where: { id: receiptId },
+      data: {
+        date: date ? new Date(date) : undefined,
+        storeName: storeName || undefined,
+        totalAmount: finalTotal,
+      },
+    });
+
+    await tx.item.deleteMany({ where: { receiptId } });
+
+    if (itemList.length > 0) {
+      await tx.item.createMany({
+        data: itemList.map((i) => ({
+          receiptId,
+          name: i.name,
+          price: parseFloat(String(i.price)) || 0,
+          quantity: parseFloat(String(i.quantity)) || 0,
+          categoryId: i.categoryId ? Number(i.categoryId) : null,
+        })),
+      });
+
+      for (const item of itemList) {
+        if (item.categoryId) {
+          await tx.productMaster.upsert({
+            where: {
+              name_storeName_familyGroupId: {
+                name: getCleanText(item.name),
+                storeName: getCleanText(storeName || existing.storeName),
+                familyGroupId,
+              },
+            },
+            update: { categoryId: Number(item.categoryId) },
+            create: {
+              name: getCleanText(item.name),
+              storeName: getCleanText(storeName || existing.storeName),
+              categoryId: Number(item.categoryId),
+              familyGroupId,
+            },
+          });
+        }
+      }
+    }
+
+    return tx.receipt.findUnique({
+      where: { id: receiptId },
+      include: { items: { include: { category: true } } },
+    });
+  });
+}
+
+/** 明細カテゴリ更新 ＋ 学習マスタ反映 */
+export async function updateItemCategoryById(
+  itemId: number,
+  familyGroupId: number,
+  categoryId: number | null | undefined
+) {
+  return prisma.$transaction(async (tx) => {
+    const currentItem = await tx.item.findUnique({
+      where: { id: itemId },
+      include: { receipt: true },
+    });
+
+    if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
+      throw new AppError('ItemNotFound', 404);
+    }
+
+    if (categoryId) {
+      const category = await tx.category.findFirst({
+        where: { id: Number(categoryId), familyGroupId },
+      });
+      if (!category) throw new AppError('CategoryNotFound', 404);
+    }
+
+    const updatedItem = await tx.item.update({
+      where: { id: itemId },
+      data: { categoryId: categoryId ? Number(categoryId) : null },
+      include: { category: true },
+    });
+
+    if (categoryId) {
+      await tx.productMaster.upsert({
+        where: {
+          name_storeName_familyGroupId: {
+            name: getCleanText(currentItem.name),
+            storeName: getCleanText(currentItem.receipt.storeName),
+            familyGroupId,
+          },
+        },
+        update: { categoryId: Number(categoryId) },
+        create: {
+          name: getCleanText(currentItem.name),
+          storeName: getCleanText(currentItem.receipt.storeName),
+          categoryId: Number(categoryId),
+          familyGroupId,
+        },
+      });
+    }
+
+    return updatedItem;
+  });
+}

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -1,216 +1,30 @@
-import { PrismaClient } from '@prisma/client';
-import { analyzeReceiptImage } from './geminiService';
-import type { ParsedItem, ReceiptCommitPayload } from '../types/receipt';
-import { estimateCategoryId } from './categoryService';
-import { validateReceiptItems } from './validationService';
-import { checkDuplicateReceipt, parseReceiptDate } from './duplicateReceiptService';
-import logger from '../utils/logger';
-import { normalizeStoreName, getCleanText } from '../utils/normalizer';
-
-const prisma = new PrismaClient();
-
 /**
- * [Issue #49-8 / #72 / #63] 解析のみを実行し、推論カテゴリを付与して返す
- * 戻り値に usageLogId を含めるように拡張
+ * 後方互換ファサード（Issue #98-3）
+ * 新規コードは `services/receipt/*` を直接 import してください。
  */
-export const analyzeOnly = async (memberId: number, imagePath: string) => {
-  logger.info(`[Analyze] 解析開始: ${imagePath} (Member: ${memberId})`);
-  
+import { prisma } from '../utils/prismaClient';
+import { analyzeOnly } from './receipt/receiptAnalysisService';
+import { saveConfirmedReceipt } from './receipt/receiptPersistenceService';
+
+export { analyzeOnly } from './receipt/receiptAnalysisService';
+export { saveParsedReceipt, saveConfirmedReceipt } from './receipt/receiptPersistenceService';
+export { DuplicateReceiptError, isDuplicateReceiptError, getDuplicateExistingId } from './receipt/receiptDuplicateError';
+
+/** 解析〜保存の一括処理（Worker 用レガシー / スクリプト用） */
+export const processAndSaveReceipt = async (memberId: number, imagePath: string) => {
   const member = await prisma.familyMember.findUnique({
     where: { id: memberId },
-    select: { familyGroupId: true }
-  });
-  const familyGroupId = member?.familyGroupId;
-
-  // Geminiで解析 (taxAmount, HH:mm, usageLogId を含む ParsedReceipt が返る)
-  const parsedData = await analyzeReceiptImage(imagePath, memberId);
-  const cleanStore = getCleanText(parsedData.storeName || '');
-
-  // 各明細にカテゴリを事前割り当て
-  const itemsWithCategories = await Promise.all(parsedData.items.map(async (item) => {
-    const cleanName = getCleanText(item.name);
-    let initialCategoryId = null;
-
-    if (familyGroupId) {
-      const mastered = await prisma.productMaster.findUnique({
-        where: { name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId } }
-      });
-      initialCategoryId = mastered
-        ? mastered.categoryId
-        : await estimateCategoryId(cleanName, cleanStore, familyGroupId, prisma);
-    }
-
-    return {
-      ...item,
-      price: parseFloat(String(item.price || 0)),         // ガソリンスタンド等の小数対応
-      quantity: parseFloat(String(item.quantity || 1)),   // リットル等の小数対応
-      categoryId: initialCategoryId
-    };
-  }));
-
-  parsedData.items = itemsWithCategories;
-  parsedData.taxAmount = parsedData.taxAmount ? parseFloat(String(parsedData.taxAmount)) : undefined;
-
-  // バリデーション (items合計 + taxAmount = totalAmount のチェック等)
-  const validation = validateReceiptItems(parsedData.items);
-  
-  return {
-    parsedData, // usageLogId が含まれる
-    imagePath,
-    validation
-  };
-};
-
-/**
- * パース済みデータをDBに永続化する（重複チェック ＋ 世帯別学習機能）
- * [Issue #63 / #72] 1対1の確実な ApiUsageLog 紐付けをトランザクション内で実行
- */
-export const saveParsedReceipt = async (
-  memberId: number, 
-  familyGroupId: number,
-  parsedData: ReceiptCommitPayload,
-  imagePath: string,
-  isSuspicious: boolean, 
-  warnings: string[] 
-) => {
-  try {
-    const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
-    const cleanStore = getCleanText(officialStoreName);
-    const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
-    
-    // Receipt.totalAmount は Int、taxAmount は Float
-    const totalAmount = Math.round(Number(parsedData.totalAmount || 0));
-    const taxAmount = parsedData.taxAmount ? parseFloat(String(parsedData.taxAmount)) : 0;
-    
-    // 安全な数値キャスト（NaNガード付き）
-    const usageLogIdStr = parsedData.usageLogId !== undefined ? String(parsedData.usageLogId) : null;
-    const usageLogId = usageLogIdStr ? parseInt(usageLogIdStr, 10) : null;
-
-    /** 同一画像の再保存（二重タップ・アプリ復帰後の再確定）は成功扱い */
-    if (imagePath) {
-      const existingByImage = await prisma.receipt.findFirst({
-        where: { familyGroupId, imagePath },
-        include: { items: { include: { category: true } } },
-      });
-      if (existingByImage) {
-        logger.info(`[Idempotent] imagePath 一致のため既存レシートを返却: ID ${existingByImage.id}`);
-        return {
-          ...JSON.parse(JSON.stringify(existingByImage)),
-          isSuspicious,
-          warnings,
-        };
-      }
-    }
-
-    /**
-     * 重複チェック（別画像で店名・日付・金額が同一の場合）
-     */
-    const duplicate = await checkDuplicateReceipt(
-      familyGroupId,
-      parsedData,
-      imagePath
-    );
-    if (duplicate.duplicateSuspected) {
-      const error = new Error('DUPLICATE_RECEIPT_DETECTED');
-      (error as any).statusCode = 409;
-      (error as any).existingId = duplicate.existingReceiptId;
-      throw error;
-    }
-
-    const savedId = await prisma.$transaction(async (tx) => {
-      const itemsToCreate = await Promise.all(parsedData.items.map(async (item: ParsedItem) => {
-        const cleanName = getCleanText(item.name);
-        const finalCategoryId = item.categoryId ? Number(item.categoryId) : null;
-
-        if (finalCategoryId) {
-          await tx.productMaster.upsert({
-            where: { name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId } },
-            update: { categoryId: finalCategoryId },
-            create: { name: cleanName, storeName: cleanStore, categoryId: finalCategoryId, familyGroupId }
-          });
-        }
-
-        return {
-          name: item.name,
-          price: parseFloat(String(item.price || 0)),
-          quantity: parseFloat(String(item.quantity || 1)),
-          categoryId: finalCategoryId
-        };
-      }));
-
-      // 1. Receiptの作成
-      const created = await tx.receipt.create({
-        data: {
-          memberId, 
-          familyGroupId, 
-          storeName: officialStoreName, 
-          date: jstDate,
-          totalAmount, 
-          taxAmount, 
-          imagePath, 
-          items: { create: itemsToCreate },
-          rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
-        },
-        select: { id: true }
-      });
-
-      // 2. [Issue #63] usageLogId が有効な数値の場合、ピンポイントで紐付けを更新
-      if (usageLogId && !isNaN(usageLogId)) {
-        await tx.apiUsageLog.update({
-          where: { id: usageLogId },
-          data: { receiptId: created.id }
-        });
-        logger.info(`[Link_Log] ApiUsageLog(ID: ${usageLogId}) を Receipt(ID: ${created.id}) に紐付けました。`);
-      }
-
-      return created.id;
-    }, { timeout: 15000 });
-
-    const final = await prisma.receipt.findUnique({
-      where: { id: savedId },
-      include: { items: { include: { category: true } } }
-    });
-
-    return { ...JSON.parse(JSON.stringify(final)), isSuspicious, warnings };
-  } catch (error: any) {
-    if (error.statusCode === 409) throw error;
-    logger.error(`[DB_ERROR] ${error}`);
-    throw error;
-  }
-};
-
-/**
- * ユーザー確認済みデータの永続化
- * [Issue #63] 曖昧なupdateManyを廃止し、saveParsedReceiptの内部トランザクションへ委譲
- */
-export const saveConfirmedReceipt = async (
-  memberId: number,
-  familyGroupId: number,
-  parsedData: ReceiptCommitPayload,
-  imagePath: string,
-  isSuspicious: boolean,
-  warnings: string[]
-) => {
-  return await saveParsedReceipt(memberId, familyGroupId, parsedData, imagePath, isSuspicious, warnings);
-};
-
-/**
- * 解析〜保存の一括処理（Worker用/自動投入用）
- */
-export const processAndSaveReceipt = async (memberId: number, imagePath: string) => {
-  const member = await prisma.familyMember.findUnique({ 
-    where: { id: memberId }, 
-    select: { familyGroupId: true } 
+    select: { familyGroupId: true },
   });
   if (!member) throw new Error('MEMBER_NOT_FOUND');
-  
+
   const { parsedData, validation } = await analyzeOnly(memberId, imagePath);
-  return await saveConfirmedReceipt(
-    memberId, 
-    member.familyGroupId, 
-    parsedData, 
-    imagePath, 
-    validation.isSuspicious, 
+  return saveConfirmedReceipt(
+    memberId,
+    member.familyGroupId,
+    parsedData,
+    imagePath,
+    validation.isSuspicious,
     validation.warnings
   );
 };


### PR DESCRIPTION
## Summary

- `backend/src/services/receipt/` を新設し、解析・永続化・CRUD・按分・統計を責務別に分割
  - `receiptAnalysisService` — `analyzeOnly`（DB 書込なし）
  - `receiptPersistenceService` — `saveParsedReceipt` / `saveConfirmedReceipt`
  - `receiptCommitService` — commit + ジョブ削除オーケストレーション
  - `receiptQueryService` / `receiptUpdateService` / `receiptSplitService` / `receiptStatsService`
- `receiptController.ts` を **604行 → 279行** に薄型化（HTTP / バリデーション / Service 呼び出し中心）
- `receiptService.ts` は後方互換ファサードとして維持（Worker・スクリプト用）
- Repository 層は **導入しない**（#98-8 Later）

Epic: #370 / 計画: `docs/refactor/plan.md`

Closes #373

## Test plan

- [x] `cd backend && npm test` — 32 passed
- [x] `cd frontend && npm test` — 33 passed
- [ ] レシート upload → 解析確認 → commit フロー
- [ ] 履歴編集・カテゴリ変更・按分保存


Made with [Cursor](https://cursor.com)