### PR TITLE
refactor(receipt): [Issue #98-8-7] Repository 導入（receipt ドメイン）

### DIFF
--- a/backend/src/repositories/receiptRepository.ts
+++ b/backend/src/repositories/receiptRepository.ts
@@ -1,0 +1,336 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../utils/prismaClient';
+import type { PrismaTx } from '../utils/prismaTransaction';
+import { AppError } from '../utils/appError';
+import { getLocalMonthDateRange, normalizeYearMonth } from '../utils/yearMonth';
+
+export const receiptWithItemsCategorySplits = {
+  items: { include: { category: true, splits: true } },
+} satisfies Prisma.ReceiptInclude;
+
+export const receiptWithItemsCategory = {
+  items: { include: { category: true } },
+} satisfies Prisma.ReceiptInclude;
+
+export type ListReceiptsParams = {
+  familyGroupId: number;
+  memberId?: string;
+  month?: string;
+};
+
+function buildListWhere(params: ListReceiptsParams): Prisma.ReceiptWhereInput {
+  const { familyGroupId, memberId, month } = params;
+  const where: Prisma.ReceiptWhereInput = { familyGroupId };
+
+  if (memberId !== undefined && memberId !== null && String(memberId).trim() !== '') {
+    const filterMemberId = Number(memberId);
+    if (!Number.isNaN(filterMemberId)) {
+      where.memberId = filterMemberId;
+    }
+  }
+
+  const normalizedMonth = normalizeYearMonth(typeof month === 'string' ? month : undefined);
+  if (normalizedMonth) {
+    const { start, end } = getLocalMonthDateRange(normalizedMonth);
+    where.date = { gte: start, lt: end };
+  }
+
+  return where;
+}
+
+export async function findReceipts(params: ListReceiptsParams) {
+  return prisma.receipt.findMany({
+    where: buildListWhere(params),
+    include: receiptWithItemsCategorySplits,
+    orderBy: { date: 'desc' },
+  });
+}
+
+export async function findLatestReceipt(familyGroupId: number) {
+  return prisma.receipt.findFirst({
+    where: { familyGroupId },
+    orderBy: { createdAt: 'desc' },
+    include: receiptWithItemsCategorySplits,
+  });
+}
+
+export async function findReceiptById(
+  id: number,
+  include: Prisma.ReceiptInclude = receiptWithItemsCategory
+) {
+  return prisma.receipt.findUnique({ where: { id }, include });
+}
+
+export async function findReceiptByImagePath(
+  familyGroupId: number,
+  imagePath: string,
+  include: Prisma.ReceiptInclude = receiptWithItemsCategory
+) {
+  return prisma.receipt.findFirst({
+    where: { familyGroupId, imagePath },
+    include,
+  });
+}
+
+export async function findReceiptIdByImagePath(familyGroupId: number, imagePath: string) {
+  return prisma.receipt.findFirst({
+    where: { familyGroupId, imagePath },
+    select: { id: true },
+  });
+}
+
+export async function findReceiptForDuplicate(
+  where: Prisma.ReceiptWhereInput,
+  select: Prisma.ReceiptSelect = { id: true }
+) {
+  return prisma.receipt.findFirst({ where, select });
+}
+
+export async function deleteReceiptById(receiptId: number, familyGroupId: number) {
+  const existing = await prisma.receipt.findUnique({ where: { id: receiptId } });
+  if (!existing || existing.familyGroupId !== familyGroupId) {
+    throw new AppError('ReceiptNotFound', 404);
+  }
+  await prisma.receipt.delete({ where: { id: receiptId } });
+}
+
+export async function listFamilyMembers(familyGroupId: number) {
+  return prisma.familyMember.findMany({
+    where: { familyGroupId },
+    select: { id: true, name: true },
+    orderBy: { id: 'asc' },
+  });
+}
+
+export async function findMemberById(memberId: number) {
+  return prisma.familyMember.findUnique({
+    where: { id: memberId },
+    select: { familyGroupId: true },
+  });
+}
+
+export type ReceiptCreateWithItemsInput = {
+  memberId: number;
+  familyGroupId: number;
+  storeName: string;
+  date: Date;
+  totalAmount: number;
+  taxAmount: number;
+  imagePath: string;
+  rawText: string;
+  items: Array<{
+    name: string;
+    price: number;
+    quantity: number;
+    categoryId: number | null;
+  }>;
+};
+
+/** commit トランザクション内で Receipt を作成（#98-4 tx 渡し） */
+export async function createReceiptInTx(tx: PrismaTx, input: ReceiptCreateWithItemsInput) {
+  return tx.receipt.create({
+    data: {
+      memberId: input.memberId,
+      familyGroupId: input.familyGroupId,
+      storeName: input.storeName,
+      date: input.date,
+      totalAmount: input.totalAmount,
+      taxAmount: input.taxAmount,
+      imagePath: input.imagePath,
+      items: { create: input.items },
+      rawText: input.rawText,
+    },
+    select: { id: true },
+  });
+}
+
+export async function linkApiUsageLogToReceiptInTx(
+  tx: PrismaTx,
+  usageLogId: number,
+  receiptId: number
+) {
+  return tx.apiUsageLog.update({
+    where: { id: usageLogId },
+    data: { receiptId },
+  });
+}
+
+export async function findReceiptByIdInTx(
+  tx: PrismaTx,
+  id: number,
+  include: Prisma.ReceiptInclude = receiptWithItemsCategory
+) {
+  return tx.receipt.findUnique({ where: { id }, include });
+}
+
+export async function findReceiptByIdForTenantInTx(
+  tx: PrismaTx,
+  receiptId: number,
+  familyGroupId: number
+) {
+  const existing = await tx.receipt.findUnique({ where: { id: receiptId } });
+  if (!existing || existing.familyGroupId !== familyGroupId) {
+    throw new AppError('ReceiptNotFound', 404);
+  }
+  return existing;
+}
+
+export async function updateReceiptInTx(
+  tx: PrismaTx,
+  receiptId: number,
+  data: { date?: Date; storeName?: string; totalAmount?: number }
+) {
+  return tx.receipt.update({
+    where: { id: receiptId },
+    data: {
+      date: data.date,
+      storeName: data.storeName,
+      totalAmount: data.totalAmount,
+    },
+  });
+}
+
+export type ItemCreateInput = {
+  receiptId: number;
+  name: string;
+  price: number;
+  quantity: number;
+  categoryId: number | null;
+};
+
+export async function deleteItemsByReceiptIdInTx(tx: PrismaTx, receiptId: number) {
+  return tx.item.deleteMany({ where: { receiptId } });
+}
+
+export async function createItemsInTx(tx: PrismaTx, items: ItemCreateInput[]) {
+  if (items.length === 0) return;
+  return tx.item.createMany({ data: items });
+}
+
+export async function findItemWithReceiptInTx(tx: PrismaTx, itemId: number) {
+  return tx.item.findUnique({
+    where: { id: itemId },
+    include: { receipt: true },
+  });
+}
+
+export async function findCategoryByIdInTx(
+  tx: PrismaTx,
+  categoryId: number,
+  familyGroupId: number
+) {
+  return tx.category.findFirst({
+    where: { id: categoryId, familyGroupId },
+  });
+}
+
+export async function updateItemCategoryInTx(
+  tx: PrismaTx,
+  itemId: number,
+  categoryId: number | null
+) {
+  return tx.item.update({
+    where: { id: itemId },
+    data: { categoryId },
+    include: { category: true },
+  });
+}
+
+export async function deleteItemSplitsInTx(tx: PrismaTx, itemId: number) {
+  return tx.itemSplit.deleteMany({ where: { itemId } });
+}
+
+export async function createItemSplitsInTx(
+  tx: PrismaTx,
+  splits: Array<{ itemId: number; familyMemberId: number; amount: number }>
+) {
+  if (splits.length === 0) return;
+  return tx.itemSplit.createMany({ data: splits });
+}
+
+export async function findItemSplitsInTx(tx: PrismaTx, itemId: number) {
+  return tx.itemSplit.findMany({ where: { itemId } });
+}
+
+export async function findFamilyMembersByIdsInTx(
+  tx: PrismaTx,
+  memberIds: number[],
+  familyGroupId: number
+) {
+  return tx.familyMember.findMany({
+    where: { id: { in: memberIds }, familyGroupId },
+    select: { id: true },
+  });
+}
+
+/** 月別合計（raw SQL） */
+export async function queryMonthlyReceiptTotal(familyGroupId: number, month: string) {
+  const totalRes = await prisma.$queryRaw<{ total: number | null }[]>`
+    SELECT SUM("totalAmount")::double precision as total
+    FROM "Receipt"
+    WHERE "familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(date, 'YYYY-MM') = ${month}
+  `;
+  return totalRes[0]?.total || 0;
+}
+
+export async function queryMonthlyCategoryStats(familyGroupId: number, month: string) {
+  return prisma.$queryRaw<
+    { categoryId: number | null; categoryName: string | null; color: string | null; totalAmount: number }[]
+  >`
+    SELECT 
+      c.id as "categoryId",
+      c.name as "categoryName",
+      c.color as "color",
+      SUM(i.price * i.quantity)::double precision as "totalAmount"
+    FROM "Item" i
+    JOIN "Receipt" r ON i."receiptId" = r.id
+    LEFT JOIN "Category" c ON i."categoryId" = c.id
+    WHERE r."familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
+    GROUP BY c.id, c.name, c.color
+    ORDER BY "totalAmount" DESC
+  `;
+}
+
+export async function findLatestReceiptInMonth(familyGroupId: number, month: string) {
+  return prisma.receipt.findFirst({
+    where: {
+      familyGroupId,
+      date: {
+        gte: new Date(`${month}-01`),
+        lt: new Date(new Date(`${month}-01`).setMonth(new Date(`${month}-01`).getMonth() + 1)),
+      },
+    },
+    orderBy: { date: 'desc' },
+    include: receiptWithItemsCategory,
+  });
+}
+
+export async function queryReceiptTrend(familyGroupId: number, limit = 6) {
+  return prisma.$queryRaw<{ period: string; total: number }[]>`
+    SELECT 
+      TO_CHAR(date, 'YYYY-MM') as period, 
+      SUM("totalAmount")::double precision as total 
+    FROM "Receipt" 
+    WHERE "familyGroupId" = ${familyGroupId} 
+    GROUP BY period 
+    ORDER BY period DESC 
+    LIMIT ${limit}
+  `;
+}
+
+export async function queryParetoByCategory(familyGroupId: number, month: string) {
+  return prisma.$queryRaw<{ name: string; amount: number }[]>`
+    SELECT 
+      COALESCE(c.name, '未分類') as name,
+      SUM(i.price * i.quantity)::double precision as amount
+    FROM "Item" i
+    JOIN "Receipt" r ON i."receiptId" = r.id
+    LEFT JOIN "Category" c ON i."categoryId" = c.id
+    WHERE r."familyGroupId" = ${familyGroupId}
+    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
+    GROUP BY c.name
+    ORDER BY amount DESC
+  `;
+}

--- a/backend/src/services/duplicateReceiptService.ts
+++ b/backend/src/services/duplicateReceiptService.ts
@@ -1,6 +1,6 @@
-import { prisma } from '../utils/prismaClient';
 import { getCleanText, normalizeStoreName } from '../utils/normalizer';
 import type { ReceiptDuplicateCheckInput } from '../types/receipt';
+import { findReceiptForDuplicate } from '../repositories/receiptRepository';
 
 export type DuplicateCheckResult = {
   duplicateSuspected: boolean;
@@ -38,10 +38,10 @@ export async function checkDuplicateReceipt(
   const normalizedImage = imagePath?.replace(/\\/g, '/');
 
   if (normalizedImage) {
-    const existingByImage = await prisma.receipt.findFirst({
-      where: { familyGroupId, imagePath: normalizedImage },
-      select: { id: true },
-    });
+    const existingByImage = await findReceiptForDuplicate(
+      { familyGroupId, imagePath: normalizedImage },
+      { id: true }
+    );
     if (existingByImage) {
       return { duplicateSuspected: false, existingReceiptId: existingByImage.id };
     }
@@ -76,10 +76,7 @@ export async function checkDuplicateReceipt(
     };
   }
 
-  const existing = await prisma.receipt.findFirst({
-    where: duplicateWhere,
-    select: { id: true, storeName: true },
-  });
+  const existing = await findReceiptForDuplicate(duplicateWhere, { id: true, storeName: true });
 
   if (existing && getCleanText(existing.storeName) === cleanStore) {
     return { duplicateSuspected: true, existingReceiptId: existing.id };

--- a/backend/src/services/receipt/receiptCommitPersistence.ts
+++ b/backend/src/services/receipt/receiptCommitPersistence.ts
@@ -2,6 +2,10 @@ import logger from '../../utils/logger';
 import { getCleanText } from '../../utils/normalizer';
 import type { PrismaTx } from '../../utils/prismaTransaction';
 import type { ParsedItem, ReceiptCommitPayload } from '../../types/receipt';
+import {
+  createReceiptInTx,
+  linkApiUsageLogToReceiptInTx,
+} from '../../repositories/receiptRepository';
 import { upsertProductMasterCategory } from './receiptProductMasterLearning';
 
 /** commit トランザクション内で永続化するための準備済み入力 */
@@ -66,26 +70,20 @@ export async function persistReceiptCommitInTx(
     })
   );
 
-  const created = await tx.receipt.create({
-    data: {
-      memberId,
-      familyGroupId,
-      storeName: officialStoreName,
-      date: jstDate,
-      totalAmount,
-      taxAmount,
-      imagePath,
-      items: { create: itemsToCreate },
-      rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
-    },
-    select: { id: true },
+  const created = await createReceiptInTx(tx, {
+    memberId,
+    familyGroupId,
+    storeName: officialStoreName,
+    date: jstDate,
+    totalAmount,
+    taxAmount,
+    imagePath,
+    rawText: JSON.stringify({ ...parsedData, validation: { isSuspicious, warnings } }),
+    items: itemsToCreate,
   });
 
   if (usageLogId && !isNaN(usageLogId)) {
-    await tx.apiUsageLog.update({
-      where: { id: usageLogId },
-      data: { receiptId: created.id },
-    });
+    await linkApiUsageLogToReceiptInTx(tx, usageLogId, created.id);
     logger.info(`[Link_Log] ApiUsageLog(ID: ${usageLogId}) を Receipt(ID: ${created.id}) に紐付けました。`);
   }
 

--- a/backend/src/services/receipt/receiptPersistenceService.ts
+++ b/backend/src/services/receipt/receiptPersistenceService.ts
@@ -1,9 +1,12 @@
-import { prisma } from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { normalizeStoreName, getCleanText } from '../../utils/normalizer';
 import { runReceiptCommitTransaction } from '../../utils/prismaTransaction';
 import { checkDuplicateReceipt, parseReceiptDate } from '../duplicateReceiptService';
 import type { ReceiptCommitPayload } from '../../types/receipt';
+import {
+  findReceiptById,
+  findReceiptByImagePath,
+} from '../../repositories/receiptRepository';
 import { DuplicateReceiptError } from './receiptDuplicateError';
 import { persistReceiptCommitInTx } from './receiptCommitPersistence';
 
@@ -31,10 +34,7 @@ export async function saveParsedReceipt(
   const usageLogId = usageLogIdStr ? parseInt(usageLogIdStr, 10) : null;
 
   if (imagePath) {
-    const existingByImage = await prisma.receipt.findFirst({
-      where: { familyGroupId, imagePath },
-      include: { items: { include: { category: true } } },
-    });
+    const existingByImage = await findReceiptByImagePath(familyGroupId, imagePath);
     if (existingByImage) {
       logger.info(`[Idempotent] imagePath 一致のため既存レシートを返却: ID ${existingByImage.id}`);
       return {
@@ -67,10 +67,7 @@ export async function saveParsedReceipt(
     })
   );
 
-  const final = await prisma.receipt.findUnique({
-    where: { id: savedId },
-    include: { items: { include: { category: true } } },
-  });
+  const final = await findReceiptById(savedId);
 
   return { ...JSON.parse(JSON.stringify(final)), isSuspicious, warnings };
 }

--- a/backend/src/services/receipt/receiptQueryService.ts
+++ b/backend/src/services/receipt/receiptQueryService.ts
@@ -1,61 +1,25 @@
-import { prisma } from '../../utils/prismaClient';
-import { AppError } from '../../utils/appError';
-import { getLocalMonthDateRange, normalizeYearMonth } from '../../utils/yearMonth';
+import {
+  deleteReceiptById as deleteReceiptInRepository,
+  findLatestReceipt,
+  findReceipts,
+  listFamilyMembers as listFamilyMembersInRepository,
+  type ListReceiptsParams,
+} from '../../repositories/receiptRepository';
 
-export type ListReceiptsParams = {
-  familyGroupId: number;
-  memberId?: string;
-  month?: string;
-};
+export type { ListReceiptsParams };
 
 export async function listReceipts(params: ListReceiptsParams) {
-  const { familyGroupId, memberId, month } = params;
-
-  const where: { familyGroupId: number; memberId?: number; date?: { gte: Date; lt: Date } } = {
-    familyGroupId,
-  };
-
-  if (memberId !== undefined && memberId !== null && String(memberId).trim() !== '') {
-    const filterMemberId = Number(memberId);
-    if (!Number.isNaN(filterMemberId)) {
-      where.memberId = filterMemberId;
-    }
-  }
-
-  const normalizedMonth = normalizeYearMonth(typeof month === 'string' ? month : undefined);
-  if (normalizedMonth) {
-    const { start, end } = getLocalMonthDateRange(normalizedMonth);
-    where.date = { gte: start, lt: end };
-  }
-
-  return prisma.receipt.findMany({
-    where,
-    include: { items: { include: { category: true, splits: true } } },
-    orderBy: { date: 'desc' },
-  });
+  return findReceipts(params);
 }
 
 export async function getLatestReceipt(familyGroupId: number) {
-  return prisma.receipt.findFirst({
-    where: { familyGroupId },
-    orderBy: { createdAt: 'desc' },
-    include: { items: { include: { category: true, splits: true } } },
-  });
+  return findLatestReceipt(familyGroupId);
 }
 
 export async function deleteReceiptById(receiptId: number, familyGroupId: number) {
-  const existing = await prisma.receipt.findUnique({ where: { id: receiptId } });
-  if (!existing || existing.familyGroupId !== familyGroupId) {
-    throw new AppError('ReceiptNotFound', 404);
-  }
-
-  await prisma.receipt.delete({ where: { id: receiptId } });
+  return deleteReceiptInRepository(receiptId, familyGroupId);
 }
 
 export async function listFamilyMembers(familyGroupId: number) {
-  return prisma.familyMember.findMany({
-    where: { familyGroupId },
-    select: { id: true, name: true },
-    orderBy: { id: 'asc' },
-  });
+  return listFamilyMembersInRepository(familyGroupId);
 }

--- a/backend/src/services/receipt/receiptSplitService.ts
+++ b/backend/src/services/receipt/receiptSplitService.ts
@@ -2,6 +2,13 @@ import { AppError } from '../../utils/appError';
 import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import { allocateItemSplits, SplitInput } from '../../utils/itemSplitAllocation';
 import { calcItemLineTotal } from '../../utils/itemLineTotal';
+import {
+  createItemSplitsInTx,
+  deleteItemSplitsInTx,
+  findFamilyMembersByIdsInTx,
+  findItemSplitsInTx,
+  findItemWithReceiptInTx,
+} from '../../repositories/receiptRepository';
 
 async function updateItemSplitsInTx(
   tx: PrismaTx,
@@ -9,17 +16,14 @@ async function updateItemSplitsInTx(
   familyGroupId: number,
   splits: SplitInput[] | undefined | null
 ) {
-  const item = await tx.item.findUnique({
-    where: { id: itemId },
-    include: { receipt: true },
-  });
+  const item = await findItemWithReceiptInTx(tx, itemId);
 
   if (!item || item.receipt.familyGroupId !== familyGroupId) {
     throw new AppError('ItemNotFound', 404);
   }
 
   if (!splits || !Array.isArray(splits) || splits.length === 0) {
-    await tx.itemSplit.deleteMany({ where: { itemId } });
+    await deleteItemSplitsInTx(tx, itemId);
     return { message: 'Splits cleared (Fallback to default payer)' };
   }
 
@@ -31,26 +35,24 @@ async function updateItemSplitsInTx(
   }));
 
   const memberIds = [...new Set(splitInputs.map((s) => s.familyMemberId))];
-  const validMembers = await tx.familyMember.findMany({
-    where: { id: { in: memberIds }, familyGroupId },
-    select: { id: true },
-  });
+  const validMembers = await findFamilyMembersByIdsInTx(tx, memberIds, familyGroupId);
   if (validMembers.length !== memberIds.length) {
     throw new AppError('Invalid familyMemberId in splits', 403);
   }
 
   const finalSplits = allocateItemSplits(totalAmount, splitInputs);
 
-  await tx.itemSplit.deleteMany({ where: { itemId } });
-  await tx.itemSplit.createMany({
-    data: finalSplits.map((fs) => ({
+  await deleteItemSplitsInTx(tx, itemId);
+  await createItemSplitsInTx(
+    tx,
+    finalSplits.map((fs) => ({
       itemId,
       familyMemberId: fs.familyMemberId,
       amount: fs.amount,
-    })),
-  });
+    }))
+  );
 
-  return tx.itemSplit.findMany({ where: { itemId } });
+  return findItemSplitsInTx(tx, itemId);
 }
 
 /** 明細（Item）の負担内訳（ItemSplit）を更新・保存 */

--- a/backend/src/services/receipt/receiptStatsService.ts
+++ b/backend/src/services/receipt/receiptStatsService.ts
@@ -1,43 +1,16 @@
-import { prisma } from '../../utils/prismaClient';
+import {
+  findLatestReceiptInMonth,
+  queryMonthlyCategoryStats,
+  queryMonthlyReceiptTotal,
+  queryParetoByCategory,
+  queryReceiptTrend,
+} from '../../repositories/receiptRepository';
 
 /** 月別統計 */
 export async function getMonthlyStats(familyGroupId: number, month: string) {
-  const totalRes = await prisma.$queryRaw<{ total: number | null }[]>`
-    SELECT SUM("totalAmount")::double precision as total
-    FROM "Receipt"
-    WHERE "familyGroupId" = ${familyGroupId}
-    AND TO_CHAR(date, 'YYYY-MM') = ${month}
-  `;
-  const totalAmount = totalRes[0]?.total || 0;
-
-  const categoryStats = await prisma.$queryRaw<
-    { categoryId: number | null; categoryName: string | null; color: string | null; totalAmount: number }[]
-  >`
-    SELECT 
-      c.id as "categoryId",
-      c.name as "categoryName",
-      c.color as "color",
-      SUM(i.price * i.quantity)::double precision as "totalAmount"
-    FROM "Item" i
-    JOIN "Receipt" r ON i."receiptId" = r.id
-    LEFT JOIN "Category" c ON i."categoryId" = c.id
-    WHERE r."familyGroupId" = ${familyGroupId}
-    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
-    GROUP BY c.id, c.name, c.color
-    ORDER BY "totalAmount" DESC
-  `;
-
-  const latestReceipt = await prisma.receipt.findFirst({
-    where: {
-      familyGroupId,
-      date: {
-        gte: new Date(`${month}-01`),
-        lt: new Date(new Date(`${month}-01`).setMonth(new Date(`${month}-01`).getMonth() + 1)),
-      },
-    },
-    orderBy: { date: 'desc' },
-    include: { items: { include: { category: true } } },
-  });
+  const totalAmount = await queryMonthlyReceiptTotal(familyGroupId, month);
+  const categoryStats = await queryMonthlyCategoryStats(familyGroupId, month);
+  const latestReceipt = await findLatestReceiptInMonth(familyGroupId, month);
 
   return {
     month,
@@ -52,30 +25,9 @@ export async function getMonthlyStats(familyGroupId: number, month: string) {
 
 /** 高度な統計（トレンド・パレート） */
 export async function getAdvancedStats(familyGroupId: number) {
-  const trend = await prisma.$queryRaw<{ period: string; total: number }[]>`
-    SELECT 
-      TO_CHAR(date, 'YYYY-MM') as period, 
-      SUM("totalAmount")::double precision as total 
-    FROM "Receipt" 
-    WHERE "familyGroupId" = ${familyGroupId} 
-    GROUP BY period 
-    ORDER BY period DESC 
-    LIMIT 6
-  `;
-
+  const trend = await queryReceiptTrend(familyGroupId);
   const month = new Date().toISOString().slice(0, 7);
-  const paretoRaw = await prisma.$queryRaw<{ name: string; amount: number }[]>`
-    SELECT 
-      COALESCE(c.name, '未分類') as name,
-      SUM(i.price * i.quantity)::double precision as amount
-    FROM "Item" i
-    JOIN "Receipt" r ON i."receiptId" = r.id
-    LEFT JOIN "Category" c ON i."categoryId" = c.id
-    WHERE r."familyGroupId" = ${familyGroupId}
-    AND TO_CHAR(r.date, 'YYYY-MM') = ${month}
-    GROUP BY c.name
-    ORDER BY amount DESC
-  `;
+  const paretoRaw = await queryParetoByCategory(familyGroupId, month);
 
   const total = paretoRaw.reduce((sum, item) => sum + (item.amount || 0), 0);
   let cumulative = 0;

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -2,6 +2,16 @@ import { AppError } from '../../utils/appError';
 import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import type { ReceiptCreateItemInput } from '../../types/receipt';
 import type { TenantContext } from '../../utils/context';
+import {
+  createItemsInTx,
+  deleteItemsByReceiptIdInTx,
+  findCategoryByIdInTx,
+  findItemWithReceiptInTx,
+  findReceiptByIdForTenantInTx,
+  findReceiptByIdInTx,
+  updateItemCategoryInTx,
+  updateReceiptInTx as patchReceiptInTx,
+} from '../../repositories/receiptRepository';
 import { saveParsedReceipt } from './receiptPersistenceService';
 import { upsertProductMasterCategory } from './receiptProductMasterLearning';
 
@@ -43,7 +53,7 @@ export type UpdateReceiptInput = {
   items?: ReceiptCreateItemInput[];
 };
 
-async function updateReceiptInTx(
+async function applyFullReceiptUpdateInTx(
   tx: PrismaTx,
   receiptId: number,
   familyGroupId: number,
@@ -51,12 +61,7 @@ async function updateReceiptInTx(
 ) {
   const { date, storeName, items } = input;
 
-  const existing = await tx.receipt.findUnique({
-    where: { id: receiptId },
-  });
-  if (!existing || existing.familyGroupId !== familyGroupId) {
-    throw new AppError('ReceiptNotFound', 404);
-  }
+  const existing = await findReceiptByIdForTenantInTx(tx, receiptId, familyGroupId);
 
   const itemList = items ?? [];
   const calculatedTotal = itemList.reduce((sum, i) => {
@@ -64,27 +69,25 @@ async function updateReceiptInTx(
   }, 0);
   const finalTotal = Math.round(calculatedTotal);
 
-  await tx.receipt.update({
-    where: { id: receiptId },
-    data: {
-      date: date ? new Date(date) : undefined,
-      storeName: storeName || undefined,
-      totalAmount: finalTotal,
-    },
+  await patchReceiptInTx(tx, receiptId, {
+    date: date ? new Date(date) : undefined,
+    storeName: storeName || undefined,
+    totalAmount: finalTotal,
   });
 
-  await tx.item.deleteMany({ where: { receiptId } });
+  await deleteItemsByReceiptIdInTx(tx, receiptId);
 
   if (itemList.length > 0) {
-    await tx.item.createMany({
-      data: itemList.map((i) => ({
+    await createItemsInTx(
+      tx,
+      itemList.map((i) => ({
         receiptId,
         name: i.name,
         price: parseFloat(String(i.price)) || 0,
         quantity: parseFloat(String(i.quantity)) || 0,
         categoryId: i.categoryId ? Number(i.categoryId) : null,
-      })),
-    });
+      }))
+    );
 
     const resolvedStoreName = storeName || existing.storeName;
     for (const item of itemList) {
@@ -99,10 +102,7 @@ async function updateReceiptInTx(
     }
   }
 
-  return tx.receipt.findUnique({
-    where: { id: receiptId },
-    include: { items: { include: { category: true } } },
-  });
+  return findReceiptByIdInTx(tx, receiptId);
 }
 
 /** 保存済みレシートの完全編集 */
@@ -111,36 +111,31 @@ export async function updateReceiptById(
   familyGroupId: number,
   input: UpdateReceiptInput
 ) {
-  return runInTransaction((tx) => updateReceiptInTx(tx, receiptId, familyGroupId, input));
+  return runInTransaction((tx) => applyFullReceiptUpdateInTx(tx, receiptId, familyGroupId, input));
 }
 
-async function updateItemCategoryInTx(
+async function updateItemCategoryInTxHandler(
   tx: PrismaTx,
   itemId: number,
   familyGroupId: number,
   categoryId: number | null | undefined
 ) {
-  const currentItem = await tx.item.findUnique({
-    where: { id: itemId },
-    include: { receipt: true },
-  });
+  const currentItem = await findItemWithReceiptInTx(tx, itemId);
 
   if (!currentItem || currentItem.receipt.familyGroupId !== familyGroupId) {
     throw new AppError('ItemNotFound', 404);
   }
 
   if (categoryId) {
-    const category = await tx.category.findFirst({
-      where: { id: Number(categoryId), familyGroupId },
-    });
+    const category = await findCategoryByIdInTx(tx, Number(categoryId), familyGroupId);
     if (!category) throw new AppError('CategoryNotFound', 404);
   }
 
-  const updatedItem = await tx.item.update({
-    where: { id: itemId },
-    data: { categoryId: categoryId ? Number(categoryId) : null },
-    include: { category: true },
-  });
+  const updatedItem = await updateItemCategoryInTx(
+    tx,
+    itemId,
+    categoryId ? Number(categoryId) : null
+  );
 
   if (categoryId) {
     await upsertProductMasterCategory(tx, {
@@ -160,5 +155,7 @@ export async function updateItemCategoryById(
   familyGroupId: number,
   categoryId: number | null | undefined
 ) {
-  return runInTransaction((tx) => updateItemCategoryInTx(tx, itemId, familyGroupId, categoryId));
+  return runInTransaction((tx) =>
+    updateItemCategoryInTxHandler(tx, itemId, familyGroupId, categoryId)
+  );
 }

--- a/backend/src/services/receiptService.ts
+++ b/backend/src/services/receiptService.ts
@@ -2,7 +2,7 @@
  * 後方互換ファサード（Issue #98-3）
  * 新規コードは `services/receipt/*` を直接 import してください。
  */
-import { prisma } from '../utils/prismaClient';
+import { findMemberById } from '../repositories/receiptRepository';
 import { analyzeOnly } from './receipt/receiptAnalysisService';
 import { saveConfirmedReceipt } from './receipt/receiptPersistenceService';
 
@@ -12,10 +12,7 @@ export { DuplicateReceiptError, isDuplicateReceiptError, getDuplicateExistingId 
 
 /** 解析〜保存の一括処理（Worker 用レガシー / スクリプト用） */
 export const processAndSaveReceipt = async (memberId: number, imagePath: string) => {
-  const member = await prisma.familyMember.findUnique({
-    where: { id: memberId },
-    select: { familyGroupId: true },
-  });
+  const member = await findMemberById(memberId);
   if (!member) throw new Error('MEMBER_NOT_FOUND');
 
   const { parsedData, validation } = await analyzeOnly(


### PR DESCRIPTION
## Summary

- `receiptRepository.ts` を新設し、Receipt ドメインの DB アクセスを集約
- `receipt/*Service` および `duplicateReceiptService` / `receiptService` から Prisma 直呼びを除去
- commit 系トランザクションは `createReceiptInTx(tx, …)` パターンで #98-4 と整合

Closes #399

## Test plan

- [x] `cd backend && npm test` — 43 passed / 29 skipped
- [ ] レシート一覧・詳細・削除が正常動作すること
- [ ] レシート commit（解析結果保存）が正常動作すること
- [ ] レシート編集・明細カテゴリ更新・按分更新が正常動作すること
- [ ] 統計 API（月別・高度統計）が正常動作すること


Made with [Cursor](https://cursor.com)