### PR TITLE
refactor(settlement): [Issue #98-8-3] 精算 API クエリ最適化（R-B008）

### DIFF
--- a/backend/src/services/settlement/settlementService.test.ts
+++ b/backend/src/services/settlement/settlementService.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { computeSettlementMemberSummaries } from './settlementAggregation';
+import { buildSettlementReceiptInputsFromItems } from './settlementService';
+
+const members = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+
+describe('buildSettlementReceiptInputsFromItems', () => {
+  it('groups items by receipt and preserves splits', () => {
+    const receipts = buildSettlementReceiptInputsFromItems([
+      {
+        receiptId: 10,
+        memberId: 1,
+        price: 100,
+        quantity: 1,
+        splits: [],
+      },
+      {
+        receiptId: 10,
+        memberId: 1,
+        price: 50,
+        quantity: 2,
+        splits: [{ familyMemberId: 2, amount: 100 }],
+      },
+      {
+        receiptId: 20,
+        memberId: 2,
+        price: 200,
+        quantity: 1,
+        splits: [],
+      },
+    ]);
+
+    expect(receipts).toHaveLength(2);
+    expect(receipts[0]).toEqual({
+      memberId: 1,
+      items: [
+        { price: 100, quantity: 1, splits: [] },
+        { price: 50, quantity: 2, splits: [{ familyMemberId: 2, amount: 100 }] },
+      ],
+    });
+    expect(receipts[1]).toEqual({
+      memberId: 2,
+      items: [{ price: 200, quantity: 1, splits: [] }],
+    });
+  });
+
+  it('produces the same aggregation as receipt-centric mapping', () => {
+    const legacyReceipts = [
+      {
+        memberId: 1,
+        items: [
+          { price: 100, quantity: 1, splits: [] },
+          {
+            price: 50,
+            quantity: 2,
+            splits: [
+              { familyMemberId: 1, amount: 40 },
+              { familyMemberId: 2, amount: 60 },
+            ],
+          },
+        ],
+      },
+      {
+        memberId: 2,
+        items: [{ price: 200, quantity: 1, splits: [] }],
+      },
+    ];
+
+    const itemRows = [
+      {
+        receiptId: 10,
+        memberId: 1,
+        price: 100,
+        quantity: 1,
+        splits: [] as { familyMemberId: number; amount: number }[],
+      },
+      {
+        receiptId: 10,
+        memberId: 1,
+        price: 50,
+        quantity: 2,
+        splits: [
+          { familyMemberId: 1, amount: 40 },
+          { familyMemberId: 2, amount: 60 },
+        ],
+      },
+      {
+        receiptId: 20,
+        memberId: 2,
+        price: 200,
+        quantity: 1,
+        splits: [] as { familyMemberId: number; amount: number }[],
+      },
+    ];
+
+    const optimizedReceipts = buildSettlementReceiptInputsFromItems(itemRows);
+    const transfers = [{ fromMemberId: 2, toMemberId: 1, amount: 60 }];
+
+    expect(
+      computeSettlementMemberSummaries(members, optimizedReceipts, transfers)
+    ).toEqual(computeSettlementMemberSummaries(members, legacyReceipts, transfers));
+  });
+});

--- a/backend/src/services/settlement/settlementService.ts
+++ b/backend/src/services/settlement/settlementService.ts
@@ -5,7 +5,78 @@ import {
   getLocalMonthDateRange,
   normalizeYearMonth,
 } from '../../utils/yearMonth';
-import { computeSettlementMemberSummaries } from './settlementAggregation';
+import {
+  computeSettlementMemberSummaries,
+  type SettlementReceiptInput,
+} from './settlementAggregation';
+
+export type SettlementItemRow = {
+  receiptId: number;
+  memberId: number;
+  price: number;
+  quantity: number;
+  splits: { familyMemberId: number; amount: number }[];
+};
+
+/** Item 行を receipt 単位にグループ化（集計入力用） */
+export function buildSettlementReceiptInputsFromItems(
+  rows: SettlementItemRow[]
+): SettlementReceiptInput[] {
+  const receiptsById = new Map<number, SettlementReceiptInput>();
+
+  for (const row of rows) {
+    let receipt = receiptsById.get(row.receiptId);
+    if (!receipt) {
+      receipt = { memberId: row.memberId, items: [] };
+      receiptsById.set(row.receiptId, receipt);
+    }
+
+    receipt.items.push({
+      price: row.price,
+      quantity: row.quantity,
+      splits: row.splits,
+    });
+  }
+
+  return Array.from(receiptsById.values());
+}
+
+async function fetchSettlementReceiptInputs(
+  familyGroupId: number,
+  startDate: Date,
+  endDate: Date
+): Promise<SettlementReceiptInput[]> {
+  const items = await prisma.item.findMany({
+    where: {
+      receipt: {
+        familyGroupId,
+        date: { gte: startDate, lt: endDate },
+      },
+    },
+    select: {
+      receiptId: true,
+      price: true,
+      quantity: true,
+      receipt: { select: { memberId: true } },
+      splits: {
+        select: {
+          familyMemberId: true,
+          amount: true,
+        },
+      },
+    },
+  });
+
+  return buildSettlementReceiptInputsFromItems(
+    items.map((item) => ({
+      receiptId: item.receiptId,
+      memberId: item.receipt.memberId,
+      price: item.price,
+      quantity: item.quantity,
+      splits: item.splits,
+    }))
+  );
+}
 
 export type SettlementTransferRecord = {
   id: number;
@@ -29,50 +100,30 @@ export async function getSettlementStatusData(
   const targetMonth = normalizeYearMonth(month) ?? getCurrentYearMonthLocal();
   const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
 
-  const members = await prisma.familyMember.findMany({
-    where: { familyGroupId },
-    select: { id: true, name: true },
-  });
-
-  const receipts = await prisma.receipt.findMany({
-    where: {
-      familyGroupId,
-      date: { gte: startDate, lt: endDate },
-    },
-    include: {
-      items: {
-        include: { splits: true },
+  const [members, receiptInputs, transfers] = await Promise.all([
+    prisma.familyMember.findMany({
+      where: { familyGroupId },
+      select: { id: true, name: true },
+    }),
+    fetchSettlementReceiptInputs(familyGroupId, startDate, endDate),
+    prisma.settlementTransfer.findMany({
+      where: {
+        month: targetMonth,
+        familyGroupId,
       },
-    },
-  });
-
-  const transfers = await prisma.settlementTransfer.findMany({
-    where: {
-      month: targetMonth,
-      familyGroupId,
-    },
-    select: {
-      id: true,
-      fromMemberId: true,
-      toMemberId: true,
-      amount: true,
-      settledAt: true,
-    },
-  });
+      select: {
+        id: true,
+        fromMemberId: true,
+        toMemberId: true,
+        amount: true,
+        settledAt: true,
+      },
+    }),
+  ]);
 
   const memberSummaries = computeSettlementMemberSummaries(
     members,
-    receipts.map((r) => ({
-      memberId: r.memberId,
-      items: r.items.map((item) => ({
-        price: item.price,
-        quantity: item.quantity,
-        splits: item.splits.map((s) => ({
-          familyMemberId: s.familyMemberId,
-          amount: s.amount,
-        })),
-      })),
-    })),
+    receiptInputs,
     transfers.map((t) => ({
       fromMemberId: t.fromMemberId,
       toMemberId: t.toMemberId,


### PR DESCRIPTION
## Summary

- `getSettlementStatusData` の Receipt 全件 `include` を廃止
- 集計に必要なフィールドのみ `Item.findMany` + `select` で取得
- members / items / transfers を `Promise.all` で並列化
- `buildSettlementReceiptInputsFromItems` を追加し、旧 mapping と集計結果一致をテスト

Epic: #378 / R-B008

Closes #395

## Test plan

- [x] `cd backend && npm test` — 40 passed（`settlementService.test.ts` 新規 2 件含む）
- [x] 明細なし Receipt はもともと集計に影響しないため除外しても結果同一


Made with [Cursor](https://cursor.com)