### PR TITLE
refactor(error): [Issue #98-5] エラーハンドリング統一（R-B006）

### DIFF
--- a/backend/src/app.integration.test.ts
+++ b/backend/src/app.integration.test.ts
@@ -322,6 +322,18 @@ describe.skipIf(!shouldRunDbIntegration())('API integration (DATABASE_URL)', () 
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.data)).toBe(true);
   });
+
+  it('POST /api/stats/settlement/transfers with invalid body returns error envelope', async () => {
+    const token = await loginAsTestMember(app);
+    const res = await request(app)
+      .post('/api/stats/settlement/transfers')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(typeof res.body.message).toBe('string');
+  });
 });
 
 describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -10,7 +10,6 @@ import {
 import { getFamilyGroupId, getMemberId } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
-import { isDuplicateReceiptError, getDuplicateExistingId } from '../services/receipt/receiptDuplicateError';
 import { commitReceipt as commitReceiptService } from '../services/receipt/receiptCommitService';
 import { createManualReceipt } from '../services/receipt/receiptUpdateService';
 import {
@@ -26,18 +25,6 @@ import {
   getAdvancedStats as fetchAdvancedStats,
 } from '../services/receipt/receiptStatsService';
 import { SplitInput } from '../utils/itemSplitAllocation';
-
-function handleDuplicateOrNext(error: unknown, res: Response, next: NextFunction): void {
-  if (isDuplicateReceiptError(error)) {
-    res.status(409).json({
-      success: false,
-      message: 'DUPLICATE',
-      existingId: getDuplicateExistingId(error),
-    });
-    return;
-  }
-  next(error);
-}
 
 export const getJobStatus = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
@@ -142,7 +129,7 @@ export const commitReceipt = async (req: Request, res: Response, next: NextFunct
 
     res.status(201).json({ success: true, data: result });
   } catch (error) {
-    handleDuplicateOrNext(error, res, next);
+    next(error);
   }
 };
 
@@ -161,7 +148,7 @@ export const createReceipt = async (req: Request, res: Response, next: NextFunct
 
     res.status(201).json({ success: true, data: newReceipt });
   } catch (error) {
-    handleDuplicateOrNext(error, res, next);
+    next(error);
   }
 };
 

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -153,7 +153,7 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
  */
 export const addSettlementTransfer = async (req: Request, res: Response, next: NextFunction) => {
   const familyGroupId = getFamilyGroupId();
-  
+
   const { month, fromMemberId, toMemberId, amount } = req.body;
   const normalizedMonth = normalizeYearMonth(month);
   const fromId = Number(fromMemberId);
@@ -161,24 +161,23 @@ export const addSettlementTransfer = async (req: Request, res: Response, next: N
   const transferAmount = Math.round(Number(amount));
 
   if (!normalizedMonth || !fromMemberId || !toMemberId || !Number.isFinite(transferAmount) || transferAmount <= 0) {
-    return res.status(400).json({ success: false, message: '必要なパラメータが不足しているか、金額が不正です。' });
+    return next(new AppError('必要なパラメータが不足しているか、金額が不正です。', 400));
   }
 
   if (fromId === toId) {
-    return res.status(400).json({ success: false, message: '自分自身への送金は登録できません。' });
+    return next(new AppError('自分自身への送金は登録できません。', 400));
   }
 
   try {
-    // 送信者・受信者が同一世帯に属しているか（テナント検証）
     const validMembers = await prisma.familyMember.findMany({
       where: {
         id: { in: [fromId, toId] },
-        familyGroupId
-      }
+        familyGroupId,
+      },
     });
 
     if (validMembers.length !== 2) {
-      return res.status(403).json({ success: false, message: '無効なユーザー指定、または権限がありません。' });
+      throw new AppError('無効なユーザー指定、または権限がありません。', 403);
     }
 
     // 送金記録の作成
@@ -216,7 +215,7 @@ export const deleteSettlementTransfer = async (
   const transferId = Number(getRouteParam(req, 'id'));
 
   if (!Number.isFinite(transferId) || transferId <= 0) {
-    return res.status(400).json({ success: false, message: '送金記録IDが不正です。' });
+    return next(new AppError('送金記録IDが不正です。', 400));
   }
 
   try {

--- a/backend/src/middleware/errorHandler.test.ts
+++ b/backend/src/middleware/errorHandler.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { AppError } from '../utils/appError';
+import { errorHandler } from '../middleware/errorHandler';
+import { DuplicateReceiptError } from '../services/receipt/receiptDuplicateError';
+
+function createMockRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  } as Response & { statusCode: number; body: unknown };
+  return res;
+}
+
+const req = { method: 'POST', path: '/test', originalUrl: '/api/test' } as Request;
+const next = vi.fn() as NextFunction;
+
+describe('errorHandler', () => {
+  it('formats DuplicateReceiptError per api-spec §2.3', () => {
+    const res = createMockRes();
+    errorHandler(new DuplicateReceiptError(42), req, res, next);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'DUPLICATE',
+      existingId: 42,
+    });
+  });
+
+  it('formats AppError with success false and message envelope', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const res = createMockRes();
+    errorHandler(new AppError('入力内容に不備があります', 400), req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: '入力内容に不備があります',
+    });
+
+    process.env.NODE_ENV = prev;
+  });
+});

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,52 +1,60 @@
 import { Request, Response, NextFunction } from 'express';
 import { AppError } from '../utils/appError';
 import logger from '../utils/logger';
