### PR TITLE
refactor(receipt): [Issue #98-8-5] Context 明示渡し（receipt ドメイン）

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -7,7 +7,7 @@ import {
   listReceiptJobsForMember,
   discardReceiptJobForMember,
 } from '../services/receiptJobService';
-import { getFamilyGroupId, getMemberId } from '../utils/context';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
 import { commitReceipt as commitReceiptService } from '../services/receipt/receiptCommitService';
@@ -28,7 +28,7 @@ import { SplitInput } from '../utils/itemSplitAllocation';
 
 export const getJobStatus = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
+    const { familyGroupId } = requireTenantContext();
     const job = await receiptQueue.getJob(getRouteParam(req, 'jobId'));
     if (!job) throw new AppError('ジョブが見つかりません。', 404);
 
@@ -54,11 +54,8 @@ export const getJobStatus = async (req: Request<{ jobId: string }>, res: Respons
 
 export const getReceiptJobs = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    const memberId = getMemberId();
-    if (!memberId) throw new AppError('メンバーIDが指定されていません。', 400);
-
-    const jobs = await listReceiptJobsForMember(familyGroupId, Number(memberId));
+    const ctx = requireTenantContext();
+    const jobs = await listReceiptJobsForMember(ctx.familyGroupId, ctx.memberId);
     res.status(200).json({ success: true, data: jobs });
   } catch (error) {
     next(error);
@@ -67,11 +64,8 @@ export const getReceiptJobs = async (_req: Request, res: Response, next: NextFun
 
 export const discardReceiptJob = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    const memberId = getMemberId();
-    if (!memberId) throw new AppError('メンバーIDが指定されていません。', 400);
-
-    await discardReceiptJobForMember(getRouteParam(req, 'jobId'), familyGroupId, Number(memberId));
+    const ctx = requireTenantContext();
+    await discardReceiptJobForMember(getRouteParam(req, 'jobId'), ctx.familyGroupId, ctx.memberId);
     res.status(200).json({ success: true, message: 'Discarded' });
   } catch (error) {
     next(error);
@@ -89,16 +83,14 @@ export const getCategories = async (_req: Request, res: Response, next: NextFunc
 
 export const uploadReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const memberId = getMemberId();
-    const familyGroupId = getFamilyGroupId();
+    const ctx = requireTenantContext();
     const imagePath = req.file?.path;
 
     if (!imagePath) throw new AppError('画像がアップロードされていません。', 400);
-    if (!memberId) throw new AppError('メンバーIDが指定されていません。', 400);
 
     const job = await receiptQueue.add('analyze-receipt', {
-      memberId: Number(memberId),
-      familyGroupId,
+      memberId: ctx.memberId,
+      familyGroupId: ctx.familyGroupId,
       imagePath,
     });
 
@@ -110,16 +102,13 @@ export const uploadReceipt = async (req: Request, res: Response, next: NextFunct
 
 export const commitReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const memberId = getMemberId();
-    const familyGroupId = getFamilyGroupId();
+    const ctx = requireTenantContext();
     const { parsedData, imagePath, validation, jobId } = req.body;
 
     if (!parsedData || !imagePath) throw new AppError('必要なデータが不足しています。', 400);
-    if (!memberId || !familyGroupId) throw new AppError('認証情報または世帯情報が取得できません。', 401);
 
     const result = await commitReceiptService({
-      memberId,
-      familyGroupId,
+      ctx,
       parsedData: parsedData as ReceiptCommitPayload,
       imagePath,
       isSuspicious: validation?.isSuspicious || false,
@@ -135,11 +124,10 @@ export const commitReceipt = async (req: Request, res: Response, next: NextFunct
 
 export const createReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const memberId = getMemberId();
-    const familyGroupId = getFamilyGroupId();
+    const ctx = requireTenantContext();
     const { date, storeName, items, imagePath } = req.body;
 
-    const newReceipt = await createManualReceipt(Number(memberId), familyGroupId, {
+    const newReceipt = await createManualReceipt(ctx, {
       date,
       storeName,
       items: items as ReceiptCreateItemInput[],
@@ -154,9 +142,9 @@ export const createReceipt = async (req: Request, res: Response, next: NextFunct
 
 export const updateReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const { familyGroupId } = requireTenantContext();
     const id = getRouteParam(req, 'id');
     const { date, storeName, items } = req.body;
-    const familyGroupId = getFamilyGroupId();
 
     const result = await updateReceiptById(Number(id), familyGroupId, {
       date,
@@ -172,9 +160,9 @@ export const updateReceipt = async (req: Request, res: Response, next: NextFunct
 
 export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const { familyGroupId } = requireTenantContext();
     const id = getRouteParam(req, 'id');
     const { categoryId } = req.body;
-    const familyGroupId = getFamilyGroupId();
 
     const result = await updateItemCategoryById(Number(id), familyGroupId, categoryId);
     res.json({ success: true, data: result });
@@ -185,9 +173,10 @@ export const updateItemCategory = async (req: Request, res: Response, next: Next
 
 export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const { familyGroupId } = requireTenantContext();
     const { month, memberId } = req.query;
     const receipts = await listReceipts({
-      familyGroupId: getFamilyGroupId(),
+      familyGroupId,
       memberId: typeof memberId === 'string' ? memberId : undefined,
       month: typeof month === 'string' ? month : undefined,
     });
@@ -199,7 +188,8 @@ export const getReceipts = async (req: Request, res: Response, next: NextFunctio
 
 export const getLatestReceipt = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const receipt = await fetchLatestReceipt(getFamilyGroupId());
+    const { familyGroupId } = requireTenantContext();
+    const receipt = await fetchLatestReceipt(familyGroupId);
     res.json({ success: true, data: receipt });
   } catch (error) {
     next(error);
@@ -208,7 +198,8 @@ export const getLatestReceipt = async (_req: Request, res: Response, next: NextF
 
 export const deleteReceipt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    await deleteReceiptById(Number(getRouteParam(req, 'id')));
+    const { familyGroupId } = requireTenantContext();
+    await deleteReceiptById(Number(getRouteParam(req, 'id')), familyGroupId);
     res.json({ success: true, message: 'Deleted' });
   } catch (error) {
     next(error);
@@ -217,7 +208,7 @@ export const deleteReceipt = async (req: Request, res: Response, next: NextFunct
 
 export const getMonthlyStats = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
+    const { familyGroupId } = requireTenantContext();
     const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
     const data = await fetchMonthlyStats(familyGroupId, month);
     res.json({ success: true, data });
@@ -228,7 +219,8 @@ export const getMonthlyStats = async (req: Request, res: Response, next: NextFun
 
 export const getAdvancedStats = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const data = await fetchAdvancedStats(getFamilyGroupId());
+    const { familyGroupId } = requireTenantContext();
+    const data = await fetchAdvancedStats(familyGroupId);
     res.json({ success: true, data });
   } catch (error) {
     next(error);
@@ -237,9 +229,7 @@ export const getAdvancedStats = async (_req: Request, res: Response, next: NextF
 
 export const getFamilyMembers = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    if (!familyGroupId) throw new AppError('世帯情報が取得できません。', 400);
-
+    const { familyGroupId } = requireTenantContext();
     const members = await listFamilyMembers(familyGroupId);
     res.json({ success: true, data: members });
   } catch (error) {
@@ -249,9 +239,9 @@ export const getFamilyMembers = async (_req: Request, res: Response, next: NextF
 
 export const updateItemSplits = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const { familyGroupId } = requireTenantContext();
     const itemId = getRouteParam(req, 'itemId');
     const { splits } = req.body;
-    const familyGroupId = getFamilyGroupId();
 
     const result = await updateItemSplitsById(
       Number(itemId),

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -6,7 +6,7 @@ import { receiptQueue } from '../queues/receiptQueue';
 import logger from '../utils/logger';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { tenantMiddleware } from '../middleware/tenantMiddleware';
-import { getFamilyGroupId, getMemberId } from '../utils/context';
+import { requireTenantContext } from '../utils/context';
 import { validate } from '../middleware/validate';
 import { uploadReceiptSchema } from '../schemas/receiptSchema';
 import { AppError } from '../utils/appError';
@@ -51,12 +51,8 @@ router.post(
       const file = req.file as Express.Multer.File;
       if (!file) throw new AppError('画像がアップロードされていません。', 400);
 
-      const familyGroupId = getFamilyGroupId();
-      const memberId = getMemberId();
-
-      if (!familyGroupId || !memberId) {
-        throw new AppError('テナントコンテキストが設定されていません。', 401);
-      }
+      const ctx = requireTenantContext();
+      const { familyGroupId, memberId } = ctx;
 
       const timestamp = Date.now();
       const baseFileName = `receipt-${timestamp}-${Math.round(Math.random() * 1e9)}`;

--- a/backend/src/services/duplicateReceiptService.ts
+++ b/backend/src/services/duplicateReceiptService.ts
@@ -47,7 +47,7 @@ export async function checkDuplicateReceipt(
     }
   }
 
-  const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
+  const officialStoreName = await normalizeStoreName(parsedData.storeName || '', familyGroupId);
   const cleanStore = getCleanText(officialStoreName);
   const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
   const totalAmount = Math.round(Number(parsedData.totalAmount || 0));

--- a/backend/src/services/receipt/receiptAnalysisService.ts
+++ b/backend/src/services/receipt/receiptAnalysisService.ts
@@ -4,19 +4,15 @@ import { getCleanText } from '../../utils/normalizer';
 import { getReceiptAnalysisProvider } from '../../ai';
 import { estimateCategoryId } from '../categoryService';
 import { validateReceiptItems } from '../validationService';
+import type { TenantContext } from '../../utils/context';
 
 /**
  * [Issue #49-8 / #72 / #63] 解析のみを実行し、推論カテゴリを付与して返す
  * 戻り値に usageLogId を含める。DB 永続化は行わない（commit 時に実施）。
  */
-export async function analyzeOnly(memberId: number, imagePath: string) {
-  logger.info(`[Analyze] 解析開始: ${imagePath} (Member: ${memberId})`);
-
-  const member = await prisma.familyMember.findUnique({
-    where: { id: memberId },
-    select: { familyGroupId: true },
-  });
-  const familyGroupId = member?.familyGroupId;
+export async function analyzeOnly(ctx: TenantContext, imagePath: string) {
+  const { memberId, familyGroupId } = ctx;
+  logger.info(`[Analyze] 解析開始: ${imagePath} (Member: ${memberId}, 世帯: ${familyGroupId})`);
 
   const parsedData = await getReceiptAnalysisProvider().analyzeReceiptImage(imagePath, memberId);
   const cleanStore = getCleanText(parsedData.storeName || '');

--- a/backend/src/services/receipt/receiptCommitService.ts
+++ b/backend/src/services/receipt/receiptCommitService.ts
@@ -1,10 +1,10 @@
 import { saveConfirmedReceipt } from './receiptPersistenceService';
 import { removeReceiptJobAfterCommit } from '../receiptJobService';
 import type { ReceiptCommitPayload } from '../../types/receipt';
+import type { TenantContext } from '../../utils/context';
 
 export type CommitReceiptInput = {
-  memberId: number;
-  familyGroupId: number;
+  ctx: TenantContext;
   parsedData: ReceiptCommitPayload;
   imagePath: string;
   isSuspicious: boolean;
@@ -14,9 +14,10 @@ export type CommitReceiptInput = {
 
 /** 解析結果の確定保存（必要に応じてジョブ削除） */
 export async function commitReceipt(input: CommitReceiptInput) {
+  const { ctx } = input;
   const result = await saveConfirmedReceipt(
-    input.memberId,
-    input.familyGroupId,
+    ctx.memberId,
+    ctx.familyGroupId,
     input.parsedData,
     input.imagePath,
     input.isSuspicious,
@@ -24,7 +25,7 @@ export async function commitReceipt(input: CommitReceiptInput) {
   );
 
   if (input.jobId) {
-    await removeReceiptJobAfterCommit(String(input.jobId), input.familyGroupId, input.memberId).catch(
+    await removeReceiptJobAfterCommit(String(input.jobId), ctx.familyGroupId, ctx.memberId).catch(
       () => {
         // 既に破棄済み等は無視（保存は成功している）
       }

--- a/backend/src/services/receipt/receiptPersistenceService.ts
+++ b/backend/src/services/receipt/receiptPersistenceService.ts
@@ -20,7 +20,7 @@ export async function saveParsedReceipt(
   isSuspicious: boolean,
   warnings: string[]
 ) {
-  const officialStoreName = await normalizeStoreName(parsedData.storeName || '');
+  const officialStoreName = await normalizeStoreName(parsedData.storeName || '', familyGroupId);
   const cleanStore = getCleanText(officialStoreName);
   const jstDate = parseReceiptDate(parsedData.purchaseDate || parsedData.date);
 

--- a/backend/src/services/receipt/receiptQueryService.ts
+++ b/backend/src/services/receipt/receiptQueryService.ts
@@ -1,4 +1,5 @@
 import { prisma } from '../../utils/prismaClient';
+import { AppError } from '../../utils/appError';
 import { getLocalMonthDateRange, normalizeYearMonth } from '../../utils/yearMonth';
 
 export type ListReceiptsParams = {
@@ -42,7 +43,12 @@ export async function getLatestReceipt(familyGroupId: number) {
   });
 }
 
-export async function deleteReceiptById(receiptId: number) {
+export async function deleteReceiptById(receiptId: number, familyGroupId: number) {
+  const existing = await prisma.receipt.findUnique({ where: { id: receiptId } });
+  if (!existing || existing.familyGroupId !== familyGroupId) {
+    throw new AppError('ReceiptNotFound', 404);
+  }
+
   await prisma.receipt.delete({ where: { id: receiptId } });
 }
 

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -1,6 +1,7 @@
 import { AppError } from '../../utils/appError';
 import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import type { ReceiptCreateItemInput } from '../../types/receipt';
+import type { TenantContext } from '../../utils/context';
 import { saveParsedReceipt } from './receiptPersistenceService';
 import { upsertProductMasterCategory } from './receiptProductMasterLearning';
 
@@ -31,13 +32,9 @@ function buildCommitPayload(input: ManualReceiptInput) {
 }
 
 /** 手動登録（解析 usageLogId 紐付けなし） */
-export async function createManualReceipt(
-  memberId: number,
-  familyGroupId: number,
-  input: ManualReceiptInput
-) {
+export async function createManualReceipt(ctx: TenantContext, input: ManualReceiptInput) {
   const payload = buildCommitPayload(input);
-  return saveParsedReceipt(memberId, familyGroupId, payload, input.imagePath || '', false, []);
+  return saveParsedReceipt(ctx.memberId, ctx.familyGroupId, payload, input.imagePath || '', false, []);
 }
 
 export type UpdateReceiptInput = {

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -18,7 +18,10 @@ export const processAndSaveReceipt = async (memberId: number, imagePath: string)
   });
   if (!member) throw new Error('MEMBER_NOT_FOUND');
 
-  const { parsedData, validation } = await analyzeOnly(memberId, imagePath);
+  const { parsedData, validation } = await analyzeOnly(
+    { familyGroupId: member.familyGroupId, memberId },
+    imagePath
+  );
   return saveConfirmedReceipt(
     memberId,
     member.familyGroupId,

--- a/backend/src/utils/context.test.ts
+++ b/backend/src/utils/context.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { requireTenantContext, runWithTenant } from './context';
+
+describe('requireTenantContext', () => {
+  it('returns familyGroupId and memberId from ALS store', () => {
+    runWithTenant({ familyGroupId: 10, memberId: 20 }, () => {
+      expect(requireTenantContext()).toEqual({ familyGroupId: 10, memberId: 20 });
+    });
+  });
+});

--- a/backend/src/utils/context.ts
+++ b/backend/src/utils/context.ts
@@ -35,6 +35,14 @@ export const getMemberId = (): number => {
 export const hasContext = (): boolean => !!tenantStorage.getStore();
 
 /**
+ * Controller 等の HTTP 境界でテナント ctx を明示取得する
+ */
+export const requireTenantContext = (): TenantContext => ({
+  familyGroupId: getFamilyGroupId(),
+  memberId: getMemberId(),
+});
+
+/**
  * ALC内で関数を実行するためのラッパー
  */
 export const runWithTenant = <T>(context: TenantContext, fn: () => T): T => {

--- a/backend/src/utils/normalizer.ts
+++ b/backend/src/utils/normalizer.ts
@@ -1,5 +1,4 @@
 import { prisma } from './prismaClient';
-import { getFamilyGroupId } from './context';
 import logger from './logger';
 
 const sanitize = (text: string | null | undefined): string => {
@@ -15,15 +14,15 @@ const sanitize = (text: string | null | undefined): string => {
 /**
  * 店舗名の正規化（世帯スコープ — Issue #93-4）
  */
-export const normalizeStoreName = async (rawName: string): Promise<string> => {
+export const normalizeStoreName = async (
+  rawName: string,
+  familyGroupId: number
+): Promise<string> => {
   try {
     const cleanRawName = sanitize(rawName);
     if (!cleanRawName) return '';
 
-    const familyGroupId = getFamilyGroupId();
-    const stores = await prisma.store.findMany(
-      familyGroupId ? { where: { familyGroupId } } : undefined
-    );
+    const stores = await prisma.store.findMany({ where: { familyGroupId } });
 
     for (const store of stores) {
       const officialName = sanitize(store.officialName);

--- a/backend/src/workers/receiptWorker.ts
+++ b/backend/src/workers/receiptWorker.ts
@@ -23,7 +23,7 @@ const receiptWorker = new Worker(
          * analyzeOnly の内部で ReceiptAnalysisProvider（Gemini）が呼ばれます。
          * [Issue #71] により、戻り値の ParsedReceipt に taxAmount が含まれるようになっています。
          */
-        const result = await analyzeOnly(memberId, imagePath);
+        const result = await analyzeOnly({ familyGroupId, memberId }, imagePath);
         
         logger.info(`[Worker] 解析完了: ID ${job.id} (画像: ${imagePath}, taxAmount抽出: ${result.parsedData.taxAmount ?? 0})`);
 


### PR DESCRIPTION
## Summary

- `requireTenantContext()` を追加し、`receiptController` / upload ルートで ctx を明示取得
- `analyzeOnly` / `commitReceipt` / `createManualReceipt` を `TenantContext` 引数に変更
- `normalizeStoreName` から `getFamilyGroupId()` 依存を除去（`familyGroupId` 明示渡し）
- `deleteReceiptById` にテナント検証を追加（越境削除防止）
- Worker は `runWithTenant` 維持 + `analyzeOnly` へ明示 ctx 渡し

Epic: #378

Closes #397

## Test plan

- [x] `cd backend && npm test` — 43 passed
- [x] integration test 維持（29 skipped 含む）


Made with [Cursor](https://cursor.com)