### PR TITLE
refactor(backend): [Issue #98-8-6] TenantContext 明示渡し（残ドメイン）

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -1,230 +1,88 @@
-import { Request, Response } from 'express';
-import prisma from '../utils/prismaClient';
+import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
-import fs from 'node:fs';
-import path from 'node:path';
-import { getFamilyGroupId } from '../utils/context';
+import { AppError } from '../utils/appError';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import {
+  listPromptTemplates,
+  createPromptTemplate,
+  updatePromptTemplate,
+  activatePromptTemplate,
+  deletePromptTemplate,
+  getAdminCostStats,
+} from '../services/admin/adminService';
 
-// --- [Issue #73] AI Cost Constants ---
-const RATE_USD_TO_JPY = 150; 
-const PRICE_USD_PER_INPUT = 0.075 / 1000000;
-const PRICE_USD_PER_OUTPUT = 0.30 / 1000000;
-
-/**
- * プロンプトの変更をJSONファイルにダンプ（同期）するヘルパー関数
- */
-const syncPromptsToJson = async (familyGroupId: number) => {
+export const getPrompts = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const prompts = await prisma.promptTemplate.findMany({
-      where: { familyGroupId },
-      orderBy: { id: 'asc' },
-    });
-    const seedsDir = path.join(__dirname, '../../prisma/seeds');
-    const filePath = path.join(seedsDir, 'prompt_templates.json');
-    
-    if (!fs.existsSync(seedsDir)) {
-      fs.mkdirSync(seedsDir, { recursive: true });
-    }
-    
-    fs.writeFileSync(filePath, JSON.stringify(prompts, null, 2), 'utf-8');
-    logger.info(`[AdminAPI] Synced prompts to JSON: ${filePath}`);
-  } catch (error) {
-    logger.error(`[AdminAPI] syncPromptsToJson Error: ${error}`);
-  }
-};
-
-/**
- * プロンプトテンプレート一覧の取得
- */
-export const getPrompts = async (req: Request, res: Response) => {
-  try {
-    const prompts = await prisma.promptTemplate.findMany({
-      orderBy: [
-        { key: 'asc' },
-        { isActive: 'desc' },
-        { updatedAt: 'desc' },
-      ],
-    });
+    const prompts = await listPromptTemplates(requireTenantContext());
     res.json({ success: true, data: prompts });
   } catch (error) {
     logger.error(`[AdminAPI] getPrompts Error: ${error}`);
-    res.status(500).json({ success: false, error: 'プロンプトの取得に失敗しました' });
+    next(new AppError('プロンプトの取得に失敗しました', 500));
   }
 };
 
-/**
- * プロンプトテンプレートの新規作成
- */
-export const createPrompt = async (req: Request, res: Response) => {
-  const { key, name, description, systemPrompt, domainHints, isActive } = req.body;
-  
-  if (!key || !systemPrompt) {
-    return res.status(400).json({ success: false, error: '必須項目が不足しています' });
-  }
-
+export const createPrompt = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    if (isActive) {
-      await prisma.promptTemplate.updateMany({
-        where: { key, familyGroupId },
-        data: { isActive: false },
-      });
-    }
-
-    const newPrompt = await prisma.promptTemplate.create({
-      data: {
-        key,
-        name,
-        description,
-        systemPrompt,
-        domainHints,
-        isActive,
-        version: 1,
-        familyGroupId,
-      },
-    });
-
-    await syncPromptsToJson(familyGroupId);
+    const newPrompt = await createPromptTemplate(requireTenantContext(), req.body);
     res.json({ success: true, data: newPrompt });
   } catch (error) {
     logger.error(`[AdminAPI] createPrompt Error: ${error}`);
-    res.status(500).json({ success: false, error: 'プロンプトの作成に失敗しました' });
+    next(error instanceof AppError ? error : new AppError('プロンプトの作成に失敗しました', 500));
   }
 };
 