+import { DuplicateReceiptError } from '../services/receipt/receiptDuplicateError';
 
 /**
- * 📂 グローバルエラーハンドリング・ミドルウェア [Issue #47]
+ * 📂 グローバルエラーハンドリング・ミドルウェア [Issue #47 / #98-5]
  */
 export const errorHandler = (
-  err: any,
+  err: unknown,
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
   const isDev = process.env.NODE_ENV === 'development';
-  
-  // ステータスコードとメッセージの決定
-  const statusCode = err instanceof AppError ? err.statusCode : (err.statusCode || 500);
-  const message = err.message || 'Internal Server Error';
+  const error = err as Error & { statusCode?: number; details?: unknown; stack?: string };
+
+  const statusCode = err instanceof AppError ? err.statusCode : (error.statusCode || 500);
+  const message = error.message || 'Internal Server Error';
   const details = err instanceof AppError ? err.details : undefined;
 
-  // 1. T320 のログファイル (error-DATE.log) へ常にフルスタックを出力
   logger.error(`[${req.method}] ${req.path} - ${message}`, {
     statusCode,
     method: req.method,
     path: req.originalUrl,
     details,
-    stack: err.stack,
-    internal: err // Prisma等の生エラーオブジェクト
+    stack: error.stack,
+    internal: err,
   });
 
-  // 2. クライアント（Expo）へのレスポンス
-  // キーを 'message' に統一することで Expo 側のコードと同期させます
+  // api-spec §2.3: 重複レシート（409）は existingId をトップレベルに含める
+  if (err instanceof DuplicateReceiptError) {
+    return res.status(409).json({
+      success: false,
+      message: 'DUPLICATE',
+      existingId: err.existingId,
+    });
+  }
+
   if (isDev) {
     return res.status(statusCode).json({
       success: false,
-      message: message, // 'error' から 'message' に変更
-      stack: err.stack,
-      details: details,
-      internal: err
-    });
-  } else {
-    const safeMessage = statusCode >= 500 
-      ? 'サーバー内部でエラーが発生しました。時間をおいて再度お試しください。' 
-      : message;
-
-    return res.status(statusCode).json({
-      success: false,
-      message: safeMessage, // 'error' から 'message' に変更
-      ...(details && { details })
+      message,
+      stack: error.stack,
+      details,
+      internal: err,
     });
   }
+
+  const safeMessage =
+    statusCode >= 500
+      ? 'サーバー内部でエラーが発生しました。時間をおいて再度お試しください。'
+      : message;
+
+  return res.status(statusCode).json({
+    success: false,
+    message: safeMessage,
+    ...(details && { details }),
+  });
 };

--- a/backend/src/services/receipt/receiptDuplicateError.ts
+++ b/backend/src/services/receipt/receiptDuplicateError.ts
@@ -1,30 +1,21 @@
-/** commit / 手動登録時の重複レシート検出 */
-export class DuplicateReceiptError extends Error {
-  readonly statusCode = 409;
+import { AppError } from '../../utils/appError';
+
+/** commit / 手動登録時の重複レシート検出（api-spec §2.3 特殊ケース 409） */
+export class DuplicateReceiptError extends AppError {
   readonly existingId: number | null;
 
   constructor(existingId?: number | null) {
-    super('DUPLICATE_RECEIPT_DETECTED');
+    super('DUPLICATE', 409);
     this.name = 'DuplicateReceiptError';
     this.existingId = existingId ?? null;
   }
 }
 
 export function isDuplicateReceiptError(error: unknown): error is DuplicateReceiptError {
-  return (
-    error instanceof DuplicateReceiptError ||
-    (typeof error === 'object' &&
-      error !== null &&
-      'statusCode' in error &&
-      (error as { statusCode: number }).statusCode === 409)
-  );
+  return error instanceof DuplicateReceiptError;
 }
 
 export function getDuplicateExistingId(error: unknown): number | null {
   if (error instanceof DuplicateReceiptError) return error.existingId;
-  if (typeof error === 'object' && error !== null && 'existingId' in error) {
-    const id = (error as { existingId?: number | null }).existingId;
-    return id ?? null;
-  }
   return null;
 }


### PR DESCRIPTION
## Summary

- `DuplicateReceiptError` を `AppError` 継承に変更し、409 DUPLICATE レスポンスを `errorHandler` に集約
- `receiptController` の `handleDuplicateOrNext`（`res.status(409)` 直返し）を削除
- `statsController` の 4xx 直返しを `next(new AppError(...))` に統一
- `errorHandler.test.ts` 追加（DUPLICATE / AppError envelope 検証）
- 結合テスト: 送金 API の 400 envelope 検証を追加

**維持（仕様どおり）:** `adminController` の `{ error }` キー、認証ミドルウェアの直返し

Epic: #370 / R-B006

Closes #375

## Test plan

- [x] `cd backend && npm test` — 34 passed
- [ ] レシート commit 重複時に `{ success: false, message: "DUPLICATE", existingId }` が返る
- [ ] 精算送金のバリデーションエラーが `{ success: false, message }` 形式


Made with [Cursor](https://cursor.com)