### PR TITLE
feat(openapi): [Issue #98-8-10] OpenAPI 全 API 追随と FE API 層移行

### DIFF
--- a/docs/design/api-spec.md
+++ b/docs/design/api-spec.md
@@ -6,7 +6,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 
 本ドキュメントは **実装準拠（as-built）** で記述する。Express ルート・ミドルウェア・コントローラの挙動を正とし、ドメインルールは [domain-model.md](./domain-model.md)（#90-2）を参照する。
 
-> **OpenAPI 正本（Phase 2 #98-8-9）**: 主要 API（auth / receipt / stats）の FE 型生成用 YAML は [../openapi/openapi.yaml](../openapi/openapi.yaml)。詳細説明は本書、機械可読スキーマは OpenAPI を正とする。
+> **OpenAPI 正本（Phase 2 #98-8-9 / #98-8-10）**: 公開 API 全体の FE 型生成用 YAML は [../openapi/openapi.yaml](../openapi/openapi.yaml)。詳細説明は本書、機械可読スキーマは OpenAPI を正とする。
 
 | 資料 | 内容 |
 |------|------|

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2,18 +2,26 @@ openapi: 3.0.3
 info:
   title: Receipt AI App API
   description: |
-    Phase 1 OpenAPI 正本（auth / receipt / stats）。
+    OpenAPI 正本（全公開 API）。
+    Phase 1: auth / receipt / stats — Phase 2 (#98-8-10): category / productMaster / admin / upload / health。
     詳細な as-built 仕様は docs/design/api-spec.md を参照。
-  version: 1.0.0
+  version: 1.1.0
 
 servers:
   - url: /api
     description: Express app（baseURL = EXPO_PUBLIC_API_URL、通常 `/api` 付き）
+  - url: /
+    description: ルート（/health のみ。/api プレフィックスなし）
 
 tags:
   - name: auth
   - name: receipt
   - name: stats
+  - name: category
+  - name: productMaster
+  - name: admin
+  - name: upload
+  - name: health
 
 paths:
   /auth/resolve-family:
@@ -647,6 +655,364 @@ paths:
                           id:
                             type: integer
 
+  /categories:
+    get:
+      tags: [category]
+      summary: カテゴリ一覧
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Category'
+    post:
+      tags: [category]
+      summary: カテゴリ新規作成
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCategoryRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Category'
+
+  /categories/{id}:
+    delete:
+      tags: [category]
+      summary: カテゴリ削除
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiMessageEnvelope'
+
+  /categories/optimize:
+    post:
+      tags: [category]
+      summary: ProductMaster からキーワード最適化
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/OptimizeCategoryResponse'
+
+  /product-master:
+    get:
+      tags: [productMaster]
+      summary: 学習マスタ一覧
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          schema:
+            type: string
+        - name: store
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProductMaster'
+
+  /product-master/{id}:
+    patch:
+      tags: [productMaster]
+      summary: マスタ個別更新
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProductMasterRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ProductMaster'
+    delete:
+      tags: [productMaster]
+      summary: マスタ削除
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiMessageEnvelope'
+
+  /product-master/merge-stores:
+    post:
+      tags: [productMaster]
+      summary: 店舗名統合
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergeStoreNamesRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MergeStoreNamesResponse'
+
+  /uploads/{filename}:
+    get:
+      tags: [upload]
+      summary: レシート画像配信（認証付き）
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filename
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 画像バイナリ
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+
+  /admin/stats:
+    get:
+      tags: [admin]
+      summary: AI コスト統計
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AdminCostStatRow'
+
+  /admin/prompts:
+    get:
+      tags: [admin]
+      summary: プロンプトテンプレート一覧
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PromptTemplate'
+    post:
+      tags: [admin]
+      summary: プロンプト新規作成
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePromptTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/PromptTemplate'
+
+  /admin/prompts/{id}:
+    patch:
+      tags: [admin]
+      summary: プロンプト更新
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePromptTemplateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/PromptTemplate'
+    delete:
+      tags: [admin]
+      summary: プロンプト削除
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiMessageEnvelope'
+
+  /admin/prompts/{id}/activate:
+    patch:
+      tags: [admin]
+      summary: デフォルトプロンプト切替
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiMessageEnvelope'
+
+  /health:
+    get:
+      tags: [health]
+      summary: 死活監視
+      servers:
+        - url: /
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1195,3 +1561,171 @@ components:
           type: integer
         amount:
           type: number
+
+    Category:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        color:
+          type: string
+          nullable: true
+        familyGroupId:
+          type: integer
+        keywords:
+          type: array
+          items:
+            type: string
+
+    CreateCategoryRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        color:
+          type: string
+          nullable: true
+
+    OptimizeCategoryResponse:
+      type: object
+      required: [addedCount, message]
+      properties:
+        addedCount:
+          type: integer
+        message:
+          type: string
+
+    ProductMaster:
+      type: object
+      required: [id, name, storeName, categoryId]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        storeName:
+          type: string
+        categoryId:
+          type: integer
+        category:
+          $ref: '#/components/schemas/CategorySummary'
+        updatedAt:
+          type: string
+          format: date-time
+
+    UpdateProductMasterRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        storeName:
+          type: string
+        categoryId:
+          type: integer
+
+    MergeStoreNamesRequest:
+      type: object
+      required: [sourceStoreName, targetStoreName]
+      properties:
+        sourceStoreName:
+          type: string
+        targetStoreName:
+          type: string
+
+    MergeStoreNamesResponse:
+      type: object
+      required: [message, count]
+      properties:
+        message:
+          type: string
+        count:
+          type: integer
+
+    PromptTemplate:
+      type: object
+      required: [id, key, systemPrompt, isActive, version]
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        systemPrompt:
+          type: string
+        domainHints:
+          type: object
+          additionalProperties: true
+          nullable: true
+        isActive:
+          type: boolean
+        version:
+          type: integer
+        familyGroupId:
+          type: integer
+
+    CreatePromptTemplateRequest:
+      type: object
+      required: [key, systemPrompt]
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        systemPrompt:
+          type: string
+        domainHints:
+          type: object
+          additionalProperties: true
+        isActive:
+          type: boolean
+
+    UpdatePromptTemplateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        systemPrompt:
+          type: string
+        domainHints:
+          type: object
+          additionalProperties: true
+
+    AdminCostStatRow:
+      type: object
+      required: [month, modelId, totalPromptTokens, totalCandidatesTokens, estimatedCostJpy]
+      properties:
+        month:
+          type: string
+        modelId:
+          type: string
+        totalPromptTokens:
+          type: integer
+        totalCandidatesTokens:
+          type: integer
+        estimatedCostJpy:
+          type: number
+
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+        env:
+          type: string
+        timestamp:
+          type: string
+          format: date-time

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -1,0 +1,52 @@
+import apiClient from '../utils/apiClient';
+import type {
+  AdminCostStatRow,
+  ApiMessageResponse,
+  ApiSuccessResponse,
+  CreatePromptTemplateRequest,
+  PromptTemplate,
+  UpdatePromptTemplateRequest,
+} from './generated';
+
+/** 管理 API（/api/admin/*）— ADMIN + TOTP 必須 */
+export const adminApi = {
+  async getCostStats(): Promise<ApiSuccessResponse<AdminCostStatRow[]>> {
+    const res = await apiClient.get('/admin/stats');
+    return res.data;
+  },
+
+  async listPrompts(): Promise<ApiSuccessResponse<PromptTemplate[]>> {
+    const res = await apiClient.get('/admin/prompts');
+    return res.data;
+  },
+
+  async createPrompt(input: CreatePromptTemplateRequest): Promise<ApiSuccessResponse<PromptTemplate>> {
+    const res = await apiClient.post('/admin/prompts', input);
+    return res.data;
+  },
+
+  async updatePrompt(
+    id: number,
+    input: UpdatePromptTemplateRequest
+  ): Promise<ApiSuccessResponse<PromptTemplate>> {
+    const res = await apiClient.patch(`/admin/prompts/${id}`, input);
+    return res.data;
+  },
+
+  async activatePrompt(id: number): Promise<ApiMessageResponse> {
+    const res = await apiClient.patch(`/admin/prompts/${id}/activate`);
+    return res.data;
+  },
+
+  async deletePrompt(id: number): Promise<ApiMessageResponse> {
+    const res = await apiClient.delete(`/admin/prompts/${id}`);
+    return res.data;
+  },
+};
+
+export type {
+  AdminCostStatRow,
+  CreatePromptTemplateRequest,
+  PromptTemplate,
+  UpdatePromptTemplateRequest,
+} from './generated';

--- a/frontend/src/api/categoryApi.ts
+++ b/frontend/src/api/categoryApi.ts
@@ -1,11 +1,33 @@
 import apiClient from '../utils/apiClient';
-import type { CategorySummary } from '../types/receipt';
-import type { ApiSuccessResponse } from './types';
+import type {
+  ApiMessageResponse,
+  ApiSuccessResponse,
+  Category,
+  CreateCategoryRequest,
+  OptimizeCategoryResponse,
+} from './generated';
 
 /** カテゴリ API（/api/categories） */
 export const categoryApi = {
-  async listCategories(): Promise<ApiSuccessResponse<CategorySummary[]>> {
+  async listCategories(): Promise<ApiSuccessResponse<Category[]>> {
     const res = await apiClient.get('/categories');
     return res.data;
   },
+
+  async createCategory(input: CreateCategoryRequest): Promise<ApiSuccessResponse<Category>> {
+    const res = await apiClient.post('/categories', input);
+    return res.data;
+  },
+
+  async deleteCategory(id: number): Promise<ApiMessageResponse> {
+    const res = await apiClient.delete(`/categories/${id}`);
+    return res.data;
+  },
+
+  async optimizeCategories(): Promise<ApiSuccessResponse<OptimizeCategoryResponse>> {
+    const res = await apiClient.post('/categories/optimize', {});
+    return res.data;
+  },
 };
+
+export type { Category, CreateCategoryRequest, OptimizeCategoryResponse } from './generated';

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -42,4 +42,24 @@ export type SettlementMemberSummary = Schemas['SettlementMemberSummary'];
 export type SettlementTransfer = Schemas['SettlementTransfer'];
 export type CreateSettlementTransferRequest = Schemas['CreateSettlementTransferRequest'];
 
+// --- category ---
+export type Category = Schemas['Category'];
+export type CreateCategoryRequest = Schemas['CreateCategoryRequest'];
+export type OptimizeCategoryResponse = Schemas['OptimizeCategoryResponse'];
+
+// --- productMaster ---
+export type ProductMaster = Schemas['ProductMaster'];
+export type UpdateProductMasterRequest = Schemas['UpdateProductMasterRequest'];
+export type MergeStoreNamesRequest = Schemas['MergeStoreNamesRequest'];
+export type MergeStoreNamesResponse = Schemas['MergeStoreNamesResponse'];
+
+// --- admin ---
+export type PromptTemplate = Schemas['PromptTemplate'];
+export type CreatePromptTemplateRequest = Schemas['CreatePromptTemplateRequest'];
+export type UpdatePromptTemplateRequest = Schemas['UpdatePromptTemplateRequest'];
+export type AdminCostStatRow = Schemas['AdminCostStatRow'];
+
+// --- health ---
+export type HealthResponse = Schemas['HealthResponse'];
+
 export type { components, paths } from './schema';

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -1006,6 +1006,582 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** カテゴリ一覧 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["Category"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** カテゴリ新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateCategoryRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["Category"];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/categories/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** カテゴリ削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiMessageEnvelope"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/categories/optimize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** ProductMaster からキーワード最適化 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["OptimizeCategoryResponse"];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/product-master": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 学習マスタ一覧 */
+        get: {
+            parameters: {
+                query?: {
+                    q?: string;
+                    store?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["ProductMaster"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/product-master/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** マスタ削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiMessageEnvelope"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** マスタ個別更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateProductMasterRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["ProductMaster"];
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/product-master/merge-stores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 店舗名統合 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["MergeStoreNamesRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["MergeStoreNamesResponse"];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/uploads/{filename}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** レシート画像配信（認証付き） */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    filename: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 画像バイナリ */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "image/*": string;
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** AI コスト統計 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["AdminCostStatRow"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/prompts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** プロンプトテンプレート一覧 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["PromptTemplate"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** プロンプト新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreatePromptTemplateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["PromptTemplate"];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/prompts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** プロンプト削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiMessageEnvelope"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** プロンプト更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdatePromptTemplateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["PromptTemplate"];
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/admin/prompts/{id}/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** デフォルトプロンプト切替 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiMessageEnvelope"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 死活監視 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["HealthResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1244,6 +1820,87 @@ export interface components {
             fromMemberId: number;
             toMemberId: number;
             amount: number;
+        };
+        Category: {
+            id: number;
+            name: string;
+            color?: string | null;
+            familyGroupId?: number;
+            keywords?: string[];
+        };
+        CreateCategoryRequest: {
+            name: string;
+            color?: string | null;
+        };
+        OptimizeCategoryResponse: {
+            addedCount: number;
+            message: string;
+        };
+        ProductMaster: {
+            id: number;
+            name: string;
+            storeName: string;
+            categoryId: number;
+            category?: components["schemas"]["CategorySummary"];
+            /** Format: date-time */
+            updatedAt?: string;
+        };
+        UpdateProductMasterRequest: {
+            name?: string;
+            storeName?: string;
+            categoryId?: number;
+        };
+        MergeStoreNamesRequest: {
+            sourceStoreName: string;
+            targetStoreName: string;
+        };
+        MergeStoreNamesResponse: {
+            message: string;
+            count: number;
+        };
+        PromptTemplate: {
+            id: number;
+            key: string;
+            name?: string | null;
+            description?: string | null;
+            systemPrompt: string;
+            domainHints?: {
+                [key: string]: unknown;
+            } | null;
+            isActive: boolean;
+            version: number;
+            familyGroupId?: number;
+        };
+        CreatePromptTemplateRequest: {
+            key: string;
+            name?: string;
+            description?: string;
+            systemPrompt: string;
+            domainHints?: {
+                [key: string]: unknown;
+            };
+            isActive?: boolean;
+        };
+        UpdatePromptTemplateRequest: {
+            name?: string;
+            description?: string;
+            systemPrompt?: string;
+            domainHints?: {
+                [key: string]: unknown;
+            };
+        };
+        AdminCostStatRow: {
+            month: string;
+            modelId: string;
+            totalPromptTokens: number;
+            totalCandidatesTokens: number;
+            estimatedCostJpy: number;
+        };
+        HealthResponse: {
+            status: string;
+            env?: string;
+            /** Format: date-time */
+            timestamp?: string;
         };
     };
     responses: never;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,5 +3,14 @@ export { authApi } from './authApi';
 export { receiptApi } from './receiptApi';
 export type { CommitReceiptPayload, ItemSplitSaveRequest, ListReceiptsParams } from './receiptApi';
 export { categoryApi } from './categoryApi';
+export type { Category, CreateCategoryRequest, OptimizeCategoryResponse } from './categoryApi';
+export { productMasterApi } from './productMasterApi';
+export type {
+  ListProductMastersParams,
+  ProductMaster,
+  MergeStoreNamesRequest,
+} from './productMasterApi';
+export { adminApi } from './adminApi';
+export type { AdminCostStatRow, PromptTemplate } from './adminApi';
 export { statsApi } from './statsApi';
 export type { MonthlyStatsData, AdvancedStatsData } from './statsApi';

--- a/frontend/src/api/productMasterApi.ts
+++ b/frontend/src/api/productMasterApi.ts
@@ -1,0 +1,51 @@
+import apiClient from '../utils/apiClient';
+import type {
+  ApiMessageResponse,
+  ApiSuccessResponse,
+  MergeStoreNamesRequest,
+  MergeStoreNamesResponse,
+  ProductMaster,
+  UpdateProductMasterRequest,
+} from './generated';
+
+export type ListProductMastersParams = {
+  q?: string;
+  store?: string;
+};
+
+/** 商品マスタ API（/api/product-master） */
+export const productMasterApi = {
+  async listProductMasters(
+    params: ListProductMastersParams = {}
+  ): Promise<ApiSuccessResponse<ProductMaster[]>> {
+    const res = await apiClient.get('/product-master', { params });
+    return res.data;
+  },
+
+  async updateProductMaster(
+    id: number,
+    input: UpdateProductMasterRequest
+  ): Promise<ApiSuccessResponse<ProductMaster>> {
+    const res = await apiClient.patch(`/product-master/${id}`, input);
+    return res.data;
+  },
+
+  async deleteProductMaster(id: number): Promise<ApiMessageResponse> {
+    const res = await apiClient.delete(`/product-master/${id}`);
+    return res.data;
+  },
+
+  async mergeStoreNames(
+    input: MergeStoreNamesRequest
+  ): Promise<ApiSuccessResponse<MergeStoreNamesResponse>> {
+    const res = await apiClient.post('/product-master/merge-stores', input);
+    return res.data;
+  },
+};
+
+export type {
+  MergeStoreNamesRequest,
+  MergeStoreNamesResponse,
+  ProductMaster,
+  UpdateProductMasterRequest,
+} from './generated';

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -8,16 +8,8 @@ import {
 } from 'react-native';
 import { AppBackButton } from '../components/ui';
 import { theme, tableStyles } from '../theme';
-import apiClient from '../utils/apiClient';
+import { adminApi, type AdminCostStatRow } from '../api';
 import { getApiErrorMessage } from '../utils/apiError';
-
-interface StatData {
-  month: string;
-  modelId: string;
-  totalPromptTokens: number;
-  totalCandidatesTokens: number;
-  estimatedCostJpy: number;
-}
 
 interface AdminStatsScreenProps {
   onBack: () => void;
@@ -25,7 +17,7 @@ interface AdminStatsScreenProps {
 
 export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) => {
   const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState<StatData[]>([]);
+  const [stats, setStats] = useState<AdminCostStatRow[]>([]);
   const [totalCost, setTotalCost] = useState(0);
   const [errorMsg, setErrorMsg] = useState<string | null>(null); // ★ 追加: エラー状態管理
 
@@ -35,12 +27,11 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
 
   const fetchStats = async () => {
     try {
-      const res = await apiClient.get('/admin/stats');
-      if (res.data && res.data.success) {
-        setStats(res.data.data);
-        const total = res.data.data.reduce((sum: number, item: StatData) => sum + item.estimatedCostJpy, 0);
-        setTotalCost(total);
-      }
+      const res = await adminApi.getCostStats();
+      const rows = res.data ?? [];
+      setStats(rows);
+      const total = rows.reduce((sum, item) => sum + item.estimatedCostJpy, 0);
+      setTotalCost(total);
     } catch (error: unknown) {
       console.error('Stats Fetch Error:', error);
       setErrorMsg(getApiErrorMessage(error, 'コスト統計の取得に失敗しました。'));

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,18 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
-import apiClient from '../utils/apiClient';
+import { categoryApi, type Category } from '../api';
 import { getApiErrorStatus } from '../utils/apiError';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 import { pickNextCategoryColor } from '../utils/categoryColor';
 import { showConfirmDialog } from '../utils/confirmDialog';
-
-interface Category {
-  id: number;
-  name: string;
-  color: string;
-}
 
 export const CategoryManagementScreen = ({ 
   onBack, 
@@ -26,26 +20,16 @@ export const CategoryManagementScreen = ({
   const [loading, setLoading] = useState(true);
   const [optimizing, setOptimizing] = useState(false);
 
-  /**
-   * [Issue #51 & #52] 
-   * バックエンドが JWT 認証（Bearer Token）を優先するように修正されたため、
-   * 手動の x-member-id 付与は「移行期間用」として最小限に留めます。
-   * ※Issue #52 完了後は、このヘルパー自体を削除し apiClient に任せます。
-   */
-  const getHeaders = () => (currentMemberId ? { 'x-member-id': currentMemberId.toString() } : {});
-
-  useEffect(() => { 
-    if (currentMemberId) fetchCategories(); 
+  useEffect(() => {
+    if (currentMemberId) fetchCategories();
   }, [currentMemberId]);
 
   const fetchCategories = async () => {
     if (!currentMemberId) return;
     setLoading(true);
     try {
-      const res = await apiClient.get('/categories', { headers: getHeaders() });
-      if (res.data && res.data.success) {
-        setCategories(res.data.data || []);
-      }
+      const res = await categoryApi.listCategories();
+      setCategories(res.data ?? []);
     } catch (e: unknown) {
       if (getApiErrorStatus(e) === 401) {
         Alert.alert("セッション切れ", "再度ログインしてください。");
@@ -60,12 +44,10 @@ export const CategoryManagementScreen = ({
   const addCategory = async () => {
     if (!newName.trim() || !currentMemberId) return;
     try {
-      const color = pickNextCategoryColor(categories.map((c) => c.color));
-      await apiClient.post(
-        '/categories',
-        { name: newName, color },
-        { headers: getHeaders() }
+      const color = pickNextCategoryColor(
+        categories.map((c) => c.color).filter((c): c is string => !!c)
       );
+      await categoryApi.createCategory({ name: newName, color });
       setNewName('');
       fetchCategories();
     } catch (e) {
@@ -81,7 +63,7 @@ export const CategoryManagementScreen = ({
         style: 'destructive',
         onPress: async () => {
           try {
-            await apiClient.delete(`/categories/${id}`, { headers: getHeaders() });
+            await categoryApi.deleteCategory(id);
             fetchCategories();
           } catch (e: unknown) {
             const status = getApiErrorStatus(e);
@@ -107,11 +89,9 @@ export const CategoryManagementScreen = ({
           onPress: async () => {
             setOptimizing(true);
             try {
-              const res = await apiClient.post('/categories/optimize', {}, { headers: getHeaders() });
-              if (res.data.success) {
-                Alert.alert('完了', res.data.data.message);
-                fetchCategories();
-              }
+              const res = await categoryApi.optimizeCategories();
+              Alert.alert('完了', res.data?.message ?? '最適化が完了しました。');
+              fetchCategories();
             } catch (e) {
               Alert.alert('エラー', '最適化処理に失敗しました。');
             } finally {
@@ -162,7 +142,7 @@ export const CategoryManagementScreen = ({
           renderItem={({ item }) => (
             <AppListItem
               title={item.name}
-              left={<AppListColorDot color={item.color} />}
+              left={<AppListColorDot color={item.color ?? theme.colors.semantic.placeholder.badge} />}
               right={
                 <AppButton
                   title={BUTTON_LABELS.delete}

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,100 +1,51 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
-import apiClient from '../utils/apiClient';
+import { productMasterApi, type ProductMaster } from '../api';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
 
-interface ProductMaster {
-  id: number;
-  name: string;
-  storeName: string;
-  categoryId: number;
-  category?: { name: string; color: string };
-  updatedAt: string;
-}
-
-interface Category {
-  id: number;
-  name: string;
-  color: string;
-}
-
-// [Issue #45] Props の型を number | null に拡張（App.tsx からの null 渡しを許容）
-export const ProductMasterScreen = ({ 
-  onBack, 
-  currentMemberId 
-}: { 
-  onBack: () => void, 
-  currentMemberId: number | null 
+export const ProductMasterScreen = ({
+  onBack,
+  currentMemberId
+}: {
+  onBack: () => void,
+  currentMemberId: number | null
 }) => {
   const [masters, setMasters] = useState<ProductMaster[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [storeFilter, setStoreFilter] = useState('');
-  const [categories, setCategories] = useState<Category[]>([]);
 
-  // ヘッダー生成関数（currentMemberId が確定している時のみ生成）
-  const getHeaders = useCallback(() => {
-    return currentMemberId ? { 'x-member-id': currentMemberId.toString() } : {};
-  }, [currentMemberId]);
-
-  /**
-   * [Issue #45] マスタデータ取得 (世帯分離対応)
-   */
   const fetchMasters = useCallback(async () => {
-    if (!currentMemberId) return; // IDがない場合は実行しない
+    if (!currentMemberId) return;
 
     try {
       setLoading(true);
-      const res = await apiClient.get('/product-master', {
-        params: { q: searchQuery, store: storeFilter },
-        headers: getHeaders()
+      const res = await productMasterApi.listProductMasters({
+        q: searchQuery,
+        store: storeFilter,
       });
-      
-      if (res.data && res.data.success) {
-        setMasters(res.data.data || []);
-      } else {
-        setMasters([]);
-      }
+      setMasters(res.data ?? []);
     } catch (err) {
       console.error('Fetch Masters Error:', err);
-      // 401エラー時は再試行を促すか、ログアウト状態を確認
     } finally {
       setLoading(false);
     }
-  }, [searchQuery, storeFilter, currentMemberId, getHeaders]);
+  }, [searchQuery, storeFilter, currentMemberId]);
 
-  /**
-   * 初回ロードとカテゴリー取得
-   */
   useEffect(() => {
     if (currentMemberId) {
       fetchMasters();
-      
-      const loadCategories = async () => {
-        try {
-          const res = await apiClient.get('/categories', { headers: getHeaders() });
-          if (res.data && res.data.success) {
-            setCategories(res.data.data || []);
-          }
-        } catch (err) {
-          console.error('Category fetch error:', err);
-        }
-      };
-      loadCategories();
     }
-  }, [fetchMasters, currentMemberId, getHeaders]);
+  }, [fetchMasters, currentMemberId]);
 
-  /**
-   * [Issue #45] 削除処理 (世帯分離対応)
-   */
   const handleDelete = (id: number) => {
     Alert.alert('確認', 'この学習データを削除しますか？', [
       { text: 'キャンセル', style: 'cancel' },
       { text: '削除', style: 'destructive', onPress: async () => {
         try {
-          await apiClient.delete(`/product-master/${id}`, { headers: getHeaders() });
+          await productMasterApi.deleteProductMaster(id);
           fetchMasters();
         } catch (e) {
           Alert.alert('エラー', '削除に失敗しました');
@@ -103,9 +54,6 @@ export const ProductMasterScreen = ({
     ]);
   };
 
-  /**
-   * [Issue #45] 店舗名統合 (世帯分離対応)
-   */
   const handleMergeStores = () => {
     if (Platform.OS === 'ios') {
       Alert.prompt(
@@ -122,10 +70,10 @@ export const ProductMasterScreen = ({
                 { text: "実行", onPress: async (target: string | undefined) => {
                   if (!target) return;
                   try {
-                    await apiClient.post('/product-master/merge-stores', 
-                      { sourceStoreName: source, targetStoreName: target },
-                      { headers: getHeaders() }
-                    );
+                    await productMasterApi.mergeStoreNames({
+                      sourceStoreName: source,
+                      targetStoreName: target,
+                    });
                     Alert.alert("完了", "統合完了しました");
                     fetchMasters();
                   } catch (e) {
@@ -214,14 +162,14 @@ export const ProductMasterScreen = ({
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
-  header: { 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    paddingHorizontal: 20, 
-    paddingBottom: 15, 
-    alignItems: 'center', 
-    borderBottomWidth: 1, 
-    borderBottomColor: theme.colors.border 
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingBottom: 15,
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border
   },
   title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1, textAlign: 'center' },
   searchBar: { padding: 10, flexDirection: 'row', gap: 10, backgroundColor: theme.colors.surface },

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -9,22 +9,11 @@ import {
   Platform,
 } from 'react-native';
 
-import apiClient from '../utils/apiClient';
+import { adminApi, type PromptTemplate } from '../api';
 import { getApiErrorMessage } from '../utils/apiError';
 import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { theme } from '../theme';
-
-interface PromptTemplate {
-  id: number;
-  key: string;
-  name: string;
-  description: string | null;
-  systemPrompt: string;
-  domainHints: Record<string, unknown> | null;
-  isActive: boolean;
-  version: number;
-}
 
 interface PromptEditorScreenProps {
   onBack: () => void;
@@ -53,12 +42,8 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
     setIsLoading(true);
     setError(null);
     try {
-      const response = await apiClient.get<{ success: boolean; data: PromptTemplate[] }>('/admin/prompts');
-      if (response.data.success && response.data.data) {
-        setTemplates(response.data.data.filter(p => p.key === PROMPT_KEY));
-      } else {
-        setError('データの取得に失敗しました。');
-      }
+      const response = await adminApi.listPrompts();
+      setTemplates((response.data ?? []).filter((p) => p.key === PROMPT_KEY));
     } catch (err: unknown) {
       setError(getApiErrorMessage(err));
     } finally {
@@ -72,7 +57,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
 
   const handleActivate = async (id: number) => {
     try {
-      await apiClient.patch(`/admin/prompts/${id}/activate`);
+      await adminApi.activatePrompt(id);
       fetchPrompts();
     } catch (err: unknown) {
       Alert.alert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
@@ -82,7 +67,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
   const handleDelete = async (id: number) => {
     const executeDelete = async () => {
       try {
-        await apiClient.delete(`/admin/prompts/${id}`);
+        await adminApi.deletePrompt(id);
         fetchPrompts();
       } catch (err: unknown) {
         Alert.alert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
@@ -122,7 +107,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
 
     try {
       if (isCreatingNew) {
-        await apiClient.post(`/admin/prompts`, {
+        await adminApi.createPrompt({
           key: PROMPT_KEY,
           name: formName,
           description: formDesc,
@@ -132,7 +117,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
         });
         if (Platform.OS !== 'web') Alert.alert('作成完了', '新しいプロンプトを作成しました。');
       } else if (editingTemplate && editingTemplate.id) {
-        await apiClient.patch(`/admin/prompts/${editingTemplate.id}`, {
+        await adminApi.updatePrompt(editingTemplate.id, {
           name: formName,
           description: formDesc,
           systemPrompt: formSystemPrompt,
@@ -158,7 +143,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
   const openEditForm = (template: PromptTemplate) => {
     setEditingTemplate(template);
     setIsCreatingNew(false);
-    setFormName(template.name);
+    setFormName(template.name || '');
     setFormDesc(template.description || '');
     setFormSystemPrompt(template.systemPrompt);
     setFormDomainHints(template.domainHints ? JSON.stringify(template.domainHints, null, 2) : '');


### PR DESCRIPTION
## Summary

- `docs/openapi/openapi.yaml` を Phase 2 向けに拡張し、公開 API（category / productMaster / upload / admin / health）を OpenAPI に網羅
- `openapi-typescript` で `frontend/src/api/generated/` を再生成し、新スキーマの export を追加
- `categoryApi` / `productMasterApi`（新規）/ `adminApi`（新規）を整備し、管理・マスタ画面の `apiClient` 直呼びを API 層 + generated 型へ移行
- `docs/design/api-spec.md` の OpenAPI 正本注記を Phase 2 全 API 向けに更新

Closes #402

## Test plan

- [x] `frontend npm test` — 42 passed
- [x] `backend npm test` — 43 passed（29 skipped）
- [x] `frontend npm run check:api` — 生成物と OpenAPI の整合確認
- [ ] カテゴリー設定画面: 一覧・追加・削除・最適化
- [ ] 学習マスタ画面: 一覧・削除・店舗統合（iOS）
- [ ] 管理画面: AI コスト統計・プロンプト CRUD / デフォルト切替


Made with [Cursor](https://cursor.com)