### PR TITLE
refactor(settlement): [Issue #98-6] statsController → SettlementService

### DIFF
--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,239 +1,50 @@
 import { Request, Response, NextFunction } from 'express';
-import { prisma } from '../utils/prismaClient';
 import { getFamilyGroupId } from '../utils/context';
-import { AppError } from '../utils/appError';
-import {
-  getCurrentYearMonthLocal,
-  getLocalMonthDateRange,
-  normalizeYearMonth,
-} from '../utils/yearMonth';
-import { calcItemLineTotal } from '../utils/itemLineTotal';
 import { getRouteParam } from '../utils/routeParams';
+import {
+  createSettlementTransfer,
+  deleteSettlementTransfer as removeSettlementTransfer,
+  getSettlementStatusData,
+} from '../services/settlement/settlementService';
 
-/**
- * [Issue #78 / #81] 月間精算ステータスの取得（暗黙的デフォルト対応 ＆ 送金実績の反映）
- * 対象月の「各メンバーの立替額」「各メンバーの負担額」を算出し、
- * さらに同月の送金実績（SettlementTransfer）を加味した最終的な「精算残額」を返します。
- */
 export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
-  const familyGroupId = getFamilyGroupId();
-  
-  const queryMonth = normalizeYearMonth(req.query.month as string);
-  const targetMonth = queryMonth ?? getCurrentYearMonthLocal();
-  const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
-
   try {
-
-    // 1. 対象グループの全メンバーを取得して初期化
-    const members = await prisma.familyMember.findMany({
-      where: { familyGroupId },
-      select: { id: true, name: true },
-    });
-
-    const stats: Record<number, { 
-      name: string; 
-      totalPaid: number; 
-      totalOwed: number; 
-      baseBalance: number; // レシートベースの本来の差額
-      transferredOut: number; // 他者へ送金した額
-      transferredIn: number; // 他者から受け取った額
-      balance: number; // 最終的な残額（baseBalance + transferredOut - transferredIn）
-    }> = {};
-    
-    members.forEach(m => {
-      stats[m.id] = { name: m.name, totalPaid: 0, totalOwed: 0, baseBalance: 0, transferredOut: 0, transferredIn: 0, balance: 0 };
-    });
-
-    // 2. 指定月・世帯のレシートを、明細とSplitを含めて取得
-    const receipts = await prisma.receipt.findMany({
-      where: {
-        familyGroupId,
-        date: { gte: startDate, lt: endDate },
-      },
-      include: {
-        items: {
-          include: { splits: true }
-        }
-      }
-    });
-
-    // 3. レシートと明細に基づく基本集計（暗黙的デフォルト処理）
-    receipts.forEach(receipt => {
-      let receiptTotalPaid = 0; // そのレシートで立替えた総額
-
-      receipt.items.forEach(item => {
-        // 金額は整数（Int）丸めで計算
-        const itemPriceInt = calcItemLineTotal(item.price, item.quantity);
-        receiptTotalPaid += itemPriceInt;
-
-        if (item.splits.length > 0) {
-          // パターン1: Splitが明示されている場合
-          item.splits.forEach(split => {
-            if (stats[split.familyMemberId]) {
-              stats[split.familyMemberId].totalOwed += split.amount; // Split側の金額（Int）を足す
-            }
-          });
-        } else {
-          // パターン2: 暗黙的デフォルト (Splitがない＝レシート支払者が全額負担)
-          if (stats[receipt.memberId]) {
-            stats[receipt.memberId].totalOwed += itemPriceInt;
-          }
-        }
-      });
-
-      // 立替額（実際にレジで支払った額）をレシートのmemberIdに加算
-      if (stats[receipt.memberId]) {
-        stats[receipt.memberId].totalPaid += receiptTotalPaid;
-      }
-    });
-
-    // ★ [Issue #81] 4. 送金実績（SettlementTransfer）の取得と集計
-    // 対象月の全送金履歴（familyGroupIdに属するメンバー間の送金）
-    const transfers = await prisma.settlementTransfer.findMany({
-      where: {
-        month: targetMonth,
-        familyGroupId,
-      },
-      select: {
-        id: true,
-        fromMemberId: true,
-        toMemberId: true,
-        amount: true,
-        settledAt: true,
-      }
-    });
-
-    transfers.forEach(t => {
-      if (stats[t.fromMemberId]) stats[t.fromMemberId].transferredOut += t.amount;
-      if (stats[t.toMemberId]) stats[t.toMemberId].transferredIn += t.amount;
-    });
-
-    // 5. 最終的な精算額（balance）の計算
-    const result = Object.entries(stats).map(([id, s]) => {
-      // 本来のレシート差額 (立替額 - 負担額)
-      // > 0: 払いすぎ (受け取る権利)
-      // < 0: 払いが足りない (支払う義務)
-      s.baseBalance = s.totalPaid - s.totalOwed;
-
-      // 最終残額の計算
-      // 支払う義務(<0)がある人は、送金(transferredOut)すると義務が減る(+方向へ)
-      // 受け取る権利(>0)がある人は、受領(transferredIn)すると権利が減る(-方向へ)
-      s.balance = s.baseBalance + s.transferredOut - s.transferredIn;
-
-      return {
-        memberId: Number(id),
-        name: s.name,
-        totalPaid: s.totalPaid,
-        totalOwed: s.totalOwed,
-        baseBalance: s.baseBalance,
-        transferredOut: s.transferredOut,
-        transferredIn: s.transferredIn,
-        balance: s.balance,
-      };
-    });
-
-    res.status(200).json({
-      success: true,
-      data: {
-        month: targetMonth,
-        members: result,
-        transfers // 履歴表示用に生の送金データも返す
-      }
-    });
-
+    const data = await getSettlementStatusData(
+      getFamilyGroupId(),
+      req.query.month as string | undefined
+    );
+    res.status(200).json({ success: true, data });
   } catch (error) {
     next(error);
   }
 };
 
