### PR TITLE
refactor(backend): [Issue #98-8-8] Repository 導入（settlement / master）

### DIFF
--- a/backend/src/repositories/categoryRepository.ts
+++ b/backend/src/repositories/categoryRepository.ts
@@ -1,0 +1,49 @@
+import { prisma } from '../utils/prismaClient';
+
+export async function findCategoriesByFamilyGroup(familyGroupId: number) {
+  return prisma.category.findMany({
+    where: { familyGroupId },
+    orderBy: { id: 'asc' },
+  });
+}
+
+export async function findCategoryColorsByFamilyGroup(familyGroupId: number) {
+  return prisma.category.findMany({
+    where: { familyGroupId },
+    select: { color: true },
+  });
+}
+
+export async function createCategoryRecord(input: {
+  name: string;
+  color: string;
+  familyGroupId: number;
+}) {
+  return prisma.category.create({ data: input });
+}
+
+export async function findCategoryByIdAndFamilyGroup(categoryId: number, familyGroupId: number) {
+  return prisma.category.findFirst({
+    where: { id: categoryId, familyGroupId },
+  });
+}
+
+export async function deleteCategoryById(categoryId: number) {
+  return prisma.category.delete({ where: { id: categoryId } });
+}
+
+export async function groupProductMasterStatsByCategory(familyGroupId: number) {
+  return prisma.productMaster.groupBy({
+    by: ['name', 'categoryId'],
+    where: { familyGroupId },
+    _count: { name: true },
+    having: { name: { _count: { gte: 5 } } },
+  });
+}
+
+export async function updateCategoryKeywords(categoryId: number, keywords: string[]) {
+  return prisma.category.update({
+    where: { id: categoryId },
+    data: { keywords },
+  });
+}

--- a/backend/src/repositories/productMasterRepository.ts
+++ b/backend/src/repositories/productMasterRepository.ts
@@ -1,0 +1,71 @@
+import { prisma } from '../utils/prismaClient';
+import { runInTransaction, type PrismaTx } from '../utils/prismaTransaction';
+import { updateReceiptStoreNamesInTx } from './receiptRepository';
+
+export type ListProductMastersWhere = {
+  familyGroupId: number;
+  name?: { contains: string; mode: 'insensitive' };
+  storeName?: { contains: string; mode: 'insensitive' };
+};
+
+export async function findProductMasters(where: ListProductMastersWhere) {
+  return prisma.productMaster.findMany({
+    where,
+    include: { category: true },
+    orderBy: { id: 'desc' },
+    take: 100,
+  });
+}
+
+export async function findProductMasterByIdAndFamilyGroup(id: number, familyGroupId: number) {
+  return prisma.productMaster.findFirst({
+    where: { id, familyGroupId },
+  });
+}
+
+export async function updateProductMasterRecord(
+  id: number,
+  data: { name: string; storeName: string; categoryId: number }
+) {
+  return prisma.productMaster.update({
+    where: { id },
+    data: {
+      name: data.name,
+      storeName: data.storeName,
+      categoryId: data.categoryId,
+    },
+  });
+}
+
+export async function deleteProductMasterById(id: number) {
+  return prisma.productMaster.delete({ where: { id } });
+}
+
+async function updateProductMasterStoreNamesInTx(
+  tx: PrismaTx,
+  familyGroupId: number,
+  sourceStoreName: string,
+  targetStoreName: string
+) {
+  return tx.productMaster.updateMany({
+    where: { storeName: sourceStoreName, familyGroupId },
+    data: { storeName: targetStoreName },
+  });
+}
+
+export async function mergeStoreNamesInTransaction(
+  familyGroupId: number,
+  sourceStoreName: string,
+  targetStoreName: string
+) {
+  return runInTransaction(async (tx) => {
+    const updateResult = await updateProductMasterStoreNamesInTx(
+      tx,
+      familyGroupId,
+      sourceStoreName,
+      targetStoreName
+    );
+    await updateReceiptStoreNamesInTx(tx, familyGroupId, sourceStoreName, targetStoreName);
+    return updateResult;
+  });
+}

--- a/backend/src/repositories/receiptRepository.ts
+++ b/backend/src/repositories/receiptRepository.ts
@@ -190,6 +190,18 @@ export async function updateReceiptInTx(
   });
 }
 
