### PR TITLE
fix(backend): stable 起動を ts-node --transpile-only に変更

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "src/server.ts",
   "scripts": {
-    "start": "ts-node src/server.ts",
+    "start": "ts-node --transpile-only src/server.ts",
     "dev": "tsx watch src/server.ts",
     "backend:dev": "ts-node-dev --respawn src/server.ts",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
## Summary

- stable の `npm run start` を `ts-node --transpile-only` に変更
- Issue #98 Phase 2（Prisma `$extends`）以降、起動時型チェックで backend がクラッシュループし、Web/Android から API が使えなくなっていた問題を解消

## 背景

| 環境 | 起動コマンド | 起動時型チェック |
|------|-------------|----------------|
| dev | `tsx watch` | なし（トランスパイルのみ） |
| stable（修正前） | `ts-node` | あり → 起動失敗 |

DB / Redis は正常。backend が起動できていなかったのが原因。

## Test plan

- [x] stable で `curl http://localhost:3000/health` → `{"status":"ok",...}`
- [x] Android から招待コードログイン成功
- [ ] PR マージ → main デプロイ後も backend が安定起動すること


Made with [Cursor](https://cursor.com)