-/**
- * プロンプトテンプレートの更新
- */
-export const updatePrompt = async (req: Request, res: Response) => {
+export const updatePrompt = async (req: Request, res: Response, next: NextFunction) => {
   const id = getRouteParam(req, 'id');
-  const { name, description, systemPrompt, domainHints } = req.body;
-
-  // ★ 追加: IDが正しく数値として渡ってきているかのバリデーション
   if (!id || isNaN(Number(id))) {
-    return res.status(400).json({ success: false, error: '無効なIDが指定されました' });
+    return next(new AppError('無効なIDが指定されました', 400));
   }
 
   try {
-    const familyGroupId = getFamilyGroupId();
-    const updated = await prisma.promptTemplate.update({
-      where: { id: Number(id) },
-      data: { 
-        name, 
-        description, 
-        systemPrompt, 
-        domainHints,
-        version: { increment: 1 } 
-      }
-    });
-    
-    await syncPromptsToJson(familyGroupId);
+    const updated = await updatePromptTemplate(requireTenantContext(), Number(id), req.body);
     res.json({ success: true, data: updated });
   } catch (error) {
     logger.error(`[AdminAPI] updatePrompt Error: ${error}`);
-    res.status(500).json({ success: false, error: 'プロンプトの更新に失敗しました' });
+    next(error instanceof AppError ? error : new AppError('プロンプトの更新に失敗しました', 500));
   }
 };
 
-/**
- * プロンプトテンプレートのデフォルト（使用中）切り替え
- */
-export const activatePrompt = async (req: Request, res: Response) => {
+export const activatePrompt = async (req: Request, res: Response, next: NextFunction) => {
   const id = getRouteParam(req, 'id');
-  
-  // バリデーション
   if (!id || isNaN(Number(id))) {
-    return res.status(400).json({ success: false, error: '無効なIDが指定されました' });
+    return next(new AppError('無効なIDが指定されました', 400));
   }
 
   try {
-    const familyGroupId = getFamilyGroupId();
-    const target = await prisma.promptTemplate.findUnique({ where: { id: Number(id) } });
-    if (!target) {
-      return res.status(404).json({ success: false, error: '対象のプロンプトが見つかりません' });
-    }
-
-    await prisma.$transaction([
-      prisma.promptTemplate.updateMany({
-        where: { key: target.key, familyGroupId },
-        data: { isActive: false },
-      }),
-      prisma.promptTemplate.update({
-        where: { id: Number(id) },
-        data: { isActive: true },
-      }),
-    ]);
-
-    await syncPromptsToJson(familyGroupId);
+    await activatePromptTemplate(requireTenantContext(), Number(id));
     res.json({ success: true, message: 'デフォルトを切り替えました' });
   } catch (error) {
     logger.error(`[AdminAPI] activatePrompt Error: ${error}`);
-    res.status(500).json({ success: false, error: '切り替えに失敗しました' });
+    next(error instanceof AppError ? error : new AppError('切り替えに失敗しました', 500));
   }
 };
 
-/**
- * プロンプトテンプレートの削除
- */
-export const deletePrompt = async (req: Request, res: Response) => {
+export const deletePrompt = async (req: Request, res: Response, next: NextFunction) => {
   const id = getRouteParam(req, 'id');
-  
-  // バリデーション
   if (!id || isNaN(Number(id))) {
-    return res.status(400).json({ success: false, error: '無効なIDが指定されました' });
+    return next(new AppError('無効なIDが指定されました', 400));
   }
 
   try {
-    const familyGroupId = getFamilyGroupId();
-    const target = await prisma.promptTemplate.findUnique({ where: { id: Number(id) } });
-    if (target?.isActive) {
-      return res.status(400).json({ success: false, error: '使用中のプロンプトは削除できません' });
-    }
-
-    await prisma.promptTemplate.delete({ where: { id: Number(id) } });
-    await syncPromptsToJson(familyGroupId);
+    await deletePromptTemplate(requireTenantContext(), Number(id));
     res.json({ success: true, message: '削除しました' });
   } catch (error) {
     logger.error(`[AdminAPI] deletePrompt Error: ${error}`);
-    res.status(500).json({ success: false, error: '削除に失敗しました' });
+    next(error instanceof AppError ? error : new AppError('削除に失敗しました', 500));
   }
 };
 
-/**
- * [Issue #73] AIコスト統計の取得（月別・モデル別）
- */
-export const getCostStats = async (req: Request, res: Response) => {
+export const getCostStats = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    const stats: any[] = await prisma.$queryRaw`
-      SELECT
-        TO_CHAR(l."createdAt", 'YYYY-MM') AS month,
-        l."modelId",
-        SUM(l."promptTokens")::int AS "totalPromptTokens",
-        SUM(l."candidatesTokens")::int AS "totalCandidatesTokens"
-      FROM "ApiUsageLog" l
-      INNER JOIN "FamilyMember" fm ON l."familyMemberId" = fm.id
-      WHERE fm."familyGroupId" = ${familyGroupId}
-      GROUP BY month, l."modelId"
-      ORDER BY month DESC;
-    `;
-
-    const result = stats.map(row => {
-      const costUsd = (row.totalPromptTokens * PRICE_USD_PER_INPUT) + (row.totalCandidatesTokens * PRICE_USD_PER_OUTPUT);
-      const costJpy = costUsd * RATE_USD_TO_JPY;
-      
-      return {
-        month: row.month,
-        modelId: row.modelId,
-        totalPromptTokens: row.totalPromptTokens,
-        totalCandidatesTokens: row.totalCandidatesTokens,
-        estimatedCostJpy: Math.round(costJpy * 100) / 100
-      };
-    });
-
+    const result = await getAdminCostStats(requireTenantContext());
     res.json({ success: true, data: result });
   } catch (error) {
     logger.error(`[AdminAPI] getCostStats Error: ${error}`);
-    res.status(500).json({ success: false, error: '統計データの取得に失敗しました' });
+    next(new AppError('統計データの取得に失敗しました', 500));
   }
 };

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -1,168 +1,44 @@
 import { Request, Response, NextFunction } from 'express';
-import { prisma } from '../utils/prismaClient'; // テナント拡張済みのインスタンスを使用
-import { AppError } from '../utils/appError';
-import logger from '../utils/logger';
-import { pickNextCategoryColor } from '../utils/categoryColor';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
-import { getFamilyGroupId } from '../utils/context';
+import {
+  listCategories,
+  createCategory as createCategoryService,
+  deleteCategory as deleteCategoryService,
+  optimizeCategoryKeywords,
+} from '../services/category/categoryService';
 
-/**
- * 📂 カテゴリー一覧取得
- */
-export const getCategories = async (req: Request, res: Response, next: NextFunction) => {
+export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const categories = await prisma.category.findMany({ 
-      orderBy: { id: 'asc' } 
-    });
-    
-    res.json({
-      success: true,
-      data: categories
-    });
+    const categories = await listCategories(requireTenantContext());
+    res.json({ success: true, data: categories });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * 📂 カテゴリー新規追加
- */
 export const createCategory = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { name, color } = req.body;
-
-    if (!name) {
-      return next(new AppError('Name is required', 400));
-    }
-
-    const familyGroupId = getFamilyGroupId();
-    const existing = await prisma.category.findMany({
-      where: { familyGroupId },
-      select: { color: true },
-    });
-    const existingColors = existing.map((c) => c.color);
-    const requested =
-      typeof color === 'string' && color.trim() ? color.trim() : '';
-    const isDuplicate =
-      requested &&
-      existingColors.some(
-        (c) => (c ?? '').trim().toLowerCase() === requested.toLowerCase()
-      );
-    const resolvedColor =
-      requested && !isDuplicate
-        ? requested
-        : pickNextCategoryColor(existingColors);
-
-    const category = await prisma.category.create({
-      data: {
-        name,
-        color: resolvedColor,
-        familyGroupId,
-      },
-    });
-
-    logger.info(`[CATEGORY] Created: ${name}`);
-
-    res.status(201).json({
-      success: true,
-      data: category
-    });
+    const category = await createCategoryService(requireTenantContext(), req.body);
+    res.status(201).json({ success: true, data: category });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * 📂 カテゴリー削除
- */
 export const deleteCategory = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const id = getRouteParam(req, 'id');
-
-    const existing = await prisma.category.findFirst({
-      where: { id: Number(id) },
-    });
-    if (!existing) {
-      return next(new AppError('Category not found', 404));
-    }
-
-    await prisma.category.delete({
-      where: { id: existing.id },
-    });
-
-    logger.info(`[CATEGORY] Deleted: ID ${id}`);
-
-    res.json({
-      success: true
-    });
-  } catch (error: any) {
-    if (error.code === 'P2003') {
-      return next(new AppError('このカテゴリーは既に使用されているため削除できません。', 400));
-    }
+    await deleteCategoryService(requireTenantContext(), Number(getRouteParam(req, 'id')));
+    res.json({ success: true });
+  } catch (error) {
     next(error);
   }
 };
 
-/**
- * [Issue #48] 📂 カテゴリーキーワードの統計的最適化
- * ProductMasterから頻出する品名を抽出し、Categoryマスタのキーワードを補強します。
- */
-export const optimizeKeywords = async (req: Request, res: Response, next: NextFunction) => {
+export const optimizeKeywords = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    // 1. 全世帯のProductMasterから頻出品名を集計 (出現回数 5回以上)
-    // ※ 統計処理のため familyGroupId のフィルタリングを一時的にバイパス、あるいは全件対象とする
-    const stats = await prisma.productMaster.groupBy({
-      by: ['name', 'categoryId'],
-      _count: {
-        name: true,
-      },
-      having: {
-        name: {
-          _count: {
-            gte: 5,
-          },
-        },
-      },
-    });
-
-    const categories = await prisma.category.findMany();
-    let totalAdded = 0;
-
-    // 2. カテゴリーごとに既存キーワードと突合し、新規分を update
-    for (const category of categories) {
-      const currentKeywords = Array.isArray(category.keywords) 
-        ? (category.keywords as string[]) 
-        : [];
-
-      // このカテゴリーに紐付く頻出名候補
-      const candidates = stats
-        .filter(s => s.categoryId === category.id)
-        .map(s => s.name);
-
-      // 未登録かつ2文字以上のキーワードを抽出
-      const newEntries = candidates.filter(
-        name => name && name.length >= 2 && !currentKeywords.includes(name)
-      );
-
-      if (newEntries.length > 0) {
-        await prisma.category.update({
-          where: { id: category.id },
-          data: {
-            keywords: [...currentKeywords, ...newEntries]
-          }
-        });
-        totalAdded += newEntries.length;
-        logger.info(`[OPTIMIZE] Category:${category.name} added ${newEntries.length} keywords.`);
-      }
-    }
-
-    res.json({
-      success: true,
-      data: {
-        addedCount: totalAdded,
-        message: `${totalAdded} 件のキーワードを最適化しました。`
-      }
-    });
+    const data = await optimizeCategoryKeywords(requireTenantContext());
+    res.json({ success: true, data });
   } catch (error) {
     next(error);
   }

--- a/backend/src/controllers/productMasterController.ts
+++ b/backend/src/controllers/productMasterController.ts
@@ -1,128 +1,75 @@
 import { Request, Response, NextFunction } from 'express';
-import { prisma } from '../utils/prismaClient';
-import logger from '../utils/logger';
-import { AppError } from '../utils/appError';
-import { getFamilyGroupId } from '../utils/context';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import {
+  listProductMasters,
+  updateProductMaster,
+  mergeStoreNames,
+  deleteProductMaster,
+} from '../services/productMaster/productMasterService';
 
-/**
- * 📂 学習マスタ一覧取得
- */
 export const getProductMasters = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { q, store } = req.query;
-    const familyGroupId = getFamilyGroupId();
-    
-    const where: any = { familyGroupId };
-    if (q) where.name = { contains: String(q), mode: 'insensitive' };
-    if (store) where.storeName = { contains: String(store), mode: 'insensitive' };
-
-    const masters = await prisma.productMaster.findMany({
-      where,
-      include: { category: true },
-      // ★ 修正: updatedAt は存在しないため id で降順ソート
-      orderBy: { id: 'desc' },
-      take: 100 
+    const masters = await listProductMasters(requireTenantContext(), {
+      q: typeof req.query.q === 'string' ? req.query.q : undefined,
+      store: typeof req.query.store === 'string' ? req.query.store : undefined,
     });
-
-    res.json({
-      success: true,
-      data: masters
-    });
+    res.json({ success: true, data: masters });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * 📂 マスタの個別更新
- */
-export const updateProductMaster = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
-  const { name, storeName, categoryId } = req.body;
-
+export const updateProductMasterHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
-    const updated = await prisma.productMaster.update({
-      where: { id: Number(id) },
-      data: { 
-        name, 
-        storeName, 
-        categoryId: Number(categoryId) 
-      }
-    });
-
-    res.json({
-      success: true,
-      data: updated
-    });
+    const updated = await updateProductMaster(
+      requireTenantContext(),
+      Number(getRouteParam(req, 'id')),
+      req.body
+    );
+    res.json({ success: true, data: updated });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * 📂 店舗名の統合ロジック (世帯分離対応)
- */
-export const mergeStoreNames = async (req: Request, res: Response, next: NextFunction) => {
-  const { sourceStoreName, targetStoreName } = req.body;
-  const familyGroupId = getFamilyGroupId();
+export { updateProductMasterHandler as updateProductMaster };
 
-  if (!sourceStoreName || !targetStoreName) {
-    return next(new AppError('統合元と統合先の指定が必要です', 400));
-  }
-
+export const mergeStoreNamesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      // 1. [Issue #45] 当該世帯の ProductMaster のみ置換
-      const updateResult = await tx.productMaster.updateMany({
-        where: { 
-          storeName: sourceStoreName,
-          familyGroupId 
-        },
-        data: { storeName: targetStoreName }
-      });
-
-      // 2. [Issue #45] 当該世帯の Receipt データのみ書き換え
-      await tx.receipt.updateMany({
-        where: { 
-          storeName: sourceStoreName,
-          familyGroupId
-        },
-        data: { storeName: targetStoreName }
-      });
-
-      return updateResult;
-    });
-
-    logger.info(`[STORE_MERGE] Family:${familyGroupId} | ${sourceStoreName} -> ${targetStoreName}`);
-    
-    res.json({
-      success: true,
-      data: {
-        message: '統合が完了しました',
-        count: result.count
-      }
-    });
+    const { sourceStoreName, targetStoreName } = req.body;
+    const data = await mergeStoreNames(
+      requireTenantContext(),
+      sourceStoreName,
+      targetStoreName
+    );
+    res.json({ success: true, data });
   } catch (error) {
     next(error);
   }
 };
 
