### PR TITLE
refactor(ai): [Issue #98-8-4] AI Provider 抽象化

### DIFF
--- a/backend/src/ai/geminiReceiptAnalysisProvider.ts
+++ b/backend/src/ai/geminiReceiptAnalysisProvider.ts
@@ -1,0 +1,7 @@
+import { analyzeReceiptImage } from '../services/geminiService';
+import type { ReceiptAnalysisProvider } from './receiptAnalysisProvider';
+
+/** Gemini 実装（既存 geminiService を委譲） */
+export const geminiReceiptAnalysisProvider: ReceiptAnalysisProvider = {
+  analyzeReceiptImage,
+};

--- a/backend/src/ai/index.ts
+++ b/backend/src/ai/index.ts
@@ -1,0 +1,7 @@
+export type { ReceiptAnalysisProvider } from './receiptAnalysisProvider';
+export { geminiReceiptAnalysisProvider } from './geminiReceiptAnalysisProvider';
+export {
+  getReceiptAnalysisProvider,
+  resetReceiptAnalysisProvider,
+  setReceiptAnalysisProvider,
+} from './receiptAnalysisProviderRegistry';

--- a/backend/src/ai/receiptAnalysisProvider.ts
+++ b/backend/src/ai/receiptAnalysisProvider.ts
@@ -1,0 +1,6 @@
+import type { ParsedReceipt } from '../types/receipt';
+
+/** レシート画像解析 Provider（Gemini 等の差し替え点） */
+export interface ReceiptAnalysisProvider {
+  analyzeReceiptImage(imagePath: string, familyMemberId?: number): Promise<ParsedReceipt>;
+}

--- a/backend/src/ai/receiptAnalysisProviderRegistry.test.ts
+++ b/backend/src/ai/receiptAnalysisProviderRegistry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ParsedReceipt } from '../types/receipt';
+import type { ReceiptAnalysisProvider } from './receiptAnalysisProvider';
+import {
+  getReceiptAnalysisProvider,
+  resetReceiptAnalysisProvider,
+  setReceiptAnalysisProvider,
+} from './receiptAnalysisProviderRegistry';
+import { geminiReceiptAnalysisProvider } from './geminiReceiptAnalysisProvider';
+
+describe('receiptAnalysisProviderRegistry', () => {
+  it('returns gemini provider by default', () => {
+    resetReceiptAnalysisProvider();
+    expect(getReceiptAnalysisProvider()).toBe(geminiReceiptAnalysisProvider);
+  });
+
+  it('allows injecting a mock provider for tests', async () => {
+    const mockParsed: ParsedReceipt = {
+      storeName: 'Mock Store',
+      date: '2026-06-01',
+      totalAmount: 100,
+      items: [{ name: 'Item', price: 100, quantity: 1 }],
+    };
+
+    const mockProvider: ReceiptAnalysisProvider = {
+      analyzeReceiptImage: vi.fn().mockResolvedValue(mockParsed),
+    };
+
+    setReceiptAnalysisProvider(mockProvider);
+
+    await expect(
+      getReceiptAnalysisProvider().analyzeReceiptImage('/tmp/mock.jpg', 1)
+    ).resolves.toEqual(mockParsed);
+
+    resetReceiptAnalysisProvider();
+    expect(getReceiptAnalysisProvider()).toBe(geminiReceiptAnalysisProvider);
+  });
+});

--- a/backend/src/ai/receiptAnalysisProviderRegistry.ts
+++ b/backend/src/ai/receiptAnalysisProviderRegistry.ts
@@ -1,0 +1,17 @@
+import { geminiReceiptAnalysisProvider } from './geminiReceiptAnalysisProvider';
+import type { ReceiptAnalysisProvider } from './receiptAnalysisProvider';
+
+let currentProvider: ReceiptAnalysisProvider = geminiReceiptAnalysisProvider;
+
+export function getReceiptAnalysisProvider(): ReceiptAnalysisProvider {
+  return currentProvider;
+}
+
+/** テスト等で Provider を差し替える（#91-7 モック方針） */
+export function setReceiptAnalysisProvider(provider: ReceiptAnalysisProvider): void {
+  currentProvider = provider;
+}
+
+export function resetReceiptAnalysisProvider(): void {
+  currentProvider = geminiReceiptAnalysisProvider;
+}

--- a/backend/src/services/receipt/receiptAnalysisService.ts
+++ b/backend/src/services/receipt/receiptAnalysisService.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { getCleanText } from '../../utils/normalizer';
-import { analyzeReceiptImage } from '../geminiService';
+import { getReceiptAnalysisProvider } from '../../ai';
 import { estimateCategoryId } from '../categoryService';
 import { validateReceiptItems } from '../validationService';
 
@@ -18,7 +18,7 @@ export async function analyzeOnly(memberId: number, imagePath: string) {
   });
   const familyGroupId = member?.familyGroupId;
 
-  const parsedData = await analyzeReceiptImage(imagePath, memberId);
+  const parsedData = await getReceiptAnalysisProvider().analyzeReceiptImage(imagePath, memberId);
   const cleanStore = getCleanText(parsedData.storeName || '');
 
   const itemsWithCategories = await Promise.all(

--- a/backend/src/workers/receiptWorker.ts
+++ b/backend/src/workers/receiptWorker.ts
@@ -20,7 +20,7 @@ const receiptWorker = new Worker(
     return await runWithTenant({ familyGroupId, memberId }, async () => {
       try {
         /**
-         * analyzeOnly の内部で geminiService.analyzeReceiptImage が呼ばれます。
+         * analyzeOnly の内部で ReceiptAnalysisProvider（Gemini）が呼ばれます。
          * [Issue #71] により、戻り値の ParsedReceipt に taxAmount が含まれるようになっています。
          */
         const result = await analyzeOnly(memberId, imagePath);


### PR DESCRIPTION
## Summary

- `backend/src/ai/` に `ReceiptAnalysisProvider` インターフェースを追加
- `GeminiReceiptAnalysisProvider` は既存 `geminiService` を委譲（挙動変更なし）
- `receiptAnalysisService` を Provider 経由の呼び出しに変更
- `setReceiptAnalysisProvider` / `resetReceiptAnalysisProvider` でテスト用モック注入可能

Epic: #378

Closes #396

## Test plan

- [x] `cd backend && npm test` — 42 passed
- [x] `geminiService.ts` は変更なし（手動スクリプト互換維持）


Made with [Cursor](https://cursor.com)