### PR TITLE
refactor(fe): [Issue #98-8-2] Frontend 残存 any 整理

### DIFF
--- a/frontend/src/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/components/ReceiptDetailComponent.tsx
@@ -13,6 +13,7 @@ import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { receiptApi } from '../api/receiptApi';
+import { getApiErrorMessage } from '../utils/apiError';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 import type { CategorySummary, ReceiptDetail, ReceiptItemDetail } from '../types/receipt';
 import type { ReceiptForSplitEditor } from '../types/settlement';
@@ -123,8 +124,8 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
         setIsEditing(false);
         if (onSaveSuccess) onSaveSuccess();
       }
-    } catch (err: any) {
-      console.error('Update failed', err.response?.data || err.message);
+    } catch (err: unknown) {
+      console.error('Update failed', getApiErrorMessage(err));
       Alert.alert('エラー', '保存に失敗しました。');
     } finally {
       setLoading(false);

--- a/frontend/src/features/app/components/AppViewRouter.tsx
+++ b/frontend/src/features/app/components/AppViewRouter.tsx
@@ -21,6 +21,7 @@ import { devUiColors, isDevAppEnv } from '../../../config/appEnv';
 import type { AppViewType } from '../hooks/useAppSession';
 import type { ReceiptScanInitialData } from '../../../types/receiptScan';
 import type { ReceiptForSplitEditor } from '../../../types/settlement';
+import type { CategorySummary } from '../../../types/receipt';
 
 export interface AppViewRouterProps {
   currentView: AppViewType;
@@ -31,7 +32,7 @@ export interface AppViewRouterProps {
   biometricEnabled: boolean;
   totpEnabled: boolean;
   setTotpEnabled: (enabled: boolean) => void;
-  categories: any[];
+  categories: CategorySummary[];
   resultData: ReceiptScanInitialData | null;
   targetReceipt: ReceiptForSplitEditor | null;
   setTargetReceipt: (receipt: ReceiptForSplitEditor | null) => void;

--- a/frontend/src/features/app/hooks/useAppSession.ts
+++ b/frontend/src/features/app/hooks/useAppSession.ts
@@ -7,6 +7,7 @@ import { setOnUnauthorized } from '../../../utils/apiClient';
 import { authService } from '../../../services/authService';
 import { canUseBiometric } from '../../../services/biometricService';
 import type { LoginResult, StoredSession } from '../../../types/auth';
+import type { CategorySummary } from '../../../types/receipt';
 
 const STORAGE_KEYS = {
   VIEW: '@app_view',
@@ -38,7 +39,7 @@ export function useAppSession() {
   const [biometricLockActive, setBiometricLockActive] = useState(false);
   const [biometricEnabled, setBiometricEnabled] = useState(false);
   const [totpEnabled, setTotpEnabled] = useState(false);
-  const [categories, setCategories] = useState<any[]>([]);
+  const [categories, setCategories] = useState<CategorySummary[]>([]);
   const [currentView, setCurrentView] = useState<AppViewType>('main');
 
   const applySession = useCallback((session: StoredSession) => {

--- a/frontend/src/features/settlement/components/SplitEditorItemTable.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorItemTable.tsx
@@ -5,12 +5,12 @@ import {
   View,
   ScrollView,
   TextInput,
-  Platform,
 } from 'react-native';
 import { AppButton } from '../../../components/ui';
 import { BUTTON_LABELS } from '../../../constants/buttonLabels';
 import { theme, tableStyles } from '../../../theme';
 import { calcItemTotal } from '../../../utils/splitEditorSplits';
+import { webTextInputOutlineNone } from '../../../utils/webPlatformStyles';
 import type {
   FamilyMemberSummary,
   ReceiptForSplitEditor,
@@ -281,7 +281,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: theme.colors.text.main,
     paddingRight: 4,
-    ...Platform.select({ web: { outlineStyle: 'none' } as any }),
+    ...webTextInputOutlineNone,
   },
   percentBox: { width: 35 },
   amountBox: { width: 60 },

--- a/frontend/src/features/settlement/components/SplitEditorMemberChips.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorMemberChips.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { StyleSheet, Text, View, TouchableOpacity, Platform } from 'react-native';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { theme } from '../../../theme';
+import { webPickerOutlineReset } from '../../../utils/webPlatformStyles';
 import type { FamilyMemberSummary } from '../../../types/settlement';
 
 interface SplitEditorMemberChipsProps {
@@ -115,6 +116,6 @@ const styles = StyleSheet.create({
     color: theme.colors.primary,
     fontSize: 14,
     fontWeight: 'bold',
-    ...Platform.select({ web: { outlineStyle: 'none', border: 'none', background: 'transparent' } as any }),
+    ...webPickerOutlineReset,
   },
 });

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -9,6 +9,7 @@ import {
 import { AppBackButton } from '../components/ui';
 import { theme, tableStyles } from '../theme';
 import apiClient from '../utils/apiClient';
+import { getApiErrorMessage } from '../utils/apiError';
 
 interface StatData {
   month: string;
@@ -40,11 +41,9 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
         const total = res.data.data.reduce((sum: number, item: StatData) => sum + item.estimatedCostJpy, 0);
         setTotalCost(total);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Stats Fetch Error:', error);
-      // ★ Alertを廃止し、バックエンドのエラーメッセージを抽出してステートにセット
-      const serverError = error?.response?.data?.error || error?.response?.data?.message || 'コスト統計の取得に失敗しました。';
-      setErrorMsg(serverError);
+      setErrorMsg(getApiErrorMessage(error, 'コスト統計の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
 import apiClient from '../utils/apiClient';
+import { getApiErrorStatus } from '../utils/apiError';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
@@ -45,8 +46,8 @@ export const CategoryManagementScreen = ({
       if (res.data && res.data.success) {
         setCategories(res.data.data || []);
       }
-    } catch (e: any) {
-      if (e.response?.status === 401) {
+    } catch (e: unknown) {
+      if (getApiErrorStatus(e) === 401) {
         Alert.alert("セッション切れ", "再度ログインしてください。");
       } else {
         Alert.alert("エラー", "カテゴリーの取得に失敗しました。");
@@ -82,8 +83,8 @@ export const CategoryManagementScreen = ({
           try {
             await apiClient.delete(`/categories/${id}`, { headers: getHeaders() });
             fetchCategories();
-          } catch (e: any) {
-            const status = e.response?.status;
+          } catch (e: unknown) {
+            const status = getApiErrorStatus(e);
             if (status === 400 || status === 409) {
               Alert.alert('制限', 'このカテゴリーは既に使用されているため削除できません。');
             } else {

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 
 import apiClient from '../utils/apiClient';
+import { getApiErrorMessage } from '../utils/apiError';
 import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
@@ -20,7 +21,7 @@ interface PromptTemplate {
   name: string;
   description: string | null;
   systemPrompt: string;
-  domainHints: Record<string, any> | null;
+  domainHints: Record<string, unknown> | null;
   isActive: boolean;
   version: number;
 }
@@ -58,8 +59,8 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       } else {
         setError('データの取得に失敗しました。');
       }
-    } catch (err: any) {
-      setError(err?.response?.data?.error || err.message || '通信エラーが発生しました。');
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err));
     } finally {
       setIsLoading(false);
     }
@@ -73,8 +74,8 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
     try {
       await apiClient.patch(`/admin/prompts/${id}/activate`);
       fetchPrompts();
-    } catch (err: any) {
-      Alert.alert('エラー', 'デフォルトの切り替えに失敗しました。');
+    } catch (err: unknown) {
+      Alert.alert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
     }
   };
 
@@ -83,8 +84,8 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       try {
         await apiClient.delete(`/admin/prompts/${id}`);
         fetchPrompts();
-      } catch (err: any) {
-        Alert.alert('エラー', err?.response?.data?.error || '削除に失敗しました。');
+      } catch (err: unknown) {
+        Alert.alert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
       }
     };
 
@@ -145,8 +146,8 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       setEditingTemplate(null);
       setIsCreatingNew(false);
       fetchPrompts();
-    } catch (err: any) {
-      setError(err?.response?.data?.error || err.message || '保存に失敗しました。');
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, '保存に失敗しました。'));
     } finally {
       setIsSaving(false);
     }

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -18,6 +18,7 @@ import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 import { showAlert } from '../utils/alertMessage';
+import { getApiErrorMessage, getApiErrorResponseData } from '../utils/apiError';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
 import type { ParsedReceiptItemInput } from '../types/receipt';
 
@@ -112,9 +113,9 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
         showAlert('成功', 'レシートを保存しました。', { onOk: onSuccess });
         return;
       }
-    } catch (err: any) {
-      const apiError = err.response?.data;
-      const message = apiError?.message || err.message;
+    } catch (err: unknown) {
+      const apiError = getApiErrorResponseData(err);
+      const message = getApiErrorMessage(err, '保存に失敗しました。');
 
       if (message === 'DUPLICATE') {
         const duplicateMessage = initialData.warnedDuplicateFromTray
@@ -124,7 +125,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
         return;
       }
 
-      console.error('Commit error:', apiError || err.message);
+      console.error('Commit error:', apiError || message);
       showAlert('エラー', message || '保存に失敗しました。');
     } finally {
       setLoading(false);

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -109,7 +109,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       }
       if (advRes.success) setAdvancedData(advRes.data);
       if (catRes.success) setAllCategories(catRes.data);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('[DEBUG-STATS] Fetch Error:', error);
       Alert.alert("エラー", "データの取得に失敗しました");
     } finally {

--- a/frontend/src/utils/apiError.test.ts
+++ b/frontend/src/utils/apiError.test.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+import {
+  getApiErrorMessage,
+  getApiErrorResponseData,
+  getApiErrorStatus,
+} from './apiError';
+
+describe('apiError', () => {
+  it('extracts error field from axios response', () => {
+    const error = new axios.AxiosError(
+      'Request failed',
+      'ERR_BAD_REQUEST',
+      undefined,
+      undefined,
+      {
+        status: 403,
+        data: { error: '権限がありません' },
+        statusText: 'Forbidden',
+        headers: {},
+        config: {} as never,
+      }
+    );
+
+    expect(getApiErrorStatus(error)).toBe(403);
+    expect(getApiErrorResponseData(error)).toEqual({ error: '権限がありません' });
+    expect(getApiErrorMessage(error)).toBe('権限がありません');
+  });
+
+  it('falls back to message field then Error.message', () => {
+    const axiosError = new axios.AxiosError(
+      'Request failed',
+      'ERR_BAD_REQUEST',
+      undefined,
+      undefined,
+      {
+        status: 409,
+        data: { message: 'DUPLICATE' },
+        statusText: 'Conflict',
+        headers: {},
+        config: {} as never,
+      }
+    );
+
+    expect(getApiErrorMessage(axiosError)).toBe('DUPLICATE');
+    expect(getApiErrorMessage(new Error('保存に失敗'))).toBe('保存に失敗');
+    expect(getApiErrorMessage('unknown')).toBe('通信エラーが発生しました。');
+  });
+});

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+function readStringField(data: unknown, key: 'error' | 'message'): string | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const value = (data as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Axios レスポンス body（存在する場合） */
+export function getApiErrorResponseData(error: unknown): unknown {
+  if (axios.isAxiosError(error)) {
+    return error.response?.data;
+  }
+  return undefined;
+}
+
+/** HTTP ステータス（Axios エラー時） */
+export function getApiErrorStatus(error: unknown): number | undefined {
+  if (axios.isAxiosError(error)) {
+    return error.response?.status;
+  }
+  return undefined;
+}
+
+/** API / Error からユーザー向けメッセージを抽出 */
+export function getApiErrorMessage(
+  error: unknown,
+  fallback = '通信エラーが発生しました。'
+): string {
+  const data = getApiErrorResponseData(error);
+  const fromError = readStringField(data, 'error');
+  if (fromError) return fromError;
+
+  const fromMessage = readStringField(data, 'message');
+  if (fromMessage) return fromMessage;
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}

--- a/frontend/src/utils/webPlatformStyles.ts
+++ b/frontend/src/utils/webPlatformStyles.ts
@@ -1,0 +1,15 @@
+import { Platform, type TextStyle } from 'react-native';
+
+/** RN Web: outlineStyle は StyleSheet 型に未収載 */
+export const webTextInputOutlineNone: TextStyle =
+  Platform.OS === 'web' ? ({ outlineStyle: 'none' } as TextStyle) : {};
+
+/** RN Web: Picker のブラウザデフォルト枠線を除去 */
+export const webPickerOutlineReset: TextStyle =
+  Platform.OS === 'web'
+    ? ({
+        outlineStyle: 'none',
+        borderWidth: 0,
+        backgroundColor: 'transparent',
+      } as TextStyle)
+    : {};


### PR DESCRIPTION
## Summary

- `utils/apiError.ts` を追加（`getApiErrorMessage` / `getApiErrorStatus`）
- 管理系 Screen の `catch (err: any)` を `unknown` + 型安全なエラー抽出へ統一
- `categories: any[]` → `CategorySummary[]`（`useAppSession`, `AppViewRouter`）
- `Platform.select({ ... } as any)` → `webPlatformStyles.ts` へ移行

Epic: #378

Closes #394

## Test plan

- [x] `cd frontend && npm test` — 42 passed
- [x] frontend 全体で `: any` / `as any` 残存なし


Made with [Cursor](https://cursor.com)