+export async function updateReceiptStoreNamesInTx(
+  tx: PrismaTx,
+  familyGroupId: number,
+  sourceStoreName: string,
+  targetStoreName: string
+) {
+  return tx.receipt.updateMany({
+    where: { storeName: sourceStoreName, familyGroupId },
+    data: { storeName: targetStoreName },
+  });
+}
+
 export type ItemCreateInput = {
   receiptId: number;
   name: string;

--- a/backend/src/repositories/settlementRepository.ts
+++ b/backend/src/repositories/settlementRepository.ts
@@ -1,0 +1,78 @@
+import { prisma } from '../utils/prismaClient';
+import { listFamilyMembers } from './receiptRepository';
+
+export type SettlementItemQueryRow = {
+  receiptId: number;
+  price: number;
+  quantity: number;
+  receipt: { memberId: number };
+  splits: { familyMemberId: number; amount: number }[];
+};
+
+export async function findSettlementItemsInRange(
+  familyGroupId: number,
+  startDate: Date,
+  endDate: Date
+): Promise<SettlementItemQueryRow[]> {
+  return prisma.item.findMany({
+    where: {
+      receipt: {
+        familyGroupId,
+        date: { gte: startDate, lt: endDate },
+      },
+    },
+    select: {
+      receiptId: true,
+      price: true,
+      quantity: true,
+      receipt: { select: { memberId: true } },
+      splits: {
+        select: {
+          familyMemberId: true,
+          amount: true,
+        },
+      },
+    },
+  });
+}
+
+export async function listFamilyMembersForSettlement(familyGroupId: number) {
+  return listFamilyMembers(familyGroupId);
+}
+
+export async function findSettlementTransfersByMonth(familyGroupId: number, month: string) {
+  return prisma.settlementTransfer.findMany({
+    where: { month, familyGroupId },
+    select: {
+      id: true,
+      fromMemberId: true,
+      toMemberId: true,
+      amount: true,
+      settledAt: true,
+    },
+  });
+}
+
+export async function findFamilyMembersByIds(familyGroupId: number, ids: number[]) {
+  return prisma.familyMember.findMany({
+    where: { id: { in: ids }, familyGroupId },
+  });
+}
+
+export async function createSettlementTransferRecord(input: {
+  familyGroupId: number;
+  month: string;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+}) {
+  return prisma.settlementTransfer.create({ data: input });
+}
+
+export async function findSettlementTransferById(transferId: number) {
+  return prisma.settlementTransfer.findUnique({ where: { id: transferId } });
+}
+
+export async function deleteSettlementTransferById(transferId: number) {
+  return prisma.settlementTransfer.delete({ where: { id: transferId } });
+}

--- a/backend/src/services/category/categoryService.ts
+++ b/backend/src/services/category/categoryService.ts
@@ -1,14 +1,19 @@
-import { prisma } from '../../utils/prismaClient';
 import { AppError } from '../../utils/appError';
 import logger from '../../utils/logger';
 import { pickNextCategoryColor } from '../../utils/categoryColor';
 import type { TenantContext } from '../../utils/context';
+import {
+  createCategoryRecord,
+  deleteCategoryById,
+  findCategoriesByFamilyGroup,
+  findCategoryByIdAndFamilyGroup,
+  findCategoryColorsByFamilyGroup,
+  groupProductMasterStatsByCategory,
+  updateCategoryKeywords,
+} from '../../repositories/categoryRepository';
 
 export async function listCategories(ctx: TenantContext) {
-  return prisma.category.findMany({
-    where: { familyGroupId: ctx.familyGroupId },
-    orderBy: { id: 'asc' },
-  });
+  return findCategoriesByFamilyGroup(ctx.familyGroupId);
 }
 
 export async function createCategory(
@@ -20,10 +25,7 @@ export async function createCategory(
     throw new AppError('Name is required', 400);
   }
 
-  const existing = await prisma.category.findMany({
-    where: { familyGroupId: ctx.familyGroupId },
-    select: { color: true },
-  });
+  const existing = await findCategoryColorsByFamilyGroup(ctx.familyGroupId);
   const existingColors = existing.map((c) => c.color);
   const requested = typeof color === 'string' && color.trim() ? color.trim() : '';
   const isDuplicate =
@@ -34,12 +36,10 @@ export async function createCategory(
   const resolvedColor =
     requested && !isDuplicate ? requested : pickNextCategoryColor(existingColors);
 
-  const category = await prisma.category.create({
-    data: {
-      name,
-      color: resolvedColor,
-      familyGroupId: ctx.familyGroupId,
-    },
+  const category = await createCategoryRecord({
+    name,
+    color: resolvedColor,
+    familyGroupId: ctx.familyGroupId,
   });
 
   logger.info(`[CATEGORY] Created: ${name}`);
@@ -47,15 +47,13 @@ export async function createCategory(
 }
 
 export async function deleteCategory(ctx: TenantContext, categoryId: number) {
-  const existing = await prisma.category.findFirst({
-    where: { id: categoryId, familyGroupId: ctx.familyGroupId },
-  });
+  const existing = await findCategoryByIdAndFamilyGroup(categoryId, ctx.familyGroupId);
   if (!existing) {
     throw new AppError('Category not found', 404);
   }
 
   try {
-    await prisma.category.delete({ where: { id: existing.id } });
+    await deleteCategoryById(existing.id);
     logger.info(`[CATEGORY] Deleted: ID ${categoryId}`);
   } catch (error: unknown) {
     if (
@@ -72,16 +70,8 @@ export async function deleteCategory(ctx: TenantContext, categoryId: number) {
 
 /** ProductMaster 統計から Category キーワードを補強（当該世帯の Category のみ更新） */
 export async function optimizeCategoryKeywords(ctx: TenantContext) {
-  const stats = await prisma.productMaster.groupBy({
-    by: ['name', 'categoryId'],
-    where: { familyGroupId: ctx.familyGroupId },
-    _count: { name: true },
-    having: { name: { _count: { gte: 5 } } },
-  });
-
-  const categories = await prisma.category.findMany({
-    where: { familyGroupId: ctx.familyGroupId },
-  });
+  const stats = await groupProductMasterStatsByCategory(ctx.familyGroupId);
+  const categories = await findCategoriesByFamilyGroup(ctx.familyGroupId);
   let totalAdded = 0;
 
   for (const category of categories) {
@@ -98,10 +88,7 @@ export async function optimizeCategoryKeywords(ctx: TenantContext) {
     );
 
     if (newEntries.length > 0) {
-      await prisma.category.update({
-        where: { id: category.id },
-        data: { keywords: [...currentKeywords, ...newEntries] },
-      });
+      await updateCategoryKeywords(category.id, [...currentKeywords, ...newEntries]);
       totalAdded += newEntries.length;
       logger.info(`[OPTIMIZE] Category:${category.name} added ${newEntries.length} keywords.`);
     }

--- a/backend/src/services/productMaster/productMasterService.ts
+++ b/backend/src/services/productMaster/productMasterService.ts
@@ -1,7 +1,13 @@
-import { prisma } from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { AppError } from '../../utils/appError';
 import type { TenantContext } from '../../utils/context';
+import {
+  deleteProductMasterById,
+  findProductMasterByIdAndFamilyGroup,
+  findProductMasters,
+  mergeStoreNamesInTransaction,
+  updateProductMasterRecord,
+} from '../../repositories/productMasterRepository';
 
 export type ListProductMastersQuery = {
   q?: string;
@@ -19,12 +25,7 @@ export async function listProductMasters(ctx: TenantContext, query: ListProductM
   if (q) where.name = { contains: String(q), mode: 'insensitive' };
   if (store) where.storeName = { contains: String(store), mode: 'insensitive' };
 
-  return prisma.productMaster.findMany({
-    where,
-    include: { category: true },
-    orderBy: { id: 'desc' },
-    take: 100,
-  });
+  return findProductMasters(where);
 }
 
 export async function updateProductMaster(
@@ -32,20 +33,15 @@ export async function updateProductMaster(
   id: number,
   input: { name: string; storeName: string; categoryId: number }
 ) {
-  const existing = await prisma.productMaster.findFirst({
-    where: { id, familyGroupId: ctx.familyGroupId },
-  });
+  const existing = await findProductMasterByIdAndFamilyGroup(id, ctx.familyGroupId);
   if (!existing) {
     throw new AppError('ProductMaster not found', 404);
   }
 
-  return prisma.productMaster.update({
-    where: { id: existing.id },
-    data: {
-      name: input.name,
-      storeName: input.storeName,
-      categoryId: Number(input.categoryId),
-    },
+  return updateProductMasterRecord(existing.id, {
+    name: input.name,
+    storeName: input.storeName,
+    categoryId: Number(input.categoryId),
   });
 }
 
@@ -59,32 +55,21 @@ export async function mergeStoreNames(
   }
 
   const { familyGroupId } = ctx;
-
-  const result = await prisma.$transaction(async (tx) => {
-    const updateResult = await tx.productMaster.updateMany({
-      where: { storeName: sourceStoreName, familyGroupId },
-      data: { storeName: targetStoreName },
-    });
-
-    await tx.receipt.updateMany({
-      where: { storeName: sourceStoreName, familyGroupId },
-      data: { storeName: targetStoreName },
-    });
-
-    return updateResult;
-  });
+  const result = await mergeStoreNamesInTransaction(
+    familyGroupId,
+    sourceStoreName,
+    targetStoreName
+  );
 
   logger.info(`[STORE_MERGE] Family:${familyGroupId} | ${sourceStoreName} -> ${targetStoreName}`);
   return { message: '統合が完了しました', count: result.count };
 }
 
 export async function deleteProductMaster(ctx: TenantContext, id: number) {
-  const existing = await prisma.productMaster.findFirst({
-    where: { id, familyGroupId: ctx.familyGroupId },
-  });
+  const existing = await findProductMasterByIdAndFamilyGroup(id, ctx.familyGroupId);
   if (!existing) {
     throw new AppError('ProductMaster not found', 404);
   }
 
-  await prisma.productMaster.delete({ where: { id: existing.id } });
+  await deleteProductMasterById(existing.id);
 }

--- a/backend/src/services/settlement/settlementService.ts
+++ b/backend/src/services/settlement/settlementService.ts
@@ -1,4 +1,3 @@
-import { prisma } from '../../utils/prismaClient';
 import { AppError } from '../../utils/appError';
 import {
   getCurrentYearMonthLocal,
@@ -10,6 +9,15 @@ import {
   type SettlementReceiptInput,
 } from './settlementAggregation';
 import type { TenantContext } from '../../utils/context';
+import {
+  createSettlementTransferRecord,
+  deleteSettlementTransferById,
+  findFamilyMembersByIds,
+  findSettlementItemsInRange,
+  findSettlementTransferById,
+  findSettlementTransfersByMonth,
+  listFamilyMembersForSettlement,
+} from '../../repositories/settlementRepository';
 
 export type SettlementItemRow = {
   receiptId: number;
@@ -47,26 +55,7 @@ async function fetchSettlementReceiptInputs(
   startDate: Date,
   endDate: Date
 ): Promise<SettlementReceiptInput[]> {
-  const items = await prisma.item.findMany({
-    where: {
-      receipt: {
-        familyGroupId,
-        date: { gte: startDate, lt: endDate },
-      },
-    },
-    select: {
-      receiptId: true,
-      price: true,
-      quantity: true,
-      receipt: { select: { memberId: true } },
-      splits: {
-        select: {
-          familyMemberId: true,
-          amount: true,
-        },
-      },
-    },
-  });
+  const items = await findSettlementItemsInRange(familyGroupId, startDate, endDate);
 
   return buildSettlementReceiptInputsFromItems(
     items.map((item) => ({
@@ -103,24 +92,9 @@ export async function getSettlementStatusData(
   const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);
 
   const [members, receiptInputs, transfers] = await Promise.all([
-    prisma.familyMember.findMany({
-      where: { familyGroupId },
-      select: { id: true, name: true },
-    }),
+    listFamilyMembersForSettlement(familyGroupId),
     fetchSettlementReceiptInputs(familyGroupId, startDate, endDate),
-    prisma.settlementTransfer.findMany({
-      where: {
-        month: targetMonth,
-        familyGroupId,
-      },
-      select: {
-        id: true,
-        fromMemberId: true,
-        toMemberId: true,
-        amount: true,
-        settledAt: true,
-      },
-    }),
+    findSettlementTransfersByMonth(familyGroupId, targetMonth),
   ]);
 
   const memberSummaries = computeSettlementMemberSummaries(
@@ -166,25 +140,18 @@ export async function createSettlementTransfer(
     throw new AppError('自分自身への送金は登録できません。', 400);
   }
 
-  const validMembers = await prisma.familyMember.findMany({
-    where: {
-      id: { in: [fromId, toId] },
-      familyGroupId,
-    },
-  });
+  const validMembers = await findFamilyMembersByIds(familyGroupId, [fromId, toId]);
 
   if (validMembers.length !== 2) {
     throw new AppError('無効なユーザー指定、または権限がありません。', 403);
   }
 
-  return prisma.settlementTransfer.create({
-    data: {
-      familyGroupId,
-      month: normalizedMonth,
-      fromMemberId: fromId,
-      toMemberId: toId,
-      amount: transferAmount,
-    },
+  return createSettlementTransferRecord({
+    familyGroupId,
+    month: normalizedMonth,
+    fromMemberId: fromId,
+    toMemberId: toId,
+    amount: transferAmount,
   });
 }
 
@@ -195,9 +162,7 @@ export async function deleteSettlementTransfer(ctx: TenantContext, transferId: n
     throw new AppError('送金記録IDが不正です。', 400);
   }
 
-  const transfer = await prisma.settlementTransfer.findUnique({
-    where: { id: transferId },
-  });
+  const transfer = await findSettlementTransferById(transferId);
 
   if (!transfer) {
     throw new AppError('送金記録が見つかりません。', 404);
@@ -207,7 +172,7 @@ export async function deleteSettlementTransfer(ctx: TenantContext, transferId: n
     throw new AppError('この送金記録を操作する権限がありません。', 403);
   }
 
-  await prisma.settlementTransfer.delete({ where: { id: transferId } });
+  await deleteSettlementTransferById(transferId);
 
   return { id: transferId };
 }


### PR DESCRIPTION
## Summary

- `settlementRepository`, `categoryRepository`, `productMasterRepository` を新設
- 各 Service から Prisma 直呼びを除去し、Service → Repository → Prisma の流れに統一
- 店舗名統合向けに `receiptRepository.updateReceiptStoreNamesInTx` を追加

Closes #400

## Test plan

- [x] `cd backend && npm test` — 43 passed / 29 skipped
- [ ] 精算 API（ステータス取得 / 送金登録 / 取消）が正常動作すること
- [ ] カテゴリー CRUD / 最適化が正常動作すること
- [ ] 商品マスタ一覧・更新・店舗統合・削除が正常動作すること


Made with [Cursor](https://cursor.com)