### PR TITLE
docs(refactor): [Issue #100-0] Epic #100 計画と ChatGPT レビュー資料を追加

### DIFF
--- a/docs/refactor/plan.md
+++ b/docs/refactor/plan.md
@@ -153,3 +153,73 @@ Epic: [#370 Issue #98](https://github.com/yama180sx/receipt-ai-app/issues/370)
 ```
 
 Navigation（#403 / #404）は Phase 2 中でリスク最高。Android / iOS / Web 同一 Screen 構成は維持。Web の URL / リロード / ブラウザ戻るを PoC で重点検証する。
+
+## 7. Epic #100 — ChatGPT レビュー 20260621 フォローアップ（Phase 3）
+
+Epic: [#423 Epic #100](https://github.com/yama180sx/receipt-ai-app/issues/423)
+
+[ChatGPT レビュー 20260621](../specs/chatgpt/ChatGPT_レビュー_20260621.txt)（74/100点）のフォローアップ。#98 / #99 / #98-8 Phase 2 完了後も残る **層境界・Screen 肥大・型/Mapper 不足** を解消する。
+
+### 7.1 方針サマリー
+
+| 項目 | 決定内容 |
+|------|----------|
+| 入力ソース | ChatGPT レビュー 20260621 + 本セッション設計議論 + コード突合 |
+| BE 方針 | Service = Application 層。UseCase 物理層は新設しない |
+| FE 方針 | Hook = Application 層。Style Pattern 段階移行（big-bang 禁止） |
+| 型方針 | DTO = `api/generated`、ViewModel = `types/`、変換 = `mappers/` |
+| スコープ外 | Drizzle 移行、UseCase フォルダ新設、StyleSheet big-bang 一括 PR |
+
+### 7.2 子 Issue 対応表
+
+| 命名 | GitHub | 優先度 | 見積（AI 補助） |
+|------|--------|--------|----------------|
+| #100 Epic | [#423](https://github.com/yama180sx/receipt-ai-app/issues/423) | — | — |
+| #100-0 | [#424](https://github.com/yama180sx/receipt-ai-app/issues/424) | Must | 0.5 人日 |
+| #100-1 | [#425](https://github.com/yama180sx/receipt-ai-app/issues/425) | Must | 1.5〜2 人日 |
+| #100-2 | [#426](https://github.com/yama180sx/receipt-ai-app/issues/426) | Must | 1.5〜2 人日 |
+| #100-3 | [#427](https://github.com/yama180sx/receipt-ai-app/issues/427) | Must | 1〜1.5 人日 |
+| #100-4 | [#428](https://github.com/yama180sx/receipt-ai-app/issues/428) | Must | 1.5〜2 人日 |
+| #100-5 | [#429](https://github.com/yama180sx/receipt-ai-app/issues/429) | Should | 1〜1.5 人日 |
+| #100-6 | [#430](https://github.com/yama180sx/receipt-ai-app/issues/430) | Must | 0.5 人日 |
+| #100-7 | [#431](https://github.com/yama180sx/receipt-ai-app/issues/431) | Must | 1.5〜2 人日 |
+| #100-8 | [#432](https://github.com/yama180sx/receipt-ai-app/issues/432) | Must | 1.5〜2 人日 |
+| #100-9 | [#433](https://github.com/yama180sx/receipt-ai-app/issues/433) | Must | 1 人日 |
+| #100-10 | [#434](https://github.com/yama180sx/receipt-ai-app/issues/434) | Should | 1 人日 |
+| #100-11 | [#435](https://github.com/yama180sx/receipt-ai-app/issues/435) | Should | 0.5 人日 |
+| #100-12 | [#436](https://github.com/yama180sx/receipt-ai-app/issues/436) | Should | 1〜1.5 人日 |
+| #100-13 | [#437](https://github.com/yama180sx/receipt-ai-app/issues/437) | Should | 0.5〜1 人日 |
+| #100-14 | [#438](https://github.com/yama180sx/receipt-ai-app/issues/438) | Should | 1.5〜2 人日 |
+| #100-15 | [#439](https://github.com/yama180sx/receipt-ai-app/issues/439) | Must | 0.5 人日 |
+| #100-16 | [#440](https://github.com/yama180sx/receipt-ai-app/issues/440) | Should | 1〜1.5 人日 |
+
+### 7.3 #98-8 との関係（重複しない既存 Issue）
+
+| 既存 Issue | 内容 | #100 との関係 |
+|-----------|------|--------------|
+| #393 [#98-8-1] | features/ 移行 | #100-5 が auth/stats/history/category を補完 |
+| #394 [#98-8-2] | FE 残存 any 排除 | 並行実施（#100 スコープ外） |
+| #397 [#98-8-5] | Context 明示渡し | 並行実施 |
+| #398 [#98-8-6] | prisma `$extends` 型安全化 | 並行実施 |
+| #399 [#98-8-7] | Repository Phase 1 | #100-2 の前提 |
+| #400 [#98-8-8] | Repository Phase 2 | #100-3 の前提 |
+| #401 [#98-8-9] | OpenAPI 型生成 | #100-4 の前提 |
+
+### 7.4 Won't fix / 見送り（記録）
+
+| 項目 | 判定 | 理由 |
+|------|------|------|
+| Drizzle ORM 移行 | **Won't fix** | 現状 pain point なし。Prisma `$extends` テナント資産を維持 |
+| UseCase 物理層（`usecases/` フォルダ） | **Won't fix** | Service / Hook = Application 層として十分 |
+| StyleSheet big-bang 一括 PR | **Won't fix** | #100-6〜#100-11 で計画的段階移行 |
+
+### 7.5 推奨着手順
+
+```
+#424（#100-0 plan）→ #425 → #426 → #427 → #428 → #439
+  → #430 → #431 / #432 / #433（並行可）
+  → #434 → #435
+  → #436 → #437 → #438 → #440
+
+（#98-8 と並行: #393, #394, #397, #399, #400, #401）
+```

--- a/docs/specs/chatgpt/ChatGPT_レビュー_20260620.txt
+++ b/docs/specs/chatgpt/ChatGPT_レビュー_20260620.txt
@@ -1,0 +1,393 @@
+添付したzipファイルは、現在React Native (Expo), TypeScript, PostgreSQLで構築中のアプリ「RecAIpt」のソースコード一式です。
+
+人間による細部レビューを一切排除した『真の品質ガバナンス』の検証として、以下の4観点から【100点満点からの厳格な減点方式】でシビアに採点してください。
+冗長な褒め言葉や配慮は一切不要です。将来の保守者（非AIネイティブな人間）への引き継ぎに耐えうるかという視点で、具体的な減点理由と改善ポイントをストレートに提示してください。
+
+【評価観点】
+1. コードの共通化とDRY原則（25点）: 微調整の連発によって、似たロジックやインラインコードが重複・コピペされていないか。
+2. コンポーネントの責務分割（25点）: 1つのファイルにロジック、UI、データ処理が詰め込まれすぎ、ファイルが肥大化していないか。
+3. 型定義の堅牢性と一元管理（25点）: Anyの乱用や不適切なアサーションがなく、型が適切に共通化されているか。
+4. 保守性とクリーン度（25点）: 結合度が強すぎて、将来の修正で別画面に予期せぬバグを誘発しやすくないか。
+思考を停止しました
+
+ZIPを実際に展開してソース構成・主要画面・型定義・バックエンド構成を確認した上で採点します。
+
+対象確認範囲：
+
+Frontend: React Native (Expo) / TypeScript
+Backend: Node.js / Express / Prisma
+DB: PostgreSQL
+ファイル数：約339
+主要画面数：約15
+Components：約17
+Hooks：約4
+Types定義：約7ファイル
+総合評価
+項目	配点	得点
+1. DRY原則・共通化	25	18
+2. 責務分割	25	15
+3. 型定義の堅牢性	25	21
+4. 保守性・クリーン度	25	18
+総合	100	72
+1. コードの共通化とDRY原則
+得点
+
+18 / 25
+
+減点 -7
+-3点
+
+画面ごとの肥大化によるロジック重複リスク
+
+確認した時点で以下が500行級。
+
+App.tsx (501行)
+HomeScreen.tsx (583行)
+SplitEditorScreen.tsx (588行)
+SettlementSummaryScreen.tsx (598行)
+
+これだけ大きいと、
+
+API呼び出し
+状態管理
+エラーハンドリング
+フォーマット処理
+
+が画面内に閉じ込められやすく、将来的に同様実装が増殖しやすい。
+
+-2点
+
+カスタムHookが少ない
+
+確認できたHook
+
+useIsWideLayout
+useReceiptJobs
+useResponsive
+
+程度。
+
+HomeScreenやSettlement系画面の状態管理量を考えると
+
+useSettlement()
+useReceiptScan()
+useReceiptSplit()
+
+のような業務単位Hookへの分離余地が大きい。
+
+-2点
+
+画面内関数数が多い
+
+特に
+
+HomeScreen
+SplitEditorScreen
+
+は画面イベントハンドラが多数存在。
+
+共通Util化できる部分が残っている。
+
+2. コンポーネント責務分割
+得点
+
+15 / 25
+
+減点 -10
+
+ここが最大の弱点。
+
+-4点
+
+App.tsxが大きすぎる
+
+501行。
+
+実質的に
+
+画面遷移
+認証
+初期化
+状態管理
+
+を全部持っている。
+
+React Navigation未導入なら仕方ない部分もあるが、
+
+現在の規模では限界。
+
+-3点
+
+ScreenがContainer化している
+
+例えば
+
+HomeScreen
+
+には
+
+UI
+API呼び出し
+権限処理
+画像選択
+状態管理
+
+が混在。
+
+理想は
+
+HomeScreen
+ ├ HomeView
+ ├ useHomeScreen
+ ├ useReceiptUpload
+ └ useImagePicker
+
+レベル。
+
+-2点
+
+Settlement系機能の凝集度が高い
+
+SplitEditorScreen
+
+SettlementSummaryScreen
+
+がそれぞれ約600行。
+
+業務ルール変更時に修正箇所が大きくなる。
+
+-1点
+
+Component数がやや少ない
+
+画面15に対してコンポーネント17。
+
+比率的に画面への集中が見える。
+
+3. 型定義の堅牢性と一元管理
+得点
+
+21 / 25
+
+減点 -4
+
+ここは比較的良い。
+
+良い点
+
+型定義フォルダが存在
+
+types/
+  auth.ts
+  receipt.ts
+  receiptScan.ts
+  settlement.ts
+
+に集約されている。
+
+良い点
+
+any乱用は見られない
+
+全体検索で
+
+any
+
+の出現は少数。
+
+かなり抑制されている。
+
+-2点
+
+一部でany使用
+
+確認箇所例
+
+PromptEditorScreen
+middleware
+prisma関連
+
+など。
+
+件数は少ないがゼロではない。
+
+-1点
+
+画面内部interfaceが残っている
+
+例
+
+interface HomeScreenProps
+
+など。
+
+規模がさらに増えるなら
+
+types/screens/
+
+へ集約した方がよい。
+
+-1点
+
+API DTOの境界が弱い
+
+Frontend型
+
+Backend型
+
+Prisma型
+
+が完全共有ではない。
+
+将来的にOpenAPI生成などへ進める余地あり。
+
+4. 保守性とクリーン度
+得点
+
+18 / 25
+
+減点 -7
+-3点
+
+画面単位の結合度が高い
+
+特に
+
+Home
+Settlement
+ReceiptScan
+
+周辺。
+
+状態が画面内に集中している。
+
+修正影響範囲の見通しが悪くなる。
+
+-2点
+
+機能別モジュール分割が不十分
+
+現在は
+
+screens
+components
+api
+utils
+
+中心。
+
+規模拡大時は
+
+features/
+  settlement/
+  receipt/
+  statistics/
+
+へ移行した方が保守しやすい。
+
+-1点
+
+テスト比率が低い
+
+確認できた大型テストは
+
+app.integration.test.ts
+
+中心。
+
+業務ロジックのユニットテストが少ない。
+
+-1点
+
+Context利用が限定的
+
+ReceiptTrayContextは存在するが、
+
+画面規模からすると状態共有戦略がまだ弱い。
+
+このプロジェクトで最優先の改善Issue
+
+優先順位順。
+
+Issue 1
+
+Settlement機能を分解
+
+対象
+
+SplitEditorScreen
+SettlementSummaryScreen
+
+期待効果
+
+約1200行削減
+保守性大幅向上
+Issue 2
+
+HomeScreen分解
+
+対象
+
+画像取得
+API処理
+画面表示
+
+をHook化
+
+Issue 3
+
+App.tsx解体
+
+認証管理
+
+初期化
+
+画面遷移
+
+を分離
+
+Issue 4
+
+Feature構成へ移行
+
+現状
+
+screens/
+components/
+utils/
+
+↓
+
+推奨
+
+features/
+  receipt/
+  settlement/
+  statistics/
+Issue 5
+
+型の共有化
+
+Backend DTO
+
+Frontend DTO
+
+OpenAPI生成
+
+または共有パッケージ化。
+
+結論
+
+このZIPの実装品質は、
+
+「個人開発〜小規模チームとしては良好」
+ですが、
+
+「非AIネイティブの第三者が3年保守する前提」
+で見ると、
+
+最大の問題は型ではなく 画面肥大化（500〜600行級Screenの存在） です。
+
+厳格採点では 72/100点。
+
+現時点では「破綻しているコードベース」ではありませんが、Settlement系とHome系を中心に責務分割を行わないまま機能追加を続けると、1年後には保守コストが急増する構造に入っています。

--- a/docs/specs/chatgpt/ChatGPT_レビュー_20260621.txt
+++ b/docs/specs/chatgpt/ChatGPT_レビュー_20260621.txt
@@ -1,0 +1,405 @@
+現在React Native (Expo), TypeScript, PostgreSQLで構築中のアプリ「RecAIpt」のソースコード一式です。
+
+人間による細部レビューを一切排除した『真の品質ガバナンス』の検証として、以下の4観点から【100点満点からの厳格な減点方式】でシビアに採点してください。
+冗長な褒め言葉や配慮は一切不要です。将来の保守者（非AIネイティブな人間）への引き継ぎに耐えうるかという視点で、具体的な減点理由と改善ポイントをストレートに提示してください。
+
+【評価観点】
+1. コードの共通化とDRY原則（25点）: 微調整の連発によって、似たロジックやインラインコードが重複・コピペされていないか。
+2. コンポーネントの責務分割（25点）: 1つのファイルにロジック、UI、データ処理が詰め込まれすぎ、ファイルが肥大化していないか。
+3. 型定義の堅牢性と一元管理（25点）: Anyの乱用や不適切なアサーションがなく、型が適切に共通化されているか。
+4. 保守性とクリーン度（25点）: 結合度が強すぎて、将来の修正で別画面に予期せぬバグを誘発しやすくないか。
+思考を停止しました
+
+ZIPを実際に展開してソース構成を確認した上で採点します。
+
+対象概要
+
+React Native (Expo) + TypeScript
+Backend: Node.js + Prisma + PostgreSQL
+ソース総数：約434ファイル
+TypeScript系：約242ファイル
+総合評価
+観点	配点	得点
+1. DRY原則・共通化	25	19
+2. 責務分割	25	17
+3. 型定義の堅牢性	25	20
+4. 保守性・クリーン度	25	18
+合計	100	74
+1. コードの共通化とDRY原則
+得点
+
+19 / 25
+
+減点 -6
+-2点
+
+画面単位で独自型を再定義している
+
+例
+
+StatisticsScreen.tsx
+
+interface Category
+interface StatItem
+interface ReceiptItem
+interface ReceiptInfo
+interface MonthlyData
+
+これらが画面内ローカル定義になっている。
+
+本来は
+
+types/
+models/
+dto/
+
+へ集約すべき。
+
+-2点
+
+APIレスポンス変換ロジックが複数箇所に散在
+
+特に
+
+receipt
+statistics
+settlement
+
+周辺で同じデータ加工パターンが見える。
+
+Mapper層が薄い。
+
+-1点
+
+画面ごとのStyleSheet定義量が多い
+
+コンポーネント共通化が進んでいるものの、
+
+screen固有UI
+
+が増え始めている。
+
+今後画面が20→50になるとスタイル重複が増える。
+
+-1点
+
+エラーハンドリング文言が各画面に残っている
+
+Alert
+showAlert
+
+の利用はあるが完全統一ではない。
+
+評価
+
+初期開発段階としては良好。
+
+ただし
+
+「機能追加に追われて後から共通化する」
+
+典型パターンに入り始めている。
+
+2. コンポーネントの責務分割
+得点
+
+17 / 25
+
+減点 -8
+-3点
+
+LoginScreen.tsx
+
+約487行
+
+責務
+
+招待コード入力
+メンバー選択
+パスワード認証
+TOTP設定
+TOTP認証
+
+全部入り。
+
+-2点
+
+HomeScreen.tsx
+
+約423行
+
+本来
+
+DashboardView
+TrayView
+MenuView
+
+へ分離可能。
+
+-2点
+
+ReceiptDetailComponent.tsx
+
+約383行
+
+データ表示＋UI制御が混在。
+
+-1点
+
+StatisticsScreen.tsx
+
+約342行
+
+統計ロジックと表示ロジックが同居。
+
+良い点
+
+feature構成が導入されている。
+
+features/
+  app/
+  home/
+  settlement/
+
+は保守性向上に寄与。
+
+評価
+
+昔ながらの
+
+巨大Screen.tsx
+
+から脱却しようとしている途中段階。
+
+現時点ではまだ画面肥大化が目立つ。
+
+3. 型定義の堅牢性と一元管理
+得点
+
+20 / 25
+
+減点 -5
+-2点
+
+any利用あり
+
+確認できた箇所
+
+authMiddleware
+tenantMiddleware
+validate
+retry
+receiptWorker
+geminiService
+
+など。
+
+件数自体は多くない。
+
+-1点
+
+as any 使用
+
+完全にゼロではない。
+
+-1点
+
+型定義ファイル数が少ない
+
+確認できた共通型
+
+types/auth.ts
+types/receipt.ts
+types/receiptScan.ts
+types/settlement.ts
+
+程度。
+
+規模の割に不足。
+
+-1点
+
+DTOとDomain型の区別が弱い
+
+例えば
+
+APIレスポンス型
+画面表示型
+DB型
+
+が混ざりやすい構造。
+
+良い点
+
+大部分はTypeScriptが真面目に使われている。
+
+良い点
+
+generated schemaが存在
+
+frontend/src/api/generated/schema.ts
+
+を利用している。
+
+良い点
+
+any地獄にはなっていない。
+
+評価
+
+一般的な業務システム平均より上。
+
+TypeScript品質は比較的高い。
+
+4. 保守性とクリーン度
+得点
+
+18 / 25
+
+減点 -7
+-2点
+
+画面からAPIへの依存がまだ強い
+
+例
+
+categoryApi
+receiptApi
+statsApi
+
+を画面で直接扱う箇所がある。
+
+理想は
+
+Service
+UseCase
+Hook
+
+へ集約。
+
+-2点
+
+Repository層の肥大化傾向
+
+例
+
+receiptRepository.ts
+349行
+
+今後危険。
+
+-1点
+
+AuthController
+
+約359行
+
+認証周辺の責務が集中。
+
+-1点
+
+Integration Test
+
+app.integration.test.ts
+636行
+
+かなり巨大。
+
+テスト保守性が低下し始めている。
+
+-1点
+
+Feature境界が完全ではない
+
+現在
+
+screen
+component
+feature
+service
+api
+
+が混在。
+
+設計思想が過渡期。
+
+良い点
+
+以下はかなり評価できる。
+
+contexts
+hooks
+features
+generated api schema
+prisma
+repository
+service
+
+が導入済み。
+
+設計崩壊レベルではない。
+
+最も危険な箇所 TOP5
+
+優先度順。
+
+1位
+
+LoginScreen.tsx
+
+487行
+
+認証方式追加時に破綻しやすい。
+
+2位
+
+HomeScreen.tsx
+
+423行
+
+今後機能追加の受け皿になって肥大化する。
+
+3位
+
+ReceiptDetailComponent.tsx
+
+383行
+
+修正影響範囲が読みにくい。
+
+4位
+
+AuthController.ts
+
+359行
+
+認証ロジックの集約が過剰。
+
+5位
+
+StatisticsScreen.tsx
+
+342行
+
+集計ロジックをHookへ分離したい。
+
+結論
+
+このコードベースは
+
+「個人開発レベルを超え、業務開発レベルに入りつつある」
+
+一方で、
+
+「機能追加を優先した結果、Screen肥大化が始まっている段階」
+
+です。
+
+厳しめに採点すると 74/100点。
+
+現時点で全面リファクタリングは不要ですが、次のフェーズで
+
+Screen分割
+型定義集約
+UseCase層追加
+DTO/Domain分離


### PR DESCRIPTION
## Summary

- `docs/refactor/plan.md` に Epic #100（Phase 3）§7 を追加し、GitHub Issue #423〜#440 との対応表・着手順・Won't fix を記録
- ChatGPT 品質レビュー原文を追加
  - `docs/specs/chatgpt/ChatGPT_レビュー_20260620.txt`（リファクタ前・72点）
  - `docs/specs/chatgpt/ChatGPT_レビュー_20260621.txt`（リファクタ後・74点）

## 関連 Issue

- Epic: #423
- 本 PR: #424（#100-0）

## Test plan

- [x] plan.md の Markdown 表・リンクが正しいこと
- [x] 追加 txt ファイルがリポジトリに含まれること
- [ ] マージ後 #424 をクローズ


Made with [Cursor](https://cursor.com)