-
-/**
- * ★ [Issue #81] 送金記録（締め処理の実績）の登録
- * POST /api/stats/settlement/transfers
- */
 export const addSettlementTransfer = async (req: Request, res: Response, next: NextFunction) => {
-  const familyGroupId = getFamilyGroupId();
-
-  const { month, fromMemberId, toMemberId, amount } = req.body;
-  const normalizedMonth = normalizeYearMonth(month);
-  const fromId = Number(fromMemberId);
-  const toId = Number(toMemberId);
-  const transferAmount = Math.round(Number(amount));
-
-  if (!normalizedMonth || !fromMemberId || !toMemberId || !Number.isFinite(transferAmount) || transferAmount <= 0) {
-    return next(new AppError('必要なパラメータが不足しているか、金額が不正です。', 400));
-  }
-
-  if (fromId === toId) {
-    return next(new AppError('自分自身への送金は登録できません。', 400));
-  }
-
   try {
-    const validMembers = await prisma.familyMember.findMany({
-      where: {
-        id: { in: [fromId, toId] },
-        familyGroupId,
-      },
+    const { month, fromMemberId, toMemberId, amount } = req.body;
+    const newTransfer = await createSettlementTransfer(getFamilyGroupId(), {
+      month,
+      fromMemberId,
+      toMemberId,
+      amount,
     });
-
-    if (validMembers.length !== 2) {
-      throw new AppError('無効なユーザー指定、または権限がありません。', 403);
-    }
-
-    // 送金記録の作成
-    const newTransfer = await prisma.settlementTransfer.create({
-      data: {
-        familyGroupId,
-        month: normalizedMonth,
-        fromMemberId: fromId,
-        toMemberId: toId,
-        amount: transferAmount,
-        // settledAt は default(now()) で自動採番
-      }
-    });
-
-    res.status(201).json({
-      success: true,
-      data: newTransfer
-    });
-
+    res.status(201).json({ success: true, data: newTransfer });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * [Issue #88] 送金記録の取消（物理削除）
- * DELETE /api/stats/settlement/transfers/:id
- */
 export const deleteSettlementTransfer = async (
   req: Request<{ id: string }>,
   res: Response,
   next: NextFunction
 ) => {
-  const familyGroupId = getFamilyGroupId();
-  const transferId = Number(getRouteParam(req, 'id'));
-
-  if (!Number.isFinite(transferId) || transferId <= 0) {
-    return next(new AppError('送金記録IDが不正です。', 400));
-  }
-
   try {
-    const transfer = await prisma.settlementTransfer.findUnique({
-      where: { id: transferId },
-    });
-
-    if (!transfer) {
-      throw new AppError('送金記録が見つかりません。', 404);
-    }
-
-    if (transfer.familyGroupId !== familyGroupId) {
-      throw new AppError('この送金記録を操作する権限がありません。', 403);
-    }
-
-    await prisma.settlementTransfer.delete({ where: { id: transferId } });
-
-    res.status(200).json({ success: true, data: { id: transferId } });
+    const data = await removeSettlementTransfer(
+      getFamilyGroupId(),
+      Number(getRouteParam(req, 'id'))
+    );
+    res.status(200).json({ success: true, data });
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/settlement/settlementAggregation.test.ts
+++ b/backend/src/services/settlement/settlementAggregation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateReceiptsIntoStats,
+  aggregateTransfersIntoStats,
+  computeSettlementMemberSummaries,
+  finalizeMemberStats,
+  initMemberStats,
+} from './settlementAggregation';
+
+const members = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+
+describe('settlementAggregation', () => {
+  it('assigns implicit default owed to payer when item has no splits', () => {
+    const stats = initMemberStats(members);
+    aggregateReceiptsIntoStats(stats, [
+      {
+        memberId: 1,
+        items: [{ price: 100, quantity: 1, splits: [] }],
+      },
+    ]);
+
+    const [alice] = finalizeMemberStats(stats);
+    expect(alice.totalPaid).toBe(100);
+    expect(alice.totalOwed).toBe(100);
+    expect(alice.baseBalance).toBe(0);
+  });
+
+  it('distributes owed by explicit splits', () => {
+    const stats = initMemberStats(members);
+    aggregateReceiptsIntoStats(stats, [
+      {
+        memberId: 1,
+        items: [
+          {
+            price: 100,
+            quantity: 1,
+            splits: [
+              { familyMemberId: 1, amount: 40 },
+              { familyMemberId: 2, amount: 60 },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = finalizeMemberStats(stats);
+    const alice = result.find((m) => m.memberId === 1)!;
+    const bob = result.find((m) => m.memberId === 2)!;
+
+    expect(alice.totalPaid).toBe(100);
+    expect(alice.totalOwed).toBe(40);
+    expect(alice.baseBalance).toBe(60);
+    expect(bob.totalPaid).toBe(0);
+    expect(bob.totalOwed).toBe(60);
+    expect(bob.baseBalance).toBe(-60);
+  });
+
+  it('applies transfers to balance per domain-model §5', () => {
+    const stats = initMemberStats(members);
+    aggregateReceiptsIntoStats(stats, [
+      {
+        memberId: 1,
+        items: [{ price: 100, quantity: 1, splits: [{ familyMemberId: 2, amount: 100 }] }],
+      },
+    ]);
+    aggregateTransfersIntoStats(stats, [{ fromMemberId: 2, toMemberId: 1, amount: 100 }]);
+
+    const result = finalizeMemberStats(stats);
+    const alice = result.find((m) => m.memberId === 1)!;
+    const bob = result.find((m) => m.memberId === 2)!;
+
+    expect(alice.baseBalance).toBe(100);
+    expect(alice.transferredIn).toBe(100);
+    expect(alice.balance).toBe(0);
+    expect(bob.baseBalance).toBe(-100);
+    expect(bob.transferredOut).toBe(100);
+    expect(bob.balance).toBe(0);
+  });
+
+  it('computeSettlementMemberSummaries integrates all steps', () => {
+    const result = computeSettlementMemberSummaries(
+      members,
+      [
+        {
+          memberId: 1,
+          items: [{ price: 50, quantity: 2, splits: [] }],
+        },
+      ],
+      []
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.find((m) => m.memberId === 1)).toMatchObject({
+      totalPaid: 100,
+      totalOwed: 100,
+      balance: 0,
+    });
+  });
+});

--- a/backend/src/services/settlement/settlementAggregation.ts
+++ b/backend/src/services/settlement/settlementAggregation.ts
@@ -1,0 +1,137 @@
+import { calcItemLineTotal } from '../../utils/itemLineTotal';
+
+export type SettlementMemberSeed = {
+  id: number;
+  name: string;
+};
+
+export type SettlementSplitInput = {
+  familyMemberId: number;
+  amount: number;
+};
+
+export type SettlementItemInput = {
+  price: number;
+  quantity: number;
+  splits: SettlementSplitInput[];
+};
+
+export type SettlementReceiptInput = {
+  memberId: number;
+  items: SettlementItemInput[];
+};
+
+export type SettlementTransferInput = {
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+};
+
+export type MemberStatAccum = {
+  name: string;
+  totalPaid: number;
+  totalOwed: number;
+  baseBalance: number;
+  transferredOut: number;
+  transferredIn: number;
+  balance: number;
+};
+
+export type SettlementMemberSummary = {
+  memberId: number;
+  name: string;
+  totalPaid: number;
+  totalOwed: number;
+  baseBalance: number;
+  transferredOut: number;
+  transferredIn: number;
+  balance: number;
+};
+
+/** domain-model.md §5 — メンバーごとの集計器を初期化 */
+export function initMemberStats(members: SettlementMemberSeed[]): Record<number, MemberStatAccum> {
+  const stats: Record<number, MemberStatAccum> = {};
+  for (const m of members) {
+    stats[m.id] = {
+      name: m.name,
+      totalPaid: 0,
+      totalOwed: 0,
+      baseBalance: 0,
+      transferredOut: 0,
+      transferredIn: 0,
+      balance: 0,
+    };
+  }
+  return stats;
+}
+
+/** domain-model.md §4.3 — 暗黙デフォルト（Split なし＝支払者全額負担）を含むレシート集計 */
+export function aggregateReceiptsIntoStats(
+  stats: Record<number, MemberStatAccum>,
+  receipts: SettlementReceiptInput[]
+): void {
+  for (const receipt of receipts) {
+    let receiptTotalPaid = 0;
+
+    for (const item of receipt.items) {
+      const itemPriceInt = calcItemLineTotal(item.price, item.quantity);
+      receiptTotalPaid += itemPriceInt;
+
+      if (item.splits.length > 0) {
+        for (const split of item.splits) {
+          if (stats[split.familyMemberId]) {
+            stats[split.familyMemberId].totalOwed += split.amount;
+          }
+        }
+      } else if (stats[receipt.memberId]) {
+        stats[receipt.memberId].totalOwed += itemPriceInt;
+      }
+    }
+
+    if (stats[receipt.memberId]) {
+      stats[receipt.memberId].totalPaid += receiptTotalPaid;
+    }
+  }
+}
+
+/** domain-model.md §5 — 送金実績を集計 */
+export function aggregateTransfersIntoStats(
+  stats: Record<number, MemberStatAccum>,
+  transfers: SettlementTransferInput[]
+): void {
+  for (const t of transfers) {
+    if (stats[t.fromMemberId]) stats[t.fromMemberId].transferredOut += t.amount;
+    if (stats[t.toMemberId]) stats[t.toMemberId].transferredIn += t.amount;
+  }
+}
+
+/** domain-model.md §5 — baseBalance / balance を確定 */
+export function finalizeMemberStats(stats: Record<number, MemberStatAccum>): SettlementMemberSummary[] {
+  return Object.entries(stats).map(([id, s]) => {
+    s.baseBalance = s.totalPaid - s.totalOwed;
+    s.balance = s.baseBalance + s.transferredOut - s.transferredIn;
+
+    return {
+      memberId: Number(id),
+      name: s.name,
+      totalPaid: s.totalPaid,
+      totalOwed: s.totalOwed,
+      baseBalance: s.baseBalance,
+      transferredOut: s.transferredOut,
+      transferredIn: s.transferredIn,
+      balance: s.balance,
+    };
+  });
+}
+
+/** レシート・送金からメンバー別精算サマリーを算出（純粋関数） */
+export function computeSettlementMemberSummaries(
+  members: SettlementMemberSeed[],
+  receipts: SettlementReceiptInput[],
+  transfers: SettlementTransferInput[]
+): SettlementMemberSummary[] {
+  const stats = initMemberStats(members);
+  aggregateReceiptsIntoStats(stats, receipts);
+  aggregateTransfersIntoStats(stats, transfers);
+  return finalizeMemberStats(stats);
+}

--- a/backend/src/services/settlement/settlementService.ts
+++ b/backend/src/services/settlement/settlementService.ts
@@ -1,0 +1,158 @@
+import { prisma } from '../../utils/prismaClient';
+import { AppError } from '../../utils/appError';
+import {
+  getCurrentYearMonthLocal,
+  getLocalMonthDateRange,
+  normalizeYearMonth,
+} from '../../utils/yearMonth';
+import { computeSettlementMemberSummaries } from './settlementAggregation';
+
+export type SettlementTransferRecord = {
+  id: number;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  settledAt: Date;
+};
+
+export type SettlementStatusData = {
+  month: string;
+  members: ReturnType<typeof computeSettlementMemberSummaries>;
+  transfers: SettlementTransferRecord[];
+};
+
+/** 月間精算ステータス（暗黙デフォルト ＋ 送金実績反映） */
+export async function getSettlementStatusData(
+  familyGroupId: number,
+  month?: string
+): Promise<SettlementStatusData> {
+  const targetMonth = normalizeYearMonth(month) ?? getCurrentYearMonthLocal();
+  const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
+
+  const members = await prisma.familyMember.findMany({
+    where: { familyGroupId },
+    select: { id: true, name: true },
+  });
+
+  const receipts = await prisma.receipt.findMany({
+    where: {
+      familyGroupId,
+      date: { gte: startDate, lt: endDate },
+    },
+    include: {
+      items: {
+        include: { splits: true },
+      },
+    },
+  });
+
+  const transfers = await prisma.settlementTransfer.findMany({
+    where: {
+      month: targetMonth,
+      familyGroupId,
+    },
+    select: {
+      id: true,
+      fromMemberId: true,
+      toMemberId: true,
+      amount: true,
+      settledAt: true,
+    },
+  });
+
+  const memberSummaries = computeSettlementMemberSummaries(
+    members,
+    receipts.map((r) => ({
+      memberId: r.memberId,
+      items: r.items.map((item) => ({
+        price: item.price,
+        quantity: item.quantity,
+        splits: item.splits.map((s) => ({
+          familyMemberId: s.familyMemberId,
+          amount: s.amount,
+        })),
+      })),
+    })),
+    transfers.map((t) => ({
+      fromMemberId: t.fromMemberId,
+      toMemberId: t.toMemberId,
+      amount: t.amount,
+    }))
+  );
+
+  return {
+    month: targetMonth,
+    members: memberSummaries,
+    transfers,
+  };
+}
+
+export type CreateSettlementTransferInput = {
+  month: string;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+};
+
+/** 送金記録の登録 */
+export async function createSettlementTransfer(
+  familyGroupId: number,
+  input: CreateSettlementTransferInput
+) {
+  const normalizedMonth = normalizeYearMonth(input.month);
+  const fromId = Number(input.fromMemberId);
+  const toId = Number(input.toMemberId);
+  const transferAmount = Math.round(Number(input.amount));
+
+  if (!normalizedMonth || !input.fromMemberId || !input.toMemberId || !Number.isFinite(transferAmount) || transferAmount <= 0) {
+    throw new AppError('必要なパラメータが不足しているか、金額が不正です。', 400);
+  }
+
+  if (fromId === toId) {
+    throw new AppError('自分自身への送金は登録できません。', 400);
+  }
+
+  const validMembers = await prisma.familyMember.findMany({
+    where: {
+      id: { in: [fromId, toId] },
+      familyGroupId,
+    },
+  });
+
+  if (validMembers.length !== 2) {
+    throw new AppError('無効なユーザー指定、または権限がありません。', 403);
+  }
+
+  return prisma.settlementTransfer.create({
+    data: {
+      familyGroupId,
+      month: normalizedMonth,
+      fromMemberId: fromId,
+      toMemberId: toId,
+      amount: transferAmount,
+    },
+  });
+}
+
+/** 送金記録の取消（物理削除） */
+export async function deleteSettlementTransfer(familyGroupId: number, transferId: number) {
+  if (!Number.isFinite(transferId) || transferId <= 0) {
+    throw new AppError('送金記録IDが不正です。', 400);
+  }
+
+  const transfer = await prisma.settlementTransfer.findUnique({
+    where: { id: transferId },
+  });
+
+  if (!transfer) {
+    throw new AppError('送金記録が見つかりません。', 404);
+  }
+
+  if (transfer.familyGroupId !== familyGroupId) {
+    throw new AppError('この送金記録を操作する権限がありません。', 403);
+  }
+
+  await prisma.settlementTransfer.delete({ where: { id: transferId } });
+
+  return { id: transferId };
+}


### PR DESCRIPTION
## Summary

- `services/settlement/settlementAggregation.ts` — 精算集計の純粋関数（domain-model §5 準拠）
- `services/settlement/settlementService.ts` — DB 取得・送金 CRUD
- `statsController.ts` を **240行 → 52行** に薄型化
- `settlementAggregation.test.ts` — 暗黙デフォルト按分・Split・送金・balance 計算の単体テスト（4件）

Epic: #370

Closes #376

## Test plan

- [x] `cd backend && npm test` — 38 passed（単体 4 + 既存）
- [ ] 精算サマリー画面で月次 balance がリファクタ前と一致
- [ ] 送金登録・取消


Made with [Cursor](https://cursor.com)