### PR TITLE
refactor(tx): [Issue #98-4] Transaction 境界統一

### DIFF
--- a/backend/src/services/receipt/receiptCommitPersistence.ts
+++ b/backend/src/services/receipt/receiptCommitPersistence.ts
@@ -1,0 +1,93 @@
+import logger from '../../utils/logger';
+import { getCleanText } from '../../utils/normalizer';
+import type { PrismaTx } from '../../utils/prismaTransaction';
+import type { ParsedItem, ReceiptCommitPayload } from '../../types/receipt';
+import { upsertProductMasterCategory } from './receiptProductMasterLearning';
+
+/** commit トランザクション内で永続化するための準備済み入力 */
+export type ReceiptCommitTxInput = {
+  memberId: number;
+  familyGroupId: number;
+  parsedData: ReceiptCommitPayload;
+  officialStoreName: string;
+  cleanStore: string;
+  jstDate: Date;
+  totalAmount: number;
+  taxAmount: number;
+  imagePath: string;
+  isSuspicious: boolean;
+  warnings: string[];
+  usageLogId: number | null;
+};
+
+/**
+ * レシート commit の DB 書込（tx は呼び出し元が開始）
+ * ProductMaster 学習 → Receipt 作成 → ApiUsageLog 紐付け
+ */
+export async function persistReceiptCommitInTx(
+  tx: PrismaTx,
+  input: ReceiptCommitTxInput
+): Promise<number> {
+  const {
+    memberId,
+    familyGroupId,
+    parsedData,
+    officialStoreName,
+    cleanStore,
+    jstDate,
+    totalAmount,
+    taxAmount,
+    imagePath,
+    isSuspicious,
+    warnings,
+    usageLogId,
+  } = input;
+
+  const itemsToCreate = await Promise.all(
+    parsedData.items.map(async (item: ParsedItem) => {
+      const cleanName = getCleanText(item.name);
+      const finalCategoryId = item.categoryId ? Number(item.categoryId) : null;
+
+      if (finalCategoryId) {
+        await upsertProductMasterCategory(tx, {
+          itemName: cleanName,
+          storeName: cleanStore,
+          familyGroupId,
+          categoryId: finalCategoryId,
+        });
+      }
+
+      return {
+        name: item.name,
+        price: parseFloat(String(item.price || 0)),
+        quantity: parseFloat(String(item.quantity || 1)),
+        categoryId: finalCategoryId,
+      };
+    })
+  );
+
+  const created = await tx.receipt.create({
+    data: {
+      memberId,
+      familyGroupId,
+      storeName: officialStoreName,
+      date: jstDate,
+      totalAmount,
+      taxAmount,
+      imagePath,
+      items: { create: itemsToCreate },
+      rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
+    },
+    select: { id: true },
+  });
+
+  if (usageLogId && !isNaN(usageLogId)) {
+    await tx.apiUsageLog.update({
+      where: { id: usageLogId },
+      data: { receiptId: created.id },
+    });
+    logger.info(`[Link_Log] ApiUsageLog(ID: ${usageLogId}) を Receipt(ID: ${created.id}) に紐付けました。`);
+  }
+
+  return created.id;
+}

--- a/backend/src/services/receipt/receiptPersistenceService.ts
+++ b/backend/src/services/receipt/receiptPersistenceService.ts
@@ -1,13 +1,16 @@
 import { prisma } from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { normalizeStoreName, getCleanText } from '../../utils/normalizer';
+import { runReceiptCommitTransaction } from '../../utils/prismaTransaction';
 import { checkDuplicateReceipt, parseReceiptDate } from '../duplicateReceiptService';
-import type { ParsedItem, ReceiptCommitPayload } from '../../types/receipt';
+import type { ReceiptCommitPayload } from '../../types/receipt';
 import { DuplicateReceiptError } from './receiptDuplicateError';
+import { persistReceiptCommitInTx } from './receiptCommitPersistence';
 
 /**
  * パース済みデータを DB に永続化（重複チェック ＋ 世帯別学習）
  * [Issue #63 / #72] ApiUsageLog 紐付けをトランザクション内で実行
+ * [Issue #98-4] commit 系 tx は runReceiptCommitTransaction のみで開始
  */
 export async function saveParsedReceipt(
   memberId: number,
@@ -47,58 +50,21 @@ export async function saveParsedReceipt(
     throw new DuplicateReceiptError(duplicate.existingReceiptId);
   }
 
-  const savedId = await prisma.$transaction(
-    async (tx) => {
-      const itemsToCreate = await Promise.all(
-        parsedData.items.map(async (item: ParsedItem) => {
-          const cleanName = getCleanText(item.name);
-          const finalCategoryId = item.categoryId ? Number(item.categoryId) : null;
-
-          if (finalCategoryId) {
-            await tx.productMaster.upsert({
-              where: {
-                name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId },
-              },
-              update: { categoryId: finalCategoryId },
-              create: { name: cleanName, storeName: cleanStore, categoryId: finalCategoryId, familyGroupId },
-            });
-          }
-
-          return {
-            name: item.name,
-            price: parseFloat(String(item.price || 0)),
-            quantity: parseFloat(String(item.quantity || 1)),
-            categoryId: finalCategoryId,
-          };
-        })
-      );
-
-      const created = await tx.receipt.create({
-        data: {
-          memberId,
-          familyGroupId,
-          storeName: officialStoreName,
-          date: jstDate,
-          totalAmount,
-          taxAmount,
-          imagePath,
-          items: { create: itemsToCreate },
-          rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
-        },
-        select: { id: true },
-      });
-
-      if (usageLogId && !isNaN(usageLogId)) {
-        await tx.apiUsageLog.update({
-          where: { id: usageLogId },
-          data: { receiptId: created.id },
-        });
-        logger.info(`[Link_Log] ApiUsageLog(ID: ${usageLogId}) を Receipt(ID: ${created.id}) に紐付けました。`);
-      }
-
-      return created.id;
-    },
-    { timeout: 15000 }
+  const savedId = await runReceiptCommitTransaction((tx) =>
+    persistReceiptCommitInTx(tx, {
+      memberId,
+      familyGroupId,
+      parsedData,
+      officialStoreName,
+      cleanStore,
+      jstDate,
+      totalAmount,
+      taxAmount,
+      imagePath,
+      isSuspicious,
+      warnings,
+      usageLogId,
+    })
   );
 
   const final = await prisma.receipt.findUnique({

--- a/backend/src/services/receipt/receiptProductMasterLearning.ts
+++ b/backend/src/services/receipt/receiptProductMasterLearning.ts
@@ -1,0 +1,33 @@
+import type { PrismaTx } from '../../utils/prismaTransaction';
+import { getCleanText } from '../../utils/normalizer';
+
+/** ProductMaster 学習（カテゴリ紐付け）— tx 明示渡し */
+export async function upsertProductMasterCategory(
+  tx: PrismaTx,
+  params: {
+    itemName: string;
+    storeName: string;
+    familyGroupId: number;
+    categoryId: number;
+  }
+): Promise<void> {
+  const cleanName = getCleanText(params.itemName);
+  const cleanStore = getCleanText(params.storeName);
+
+  await tx.productMaster.upsert({
+    where: {
+      name_storeName_familyGroupId: {
+        name: cleanName,
+        storeName: cleanStore,
+        familyGroupId: params.familyGroupId,
+      },
+    },
+    update: { categoryId: params.categoryId },
+    create: {
+      name: cleanName,
+      storeName: cleanStore,
+      categoryId: params.categoryId,
+      familyGroupId: params.familyGroupId,
+    },
+  });
+}

--- a/backend/src/services/receipt/receiptSplitService.ts
+++ b/backend/src/services/receipt/receiptSplitService.ts
@@ -1,7 +1,57 @@
-import { prisma } from '../../utils/prismaClient';
 import { AppError } from '../../utils/appError';
+import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import { allocateItemSplits, SplitInput } from '../../utils/itemSplitAllocation';
 import { calcItemLineTotal } from '../../utils/itemLineTotal';
+
+async function updateItemSplitsInTx(
+  tx: PrismaTx,
+  itemId: number,
+  familyGroupId: number,
+  splits: SplitInput[] | undefined | null
+) {
+  const item = await tx.item.findUnique({
+    where: { id: itemId },
+    include: { receipt: true },
+  });
+
+  if (!item || item.receipt.familyGroupId !== familyGroupId) {
+    throw new AppError('ItemNotFound', 404);
+  }
+
+  if (!splits || !Array.isArray(splits) || splits.length === 0) {
+    await tx.itemSplit.deleteMany({ where: { itemId } });
+    return { message: 'Splits cleared (Fallback to default payer)' };
+  }
+
+  const totalAmount = calcItemLineTotal(item.price, item.quantity);
+  const splitInputs: SplitInput[] = splits.map((split) => ({
+    familyMemberId: Number(split.familyMemberId),
+    ratio: split.ratio,
+    amount: split.amount,
+  }));
+
+  const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
+  const validMembers = await tx.familyMember.findMany({
+    where: { id: { in: memberIds }, familyGroupId },
+    select: { id: true },
+  });
+  if (validMembers.length !== memberIds.length) {
+    throw new AppError('Invalid familyMemberId in splits', 403);
+  }
+
+  const finalSplits = allocateItemSplits(totalAmount, splitInputs);
+
+  await tx.itemSplit.deleteMany({ where: { itemId } });
+  await tx.itemSplit.createMany({
+    data: finalSplits.map((fs) => ({
+      itemId,
+      familyMemberId: fs.familyMemberId,
+      amount: fs.amount,
+    })),
+  });
+
+  return tx.itemSplit.findMany({ where: { itemId } });
+}
 
 /** 明細（Item）の負担内訳（ItemSplit）を更新・保存 */
 export async function updateItemSplitsById(
@@ -9,48 +59,5 @@ export async function updateItemSplitsById(
   familyGroupId: number,
   splits: SplitInput[] | undefined | null
 ) {
-  return prisma.$transaction(async (tx) => {
-    const item = await tx.item.findUnique({
-      where: { id: itemId },
-      include: { receipt: true },
-    });
-
-    if (!item || item.receipt.familyGroupId !== familyGroupId) {
-      throw new AppError('ItemNotFound', 404);
-    }
-
-    if (!splits || !Array.isArray(splits) || splits.length === 0) {
-      await tx.itemSplit.deleteMany({ where: { itemId } });
-      return { message: 'Splits cleared (Fallback to default payer)' };
-    }
-
-    const totalAmount = calcItemLineTotal(item.price, item.quantity);
-    const splitInputs: SplitInput[] = splits.map((split) => ({
-      familyMemberId: Number(split.familyMemberId),
-      ratio: split.ratio,
-      amount: split.amount,
-    }));
-
-    const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
-    const validMembers = await tx.familyMember.findMany({
-      where: { id: { in: memberIds }, familyGroupId },
-      select: { id: true },
-    });
-    if (validMembers.length !== memberIds.length) {
-      throw new AppError('Invalid familyMemberId in splits', 403);
-    }
-
-    const finalSplits = allocateItemSplits(totalAmount, splitInputs);
-
-    await tx.itemSplit.deleteMany({ where: { itemId } });
-    await tx.itemSplit.createMany({
-      data: finalSplits.map((fs) => ({
-        itemId,
-        familyMemberId: fs.familyMemberId,
-        amount: fs.amount,
-      })),
-    });
-
-    return tx.itemSplit.findMany({ where: { itemId } });
-  });
+  return runInTransaction((tx) => updateItemSplitsInTx(tx, itemId, familyGroupId, splits));
 }

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -1,8 +1,8 @@
-import { prisma } from '../../utils/prismaClient';
 import { AppError } from '../../utils/appError';
-import { getCleanText } from '../../utils/normalizer';
+import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import type { ReceiptCreateItemInput } from '../../types/receipt';
 import { saveParsedReceipt } from './receiptPersistenceService';
+import { upsertProductMasterCategory } from './receiptProductMasterLearning';
 
 export type ManualReceiptInput = {
   date: string;
@@ -37,14 +37,7 @@ export async function createManualReceipt(
   input: ManualReceiptInput
 ) {
   const payload = buildCommitPayload(input);
-  return saveParsedReceipt(
-    memberId,
-    familyGroupId,
-    payload,
-    input.imagePath || '',
-    false,
-    []
-  );
+  return saveParsedReceipt(memberId, familyGroupId, payload, input.imagePath || '', false, []);
 }
 
 export type UpdateReceiptInput = {
@@ -53,77 +46,115 @@ export type UpdateReceiptInput = {
   items?: ReceiptCreateItemInput[];
 };
 
-/** 保存済みレシートの完全編集 */
-export async function updateReceiptById(
+async function updateReceiptInTx(
+  tx: PrismaTx,
   receiptId: number,
   familyGroupId: number,
   input: UpdateReceiptInput
 ) {
   const { date, storeName, items } = input;
 
-  return prisma.$transaction(async (tx) => {
-    const existing = await tx.receipt.findUnique({
-      where: { id: receiptId },
+  const existing = await tx.receipt.findUnique({
+    where: { id: receiptId },
+  });
+  if (!existing || existing.familyGroupId !== familyGroupId) {
+    throw new AppError('ReceiptNotFound', 404);
+  }
+
+  const itemList = items ?? [];
+  const calculatedTotal = itemList.reduce((sum, i) => {
+    return sum + Number(i.price || 0) * Number(i.quantity || 0);
+  }, 0);
+  const finalTotal = Math.round(calculatedTotal);
+
+  await tx.receipt.update({
+    where: { id: receiptId },
+    data: {
+      date: date ? new Date(date) : undefined,
+      storeName: storeName || undefined,
+      totalAmount: finalTotal,
+    },
+  });
+
+  await tx.item.deleteMany({ where: { receiptId } });
+
+  if (itemList.length > 0) {
+    await tx.item.createMany({
+      data: itemList.map((i) => ({
+        receiptId,
+        name: i.name,
+        price: parseFloat(String(i.price)) || 0,
+        quantity: parseFloat(String(i.quantity)) || 0,
+        categoryId: i.categoryId ? Number(i.categoryId) : null,
+      })),
     });
-    if (!existing || existing.familyGroupId !== familyGroupId) {
-      throw new AppError('ReceiptNotFound', 404);
-    }
 
-    const itemList = items ?? [];
-    const calculatedTotal = itemList.reduce((sum, i) => {
-      return sum + Number(i.price || 0) * Number(i.quantity || 0);
-    }, 0);
-    const finalTotal = Math.round(calculatedTotal);
-
-    await tx.receipt.update({
-      where: { id: receiptId },
-      data: {
-        date: date ? new Date(date) : undefined,
-        storeName: storeName || undefined,
-        totalAmount: finalTotal,
-      },
-    });
-
-    await tx.item.deleteMany({ where: { receiptId } });
-
-    if (itemList.length > 0) {
-      await tx.item.createMany({
-        data: itemList.map((i) => ({
-          receiptId,
-          name: i.name,
-          price: parseFloat(String(i.price)) || 0,
-          quantity: parseFloat(String(i.quantity)) || 0,
-          categoryId: i.categoryId ? Number(i.categoryId) : null,
-        })),
-      });
-
-      for (const item of itemList) {
-        if (item.categoryId) {
-          await tx.productMaster.upsert({
-            where: {
-              name_storeName_familyGroupId: {
-                name: getCleanText(item.name),
-                storeName: getCleanText(storeName || existing.storeName),
-                familyGroupId,
-              },
-            },
-            update: { categoryId: Number(item.categoryId) },
-            create: {
-              name: getCleanText(item.name),
-              storeName: getCleanText(storeName || existing.storeName),
-              categoryId: Number(item.categoryId),
-              familyGroupId,
-            },
-          });
-        }
+    const resolvedStoreName = storeName || existing.storeName;
+    for (const item of itemList) {
+      if (item.categoryId) {
+        await upsertProductMasterCategory(tx, {
+          itemName: item.name,
+          storeName: resolvedStoreName,
+          familyGroupId,
+          categoryId: Number(item.categoryId),
+        });
       }
     }
+  }
 
-    return tx.receipt.findUnique({
-      where: { id: receiptId },
-      include: { items: { include: { category: true } } },
-    });
+  return tx.receipt.findUnique({
+    where: { id: receiptId },
+    include: { items: { include: { category: true } } },
   });
+}
+
+/** 保存済みレシートの完全編集 */
+export async function updateReceiptById(
+  receiptId: number,
+  familyGroupId: number,
+  input: UpdateReceiptInput
+) {
+  return runInTransaction((tx) => updateReceiptInTx(tx, receiptId, familyGroupId, input));
+}
+
+async function updateItemCategoryInTx(
+  tx: PrismaTx,
+  itemId: number,
+  familyGroupId: number,
+  categoryId: number | null | undefined
+) {
+  const currentItem = await tx.item.findUnique({
+    where: { id: itemId },
+    include: { receipt: true },
+  });
+
+  if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
+    throw new AppError('ItemNotFound', 404);
+  }
+
+  if (categoryId) {
+    const category = await tx.category.findFirst({
+      where: { id: Number(categoryId), familyGroupId },
+    });
+    if (!category) throw new AppError('CategoryNotFound', 404);
+  }
+
+  const updatedItem = await tx.item.update({
+    where: { id: itemId },
+    data: { categoryId: categoryId ? Number(categoryId) : null },
+    include: { category: true },
+  });
+
+  if (categoryId) {
+    await upsertProductMasterCategory(tx, {
+      itemName: currentItem.name,
+      storeName: currentItem.receipt.storeName,
+      familyGroupId,
+      categoryId: Number(categoryId),
+    });
+  }
+
+  return updatedItem;
 }
 
 /** 明細カテゴリ更新 ＋ 学習マスタ反映 */
@@ -132,48 +163,5 @@ export async function updateItemCategoryById(
   familyGroupId: number,
   categoryId: number | null | undefined
 ) {
-  return prisma.$transaction(async (tx) => {
-    const currentItem = await tx.item.findUnique({
-      where: { id: itemId },
-      include: { receipt: true },
-    });
-
-    if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
-      throw new AppError('ItemNotFound', 404);
-    }
-
-    if (categoryId) {
-      const category = await tx.category.findFirst({
-        where: { id: Number(categoryId), familyGroupId },
-      });
-      if (!category) throw new AppError('CategoryNotFound', 404);
-    }
-
-    const updatedItem = await tx.item.update({
-      where: { id: itemId },
-      data: { categoryId: categoryId ? Number(categoryId) : null },
-      include: { category: true },
-    });
-
-    if (categoryId) {
-      await tx.productMaster.upsert({
-        where: {
-          name_storeName_familyGroupId: {
-            name: getCleanText(currentItem.name),
-            storeName: getCleanText(currentItem.receipt.storeName),
-            familyGroupId,
-          },
-        },
-        update: { categoryId: Number(categoryId) },
-        create: {
-          name: getCleanText(currentItem.name),
-          storeName: getCleanText(currentItem.receipt.storeName),
-          categoryId: Number(categoryId),
-          familyGroupId,
-        },
-      });
-    }
-
-    return updatedItem;
-  });
+  return runInTransaction((tx) => updateItemCategoryInTx(tx, itemId, familyGroupId, categoryId));
 }

--- a/backend/src/utils/prismaTransaction.ts
+++ b/backend/src/utils/prismaTransaction.ts
@@ -1,0 +1,30 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from './prismaClient';
+
+/** Prisma インタラクティブトランザクションのクライアント型 */
+export type PrismaTx = Prisma.TransactionClient;
+
+type TransactionOptions = {
+  timeout?: number;
+};
+
+/** 汎用トランザクション実行（更新・按分等） */
+export async function runInTransaction<T>(
+  fn: (tx: PrismaTx) => Promise<T>,
+  options?: TransactionOptions
+): Promise<T> {
+  if (options?.timeout) {
+    return prisma.$transaction(fn, { timeout: options.timeout });
+  }
+  return prisma.$transaction(fn);
+}
+
+/**
+ * レシート commit 系の唯一の tx 開始点（Issue #98-4）
+ * saveParsedReceipt / saveConfirmedReceipt の DB 書込はここ経由のみ。
+ */
+export async function runReceiptCommitTransaction<T>(
+  fn: (tx: PrismaTx) => Promise<T>
+): Promise<T> {
+  return runInTransaction(fn, { timeout: 15000 });
+}


### PR DESCRIPTION
## Summary

- `utils/prismaTransaction.ts` を新設
  - `runReceiptCommitTransaction` — **commit 系の唯一の tx 開始点**（timeout 15s）
  - `runInTransaction` — 更新・按分等の汎用 tx ラッパー
  - `PrismaTx` 型を export
- `receiptCommitPersistence.ts` — `persistReceiptCommitInTx(tx, …)` に DB 書込を集約
- `receiptProductMasterLearning.ts` — ProductMaster 学習を tx 明示渡しに共通化
- `receiptUpdateService` / `receiptSplitService` — `*InTx` + `runInTransaction` パターンに整理

**スコープ外:** `adminController` / `productMasterController` の tx（Receipt commit 系 AC の対象外）

Epic: #370 / 計画: `docs/refactor/plan.md`

Closes #374

## Test plan

- [x] `cd backend && npm test` — 32 passed
- [ ] レシート commit（upload → 確認 → 保存）
- [ ] 履歴編集・カテゴリ変更・按分保存


Made with [Cursor](https://cursor.com)