-/**
- * 📂 マスタ削除
- */
-export const deleteProductMaster = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
+export { mergeStoreNamesHandler as mergeStoreNames };
+
+export const deleteProductMasterHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
-    await prisma.productMaster.delete({ 
-      where: { id: Number(id) } 
-    });
-
-    res.json({
-      success: true,
-      message: '削除しました'
-    });
+    await deleteProductMaster(requireTenantContext(), Number(getRouteParam(req, 'id')));
+    res.json({ success: true, message: '削除しました' });
   } catch (error) {
     next(error);
   }
 };
+
+export { deleteProductMasterHandler as deleteProductMaster };

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { getFamilyGroupId } from '../utils/context';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
 import {
   createSettlementTransfer,
@@ -9,10 +9,8 @@ import {
 
 export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const data = await getSettlementStatusData(
-      getFamilyGroupId(),
-      req.query.month as string | undefined
-    );
+    const ctx = requireTenantContext();
+    const data = await getSettlementStatusData(ctx, req.query.month as string | undefined);
     res.status(200).json({ success: true, data });
   } catch (error) {
     next(error);
@@ -21,8 +19,9 @@ export const getSettlementStatus = async (req: Request, res: Response, next: Nex
 
 export const addSettlementTransfer = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const ctx = requireTenantContext();
     const { month, fromMemberId, toMemberId, amount } = req.body;
-    const newTransfer = await createSettlementTransfer(getFamilyGroupId(), {
+    const newTransfer = await createSettlementTransfer(ctx, {
       month,
       fromMemberId,
       toMemberId,
@@ -40,10 +39,8 @@ export const deleteSettlementTransfer = async (
   next: NextFunction
 ) => {
   try {
-    const data = await removeSettlementTransfer(
-      getFamilyGroupId(),
-      Number(getRouteParam(req, 'id'))
-    );
+    const ctx = requireTenantContext();
+    const data = await removeSettlementTransfer(ctx, Number(getRouteParam(req, 'id')));
     res.status(200).json({ success: true, data });
   } catch (error) {
     next(error);

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,14 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
-import fs from 'fs';
-import path from 'path';
-import { AppError } from '../utils/appError';
-import { getFamilyGroupId } from '../utils/context';
-import { canAccessReceiptImage, getImageFullPath } from '../services/imageAccessService';
+import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { resolveReceiptImagePath } from '../services/upload/receiptImageService';
 
 /**
  * [Issue #93-1 / G3] レシート画像の認証付き配信。
- * 自世帯の Receipt、または解析ジョブ投入済み imagePath のみ返す。
  */
 export const serveReceiptImage = async (
   req: Request<{ filename: string }>,
@@ -16,25 +12,10 @@ export const serveReceiptImage = async (
   next: NextFunction
 ) => {
   try {
-    const familyGroupId = getFamilyGroupId();
-    const rawFilename = getRouteParam(req, 'filename');
-    const filename = path.basename(rawFilename);
-
-    if (!filename || filename !== rawFilename || filename.includes('..')) {
-      throw new AppError('Invalid filename', 400);
-    }
-
-    const imagePath = path.join('uploads', filename).replace(/\\/g, '/');
-
-    if (!(await canAccessReceiptImage(familyGroupId, imagePath))) {
-      throw new AppError('Not Found', 404);
-    }
-
-    const fullPath = getImageFullPath(imagePath);
-    if (!fs.existsSync(fullPath)) {
-      throw new AppError('Not Found', 404);
-    }
-
+    const fullPath = await resolveReceiptImagePath(
+      requireTenantContext(),
+      getRouteParam(req, 'filename')
+    );
     res.sendFile(fullPath);
   } catch (error) {
     next(error);

--- a/backend/src/middleware/tenantMiddleware.ts
+++ b/backend/src/middleware/tenantMiddleware.ts
@@ -52,7 +52,7 @@ export const tenantMiddleware = async (req: Request, res: Response, next: NextFu
 
     // --- ここが ALC の生命線 ---
     // runWithTenant のコールバック内で next() を呼ぶことで、
-    // この後に続く controller や service 内で getFamilyGroupId() が使えるようになります。
+    // この後に続く controller が requireTenantContext() で ctx を取得できる。
     runWithTenant(
       { familyGroupId: member.familyGroupId, memberId: member.id },
       () => {

--- a/backend/src/services/admin/adminService.ts
+++ b/backend/src/services/admin/adminService.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import prisma from '../../utils/prismaClient';
+import logger from '../../utils/logger';
+import { AppError } from '../../utils/appError';
+import type { TenantContext } from '../../utils/context';
+
+const RATE_USD_TO_JPY = 150;
+const PRICE_USD_PER_INPUT = 0.075 / 1000000;
+const PRICE_USD_PER_OUTPUT = 0.3 / 1000000;
+
+const syncPromptsToJson = async (familyGroupId: number) => {
+  try {
+    const prompts = await prisma.promptTemplate.findMany({
+      where: { familyGroupId },
+      orderBy: { id: 'asc' },
+    });
+    const seedsDir = path.join(__dirname, '../../../prisma/seeds');
+    const filePath = path.join(seedsDir, 'prompt_templates.json');
+
+    if (!fs.existsSync(seedsDir)) {
+      fs.mkdirSync(seedsDir, { recursive: true });
+    }
+
+    fs.writeFileSync(filePath, JSON.stringify(prompts, null, 2), 'utf-8');
+    logger.info(`[AdminAPI] Synced prompts to JSON: ${filePath}`);
+  } catch (error) {
+    logger.error(`[AdminAPI] syncPromptsToJson Error: ${error}`);
+  }
+};
+
+export async function listPromptTemplates(ctx: TenantContext) {
+  return prisma.promptTemplate.findMany({
+    where: { familyGroupId: ctx.familyGroupId },
+    orderBy: [{ key: 'asc' }, { isActive: 'desc' }, { updatedAt: 'desc' }],
+  });
+}
+
+export async function createPromptTemplate(
+  ctx: TenantContext,
+  input: {
+    key: string;
+    name?: string;
+    description?: string;
+    systemPrompt: string;
+    domainHints?: unknown;
+    isActive?: boolean;
+  }
+) {
+  const { key, name, description, systemPrompt, domainHints, isActive } = input;
+  if (!key || !systemPrompt) {
+    throw new AppError('必須項目が不足しています', 400);
+  }
+
+  const { familyGroupId } = ctx;
+
+  if (isActive) {
+    await prisma.promptTemplate.updateMany({
+      where: { key, familyGroupId },
+      data: { isActive: false },
+    });
+  }
+
+  const newPrompt = await prisma.promptTemplate.create({
+    data: {
+      key,
+      name,
+      description,
+      systemPrompt,
+      domainHints,
+      isActive,
+      version: 1,
+      familyGroupId,
+    },
+  });
+
+  await syncPromptsToJson(familyGroupId);
+  return newPrompt;
+}
+
+export async function updatePromptTemplate(
+  ctx: TenantContext,
+  id: number,
+  input: {
+    name?: string;
+    description?: string;
+    systemPrompt?: string;
+    domainHints?: unknown;
+  }
+) {
+  const existing = await prisma.promptTemplate.findFirst({
+    where: { id, familyGroupId: ctx.familyGroupId },
+  });
+  if (!existing) {
+    throw new AppError('対象のプロンプトが見つかりません', 404);
+  }
+
+  const updated = await prisma.promptTemplate.update({
+    where: { id: existing.id },
+    data: {
+      name: input.name,
+      description: input.description,
+      systemPrompt: input.systemPrompt,
+      domainHints: input.domainHints,
+      version: { increment: 1 },
+    },
+  });
+
+  await syncPromptsToJson(ctx.familyGroupId);
+  return updated;
+}
+
+export async function activatePromptTemplate(ctx: TenantContext, id: number) {
+  const target = await prisma.promptTemplate.findFirst({
+    where: { id, familyGroupId: ctx.familyGroupId },
+  });
+  if (!target) {
+    throw new AppError('対象のプロンプトが見つかりません', 404);
+  }
+
+  await prisma.$transaction([
+    prisma.promptTemplate.updateMany({
+      where: { key: target.key, familyGroupId: ctx.familyGroupId },
+      data: { isActive: false },
+    }),
+    prisma.promptTemplate.update({
+      where: { id: target.id },
+      data: { isActive: true },
+    }),
+  ]);
+
+  await syncPromptsToJson(ctx.familyGroupId);
+}
+
+export async function deletePromptTemplate(ctx: TenantContext, id: number) {
+  const target = await prisma.promptTemplate.findFirst({
+    where: { id, familyGroupId: ctx.familyGroupId },
+  });
+  if (!target) {
+    throw new AppError('対象のプロンプトが見つかりません', 404);
+  }
+  if (target.isActive) {
+    throw new AppError('使用中のプロンプトは削除できません', 400);
+  }
+
+  await prisma.promptTemplate.delete({ where: { id: target.id } });
+  await syncPromptsToJson(ctx.familyGroupId);
+}
+
+type CostStatRow = {
+  month: string;
+  modelId: string;
+  totalPromptTokens: number;
+  totalCandidatesTokens: number;
+  estimatedCostJpy: number;
+};
+
+export async function getAdminCostStats(ctx: TenantContext): Promise<CostStatRow[]> {
+  const stats = await prisma.$queryRaw<
+    Array<{
+      month: string;
+      modelId: string;
+      totalPromptTokens: number;
+      totalCandidatesTokens: number;
+    }>
+  >`
+    SELECT
+      TO_CHAR(l."createdAt", 'YYYY-MM') AS month,
+      l."modelId",
+      SUM(l."promptTokens")::int AS "totalPromptTokens",
+      SUM(l."candidatesTokens")::int AS "totalCandidatesTokens"
+    FROM "ApiUsageLog" l
+    INNER JOIN "FamilyMember" fm ON l."familyMemberId" = fm.id
+    WHERE fm."familyGroupId" = ${ctx.familyGroupId}
+    GROUP BY month, l."modelId"
+    ORDER BY month DESC;
+  `;
+
+  return stats.map((row) => {
+    const costUsd =
+      row.totalPromptTokens * PRICE_USD_PER_INPUT +
+      row.totalCandidatesTokens * PRICE_USD_PER_OUTPUT;
+    const costJpy = costUsd * RATE_USD_TO_JPY;
+
+    return {
+      month: row.month,
+      modelId: row.modelId,
+      totalPromptTokens: row.totalPromptTokens,
+      totalCandidatesTokens: row.totalCandidatesTokens,
+      estimatedCostJpy: Math.round(costJpy * 100) / 100,
+    };
+  });
+}

--- a/backend/src/services/category/categoryService.ts
+++ b/backend/src/services/category/categoryService.ts
@@ -1,0 +1,114 @@
+import { prisma } from '../../utils/prismaClient';
+import { AppError } from '../../utils/appError';
+import logger from '../../utils/logger';
+import { pickNextCategoryColor } from '../../utils/categoryColor';
+import type { TenantContext } from '../../utils/context';
+
+export async function listCategories(ctx: TenantContext) {
+  return prisma.category.findMany({
+    where: { familyGroupId: ctx.familyGroupId },
+    orderBy: { id: 'asc' },
+  });
+}
+
+export async function createCategory(
+  ctx: TenantContext,
+  input: { name: string; color?: string | null }
+) {
+  const { name, color } = input;
+  if (!name) {
+    throw new AppError('Name is required', 400);
+  }
+
+  const existing = await prisma.category.findMany({
+    where: { familyGroupId: ctx.familyGroupId },
+    select: { color: true },
+  });
+  const existingColors = existing.map((c) => c.color);
+  const requested = typeof color === 'string' && color.trim() ? color.trim() : '';
+  const isDuplicate =
+    requested &&
+    existingColors.some(
+      (c) => (c ?? '').trim().toLowerCase() === requested.toLowerCase()
+    );
+  const resolvedColor =
+    requested && !isDuplicate ? requested : pickNextCategoryColor(existingColors);
+
+  const category = await prisma.category.create({
+    data: {
+      name,
+      color: resolvedColor,
+      familyGroupId: ctx.familyGroupId,
+    },
+  });
+
+  logger.info(`[CATEGORY] Created: ${name}`);
+  return category;
+}
+
+export async function deleteCategory(ctx: TenantContext, categoryId: number) {
+  const existing = await prisma.category.findFirst({
+    where: { id: categoryId, familyGroupId: ctx.familyGroupId },
+  });
+  if (!existing) {
+    throw new AppError('Category not found', 404);
+  }
+
+  try {
+    await prisma.category.delete({ where: { id: existing.id } });
+    logger.info(`[CATEGORY] Deleted: ID ${categoryId}`);
+  } catch (error: unknown) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2003'
+    ) {
+      throw new AppError('このカテゴリーは既に使用されているため削除できません。', 400);
+    }
+    throw error;
+  }
+}
+
+/** ProductMaster 統計から Category キーワードを補強（当該世帯の Category のみ更新） */
+export async function optimizeCategoryKeywords(ctx: TenantContext) {
+  const stats = await prisma.productMaster.groupBy({
+    by: ['name', 'categoryId'],
+    where: { familyGroupId: ctx.familyGroupId },
+    _count: { name: true },
+    having: { name: { _count: { gte: 5 } } },
+  });
+
+  const categories = await prisma.category.findMany({
+    where: { familyGroupId: ctx.familyGroupId },
+  });
+  let totalAdded = 0;
+
+  for (const category of categories) {
+    const currentKeywords = Array.isArray(category.keywords)
+      ? (category.keywords as string[])
+      : [];
+
+    const candidates = stats
+      .filter((s) => s.categoryId === category.id)
+      .map((s) => s.name);
+
+    const newEntries = candidates.filter(
+      (name) => name && name.length >= 2 && !currentKeywords.includes(name)
+    );
+
+    if (newEntries.length > 0) {
+      await prisma.category.update({
+        where: { id: category.id },
+        data: { keywords: [...currentKeywords, ...newEntries] },
+      });
+      totalAdded += newEntries.length;
+      logger.info(`[OPTIMIZE] Category:${category.name} added ${newEntries.length} keywords.`);
+    }
+  }
+
+  return {
+    addedCount: totalAdded,
+    message: `${totalAdded} 件のキーワードを最適化しました。`,
+  };
+}

--- a/backend/src/services/productMaster/productMasterService.ts
+++ b/backend/src/services/productMaster/productMasterService.ts
@@ -1,0 +1,90 @@
+import { prisma } from '../../utils/prismaClient';
+import logger from '../../utils/logger';
+import { AppError } from '../../utils/appError';
+import type { TenantContext } from '../../utils/context';
+
+export type ListProductMastersQuery = {
+  q?: string;
+  store?: string;
+};
+
+export async function listProductMasters(ctx: TenantContext, query: ListProductMastersQuery) {
+  const { q, store } = query;
+  const where: {
+    familyGroupId: number;
+    name?: { contains: string; mode: 'insensitive' };
+    storeName?: { contains: string; mode: 'insensitive' };
+  } = { familyGroupId: ctx.familyGroupId };
+
+  if (q) where.name = { contains: String(q), mode: 'insensitive' };
+  if (store) where.storeName = { contains: String(store), mode: 'insensitive' };
+
+  return prisma.productMaster.findMany({
+    where,
+    include: { category: true },
+    orderBy: { id: 'desc' },
+    take: 100,
+  });
+}
+
+export async function updateProductMaster(
+  ctx: TenantContext,
+  id: number,
+  input: { name: string; storeName: string; categoryId: number }
+) {
+  const existing = await prisma.productMaster.findFirst({
+    where: { id, familyGroupId: ctx.familyGroupId },
+  });
+  if (!existing) {
+    throw new AppError('ProductMaster not found', 404);
+  }
+
+  return prisma.productMaster.update({
+    where: { id: existing.id },
+    data: {
+      name: input.name,
+      storeName: input.storeName,
+      categoryId: Number(input.categoryId),
+    },
+  });
+}
+
+export async function mergeStoreNames(
+  ctx: TenantContext,
+  sourceStoreName: string,
+  targetStoreName: string
+) {
+  if (!sourceStoreName || !targetStoreName) {
+    throw new AppError('統合元と統合先の指定が必要です', 400);
+  }
+
+  const { familyGroupId } = ctx;
+
+  const result = await prisma.$transaction(async (tx) => {
+    const updateResult = await tx.productMaster.updateMany({
+      where: { storeName: sourceStoreName, familyGroupId },
+      data: { storeName: targetStoreName },
+    });
+
+    await tx.receipt.updateMany({
+      where: { storeName: sourceStoreName, familyGroupId },
+      data: { storeName: targetStoreName },
+    });
+
+    return updateResult;
+  });
+
+  logger.info(`[STORE_MERGE] Family:${familyGroupId} | ${sourceStoreName} -> ${targetStoreName}`);
+  return { message: '統合が完了しました', count: result.count };
+}
+
+export async function deleteProductMaster(ctx: TenantContext, id: number) {
+  const existing = await prisma.productMaster.findFirst({
+    where: { id, familyGroupId: ctx.familyGroupId },
+  });
+  if (!existing) {
+    throw new AppError('ProductMaster not found', 404);
+  }
+
+  await prisma.productMaster.delete({ where: { id: existing.id } });
+}

--- a/backend/src/services/settlement/settlementService.ts
+++ b/backend/src/services/settlement/settlementService.ts
@@ -9,6 +9,7 @@ import {
   computeSettlementMemberSummaries,
   type SettlementReceiptInput,
 } from './settlementAggregation';
+import type { TenantContext } from '../../utils/context';
 
 export type SettlementItemRow = {
   receiptId: number;
@@ -94,9 +95,10 @@ export type SettlementStatusData = {
 
 /** 月間精算ステータス（暗黙デフォルト ＋ 送金実績反映） */
 export async function getSettlementStatusData(
-  familyGroupId: number,
+  ctx: TenantContext,
   month?: string
 ): Promise<SettlementStatusData> {
+  const { familyGroupId } = ctx;
   const targetMonth = normalizeYearMonth(month) ?? getCurrentYearMonthLocal();
   const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
 
@@ -147,9 +149,10 @@ export type CreateSettlementTransferInput = {
 
 /** 送金記録の登録 */
 export async function createSettlementTransfer(
-  familyGroupId: number,
+  ctx: TenantContext,
   input: CreateSettlementTransferInput
 ) {
+  const { familyGroupId } = ctx;
   const normalizedMonth = normalizeYearMonth(input.month);
   const fromId = Number(input.fromMemberId);
   const toId = Number(input.toMemberId);
@@ -186,7 +189,8 @@ export async function createSettlementTransfer(
 }
 
 /** 送金記録の取消（物理削除） */
-export async function deleteSettlementTransfer(familyGroupId: number, transferId: number) {
+export async function deleteSettlementTransfer(ctx: TenantContext, transferId: number) {
+  const { familyGroupId } = ctx;
   if (!Number.isFinite(transferId) || transferId <= 0) {
     throw new AppError('送金記録IDが不正です。', 400);
   }

--- a/backend/src/services/upload/receiptImageService.ts
+++ b/backend/src/services/upload/receiptImageService.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { AppError } from '../../utils/appError';
+import type { TenantContext } from '../../utils/context';
+import { canAccessReceiptImage, getImageFullPath } from '../imageAccessService';
+
+export async function resolveReceiptImagePath(
+  ctx: TenantContext,
+  rawFilename: string
+): Promise<string> {
+  const filename = path.basename(rawFilename);
+
+  if (!filename || filename !== rawFilename || filename.includes('..')) {
+    throw new AppError('Invalid filename', 400);
+  }
+
+  const imagePath = path.join('uploads', filename).replace(/\\/g, '/');
+
+  if (!(await canAccessReceiptImage(ctx.familyGroupId, imagePath))) {
+    throw new AppError('Not Found', 404);
+  }
+
+  const fullPath = getImageFullPath(imagePath);
+  if (!fs.existsSync(fullPath)) {
+    throw new AppError('Not Found', 404);
+  }
+
+  return fullPath;
+}


### PR DESCRIPTION
## Summary

- category / productMaster / admin / upload / settlement の Controller から `getFamilyGroupId()` を除去し、`requireTenantContext()` + Service 層へ委譲
- 新規 Service: `categoryService`, `productMasterService`, `adminService`, `receiptImageService`
- `settlementService` の公開 API を `TenantContext` 受け取りに統一
- category / productMaster / admin の update・delete に familyGroupId テナント検証を追加
- `optimizeCategoryKeywords` を当該世帯のデータのみ対象に限定

Closes #398

## Test plan

- [x] `cd backend && npm test` — 43 passed / 29 skipped
- [ ] カテゴリー CRUD / 最適化が正常動作すること
- [ ] 商品マスタ一覧・更新・店舗統合・削除が正常動作すること
- [ ] 管理画面（プロンプト CRUD / コスト統計）が正常動作すること
- [ ] レシート画像の認証付き配信が正常動作すること
- [ ] 精算 API（ステータス取得 / 送金登録 / 取消）が正常動作すること


Made with [Cursor](https://cursor.com)