### PR TITLE
refactor(auth): [Issue #100-1] authService 本実装と authController 薄型化

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,358 +1,59 @@
 import { Request, Response, NextFunction } from 'express';
-import bcrypt from 'bcrypt';
-import { Role } from '@prisma/client';
+import { JWTPayload } from '../utils/auth';
 import {
-  generateAccessToken,
-  generatePendingToken,
-  JWTPayload,
-} from '../utils/auth';
-import { prisma } from '../utils/prismaClient';
-import { AppError } from '../utils/appError';
-import {
-  buildOtpauthUrl,
-  decryptSecretFromStorage,
-  encryptSecretForStorage,
-  generateTotpSecret,
-  isTotpRequiredForRole,
-  verifyTotpCode,
-} from '../services/totpService';
+  confirmTotpSetupForMember,
+  disableTotpForMember,
+  listFamilyMembersForInvite,
+  loginMember,
+  resolveFamilyByInviteCode,
+  startTotpSetupForMember,
+  verifyTotpForMember,
+} from '../services/authService';
 import { getRouteParam } from '../utils/routeParams';
 
 type AuthUser = JWTPayload;
 
-function formatMember(member: {
-  id: number;
-  name: string;
-  familyGroupId: number;
-  role: Role;
-  totpEnabled: boolean;
-}) {
-  return {
-    id: member.id,
-    name: member.name,
-    familyGroupId: member.familyGroupId,
-    role: member.role,
-    totpEnabled: member.totpEnabled,
+const ok = <T>(res: Response, data: T) => res.status(200).json({ success: true, data });
+
+const getAuthUser = (req: Request): AuthUser => (req as Request & { user: AuthUser }).user;
+
+const handle =
+  (fn: (req: Request, res: Response) => Promise<unknown>) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      ok(res, await fn(req, res));
+    } catch (error) {
+      next(error);
+    }
   };
-}
 
-function buildAccessResponse(member: {
-  id: number;
-  name: string;
-  familyGroupId: number;
-  role: Role;
-  totpEnabled: boolean;
-}) {
-  const memberDto = formatMember(member);
-  return {
-    token: generateAccessToken({
-      id: member.id,
-      name: member.name,
-      familyGroupId: member.familyGroupId,
-      role: member.role,
-    }),
-    pendingToken: null,
-    member: memberDto,
-    requiresTotpVerification: false,
-    requiresTotpSetup: false,
-  };
-}
+export const resolveFamily = handle(async (req) => {
+  const { inviteCode } = req.body;
+  return resolveFamilyByInviteCode(typeof inviteCode === 'string' ? inviteCode : '');
+});
 
-export const resolveFamily = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { inviteCode } = req.body;
+export const getFamilyMembers = handle(async (req) => {
+  const familyGroupId = parseInt(getRouteParam(req, 'familyGroupId'), 10);
+  const inviteCode = typeof req.query.inviteCode === 'string' ? req.query.inviteCode : '';
+  return listFamilyMembersForInvite(familyGroupId, inviteCode);
+});
 
-    if (!inviteCode || typeof inviteCode !== 'string' || !inviteCode.trim()) {
-      throw new AppError('招待コードを入力してください。', 400);
-    }
+export const login = handle(async (req) => loginMember(req.body));
 
-    const familyGroup = await prisma.familyGroup.findUnique({
-      where: { inviteCode: inviteCode.trim() },
-      select: { id: true, name: true },
-    });
+export const startTotpSetup = handle(async (req) => startTotpSetupForMember(getAuthUser(req).id));
 
-    if (!familyGroup) {
-      throw new AppError('招待コードが正しくありません。', 404);
-    }
+export const confirmTotpSetup = handle(async (req) => {
+  const user = getAuthUser(req);
+  const { code } = req.body;
+  return confirmTotpSetupForMember(user.id, typeof code === 'string' ? code : '', user.purpose ?? 'access');
+});
 
-    res.status(200).json({
-      success: true,
-      data: {
-        familyGroupId: familyGroup.id,
-        name: familyGroup.name,
-      },
-    });
-  } catch (error) {
-    next(error);
-  }
-};
+export const verifyTotp = handle(async (req) => {
+  const { code } = req.body;
+  return verifyTotpForMember(getAuthUser(req).id, typeof code === 'string' ? code : '');
+});
 
-export const getFamilyMembers = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const familyGroupId = parseInt(getRouteParam(req, 'familyGroupId'), 10);
-    const inviteCode = typeof req.query.inviteCode === 'string' ? req.query.inviteCode.trim() : '';
-
-    if (Number.isNaN(familyGroupId)) {
-      throw new AppError('世帯IDが不正です。', 400);
-    }
-
-    if (!inviteCode) {
-      throw new AppError('招待コードを指定してください。', 400);
-    }
-
-    const familyGroup = await prisma.familyGroup.findFirst({
-      where: { id: familyGroupId, inviteCode },
-      select: { id: true },
-    });
-
-    if (!familyGroup) {
-      throw new AppError('世帯が見つからないか、招待コードが一致しません。', 404);
-    }
-
-    const members = await prisma.familyMember.findMany({
-      where: { familyGroupId },
-      select: { id: true, name: true },
-      orderBy: { id: 'asc' },
-    });
-
-    res.status(200).json({
-      success: true,
-      data: members,
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const login = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId, memberId, password } = req.body;
-
-    if (!familyGroupId || !memberId || !password) {
-      throw new AppError('世帯ID、メンバーID、パスワードを入力してください。', 400);
-    }
-
-    const parsedFamilyGroupId = parseInt(familyGroupId, 10);
-    const parsedMemberId = parseInt(memberId, 10);
-
-    if (Number.isNaN(parsedFamilyGroupId) || Number.isNaN(parsedMemberId)) {
-      throw new AppError('世帯IDまたはメンバーIDが不正です。', 400);
-    }
-
-    const member = await prisma.familyMember.findUnique({
-      where: { id: parsedMemberId },
-      include: { familyGroup: true },
-    });
-
-    if (!member || !member.familyGroup) {
-      throw new AppError('指定されたメンバーまたは世帯が見つかりません。', 404);
-    }
-
-    if (member.familyGroupId !== parsedFamilyGroupId) {
-      throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
-    }
-
-    if (!member.password_hash) {
-      throw new AppError('パスワードが設定されていません。管理者に連絡してください。', 403);
-    }
-
-    const isMatch = await bcrypt.compare(password, member.password_hash);
-    if (!isMatch) {
-      throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
-    }
-
-    const tokenInput = {
-      id: member.id,
-      name: member.name,
-      familyGroupId: member.familyGroupId,
-      role: member.role,
-    };
-    const memberDto = formatMember(member);
-
-    if (member.totpEnabled) {
-      res.status(200).json({
-        success: true,
-        data: {
-          token: null,
-          pendingToken: generatePendingToken(tokenInput, 'totp_pending'),
-          member: memberDto,
-          requiresTotpVerification: true,
-          requiresTotpSetup: false,
-        },
-      });
-      return;
-    }
-
-    if (isTotpRequiredForRole(member.role)) {
-      res.status(200).json({
-        success: true,
-        data: {
-          token: null,
-          pendingToken: generatePendingToken(tokenInput, 'totp_setup'),
-          member: memberDto,
-          requiresTotpVerification: false,
-          requiresTotpSetup: true,
-        },
-      });
-      return;
-    }
-
-    res.status(200).json({
-      success: true,
-      data: buildAccessResponse(member),
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/** TOTP セットアップ開始（pending setup またはログイン済みメンバー） */
-export const startTotpSetup = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const user = (req as Request & { user: AuthUser }).user;
-    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
-    if (!member) {
-      throw new AppError('メンバーが見つかりません。', 404);
-    }
-    if (member.totpEnabled) {
-      throw new AppError('二要素認証は既に有効です。', 400);
-    }
-
-    const secret = generateTotpSecret();
-    await prisma.familyMember.update({
-      where: { id: member.id },
-      data: {
-        totpSecret: encryptSecretForStorage(secret),
-        totpEnabled: false,
-        totpVerifiedAt: null,
-      },
-    });
-
-    res.status(200).json({
-      success: true,
-      data: {
-        secret,
-        otpauthUrl: buildOtpauthUrl(member.name, secret),
-      },
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/** TOTP セットアップ完了 → フル JWT 発行（setup 時）または有効化のみ */
-export const confirmTotpSetup = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const user = (req as Request & { user: AuthUser }).user;
-    const { code } = req.body;
-    if (!code || typeof code !== 'string') {
-      throw new AppError('認証コードを入力してください。', 400);
-    }
-
-    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
-    if (!member?.totpSecret) {
-      throw new AppError('二要素認証のセットアップが開始されていません。', 400);
-    }
-    if (member.totpEnabled) {
-      throw new AppError('二要素認証は既に有効です。', 400);
-    }
-
-    const secret = decryptSecretFromStorage(member.totpSecret);
-    if (!verifyTotpCode(secret, code.trim())) {
-      throw new AppError('認証コードが正しくありません。', 401);
-    }
-
-    const updated = await prisma.familyMember.update({
-      where: { id: member.id },
-      data: {
-        totpEnabled: true,
-        totpVerifiedAt: new Date(),
-      },
-    });
-
-    const memberDto = formatMember(updated);
-    const isSetupFlow = user.purpose === 'totp_setup';
-
-    res.status(200).json({
-      success: true,
-      data: isSetupFlow
-        ? buildAccessResponse(updated)
-        : { member: memberDto, totpEnabled: true },
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/** ログイン時 TOTP 検証 */
-export const verifyTotp = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const user = (req as Request & { user: AuthUser }).user;
-    const { code } = req.body;
-    if (!code || typeof code !== 'string') {
-      throw new AppError('認証コードを入力してください。', 400);
-    }
-
-    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
-    if (!member?.totpEnabled || !member.totpSecret) {
-      throw new AppError('二要素認証が有効ではありません。', 400);
-    }
-
-    const secret = decryptSecretFromStorage(member.totpSecret);
-    if (!verifyTotpCode(secret, code.trim())) {
-      throw new AppError('認証コードが正しくありません。', 401);
-    }
-
-    res.status(200).json({
-      success: true,
-      data: buildAccessResponse(member),
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-/** 二要素認証を無効化（必須ロールでは拒否） */
-export const disableTotp = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const user = (req as Request & { user: AuthUser }).user;
-    const { password, code } = req.body;
-    if (!password || !code) {
-      throw new AppError('パスワードと認証コードを入力してください。', 400);
-    }
-
-    const member = await prisma.familyMember.findUnique({ where: { id: user.id } });
-    if (!member?.password_hash || !member.totpEnabled || !member.totpSecret) {
-      throw new AppError('二要素認証が有効ではありません。', 400);
-    }
-    if (isTotpRequiredForRole(member.role)) {
-      throw new AppError('二要素認証は必須のため無効にできません。', 403);
-    }
-
-    const passwordOk = await bcrypt.compare(password, member.password_hash);
-    if (!passwordOk) {
-      throw new AppError('パスワードが正しくありません。', 401);
-    }
-
-    const secret = decryptSecretFromStorage(member.totpSecret);
-    if (!verifyTotpCode(secret, String(code).trim())) {
-      throw new AppError('認証コードが正しくありません。', 401);
-    }
-
-    await prisma.familyMember.update({
-      where: { id: member.id },
-      data: {
-        totpSecret: null,
-        totpEnabled: false,
-        totpVerifiedAt: null,
-      },
-    });
-
-    res.status(200).json({
-      success: true,
-      data: { totpEnabled: false },
-    });
-  } catch (error) {
-    next(error);
-  }
-};
+export const disableTotp = handle(async (req) => {
+  const { password, code } = req.body;
+  return disableTotpForMember(getAuthUser(req).id, String(password ?? ''), String(code ?? ''));
+});

--- a/backend/src/repositories/memberRepository.ts
+++ b/backend/src/repositories/memberRepository.ts
@@ -1,0 +1,66 @@
+import { prisma } from '../utils/prismaClient';
+
+export async function findFamilyGroupByInviteCode(inviteCode: string) {
+  return prisma.familyGroup.findUnique({
+    where: { inviteCode },
+    select: { id: true, name: true },
+  });
+}
+
+export async function findFamilyGroupByIdAndInviteCode(familyGroupId: number, inviteCode: string) {
+  return prisma.familyGroup.findFirst({
+    where: { id: familyGroupId, inviteCode },
+    select: { id: true },
+  });
+}
+
+export async function findMembersByFamilyGroupId(familyGroupId: number) {
+  return prisma.familyMember.findMany({
+    where: { familyGroupId },
+    select: { id: true, name: true },
+    orderBy: { id: 'asc' },
+  });
+}
+
+export async function findMemberByIdWithFamily(memberId: number) {
+  return prisma.familyMember.findUnique({
+    where: { id: memberId },
+    include: { familyGroup: true },
+  });
+}
+
+export async function findMemberById(memberId: number) {
+  return prisma.familyMember.findUnique({ where: { id: memberId } });
+}
+
+export async function saveMemberTotpSetup(memberId: number, encryptedSecret: string) {
+  return prisma.familyMember.update({
+    where: { id: memberId },
+    data: {
+      totpSecret: encryptedSecret,
+      totpEnabled: false,
+      totpVerifiedAt: null,
+    },
+  });
+}
+
+export async function enableMemberTotp(memberId: number) {
+  return prisma.familyMember.update({
+    where: { id: memberId },
+    data: {
+      totpEnabled: true,
+      totpVerifiedAt: new Date(),
+    },
+  });
+}
+
+export async function disableMemberTotp(memberId: number) {
+  return prisma.familyMember.update({
+    where: { id: memberId },
+    data: {
+      totpSecret: null,
+      totpEnabled: false,
+      totpVerifiedAt: null,
+    },
+  });
+}

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,18 +1,282 @@
-// backend/src/utils/auth.ts (または services/authService.ts)
-import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import { Role } from '@prisma/client';
+import { AppError } from '../utils/appError';
+import {
+  generateAccessToken,
+  generatePendingToken,
+  type TokenPurpose,
+} from '../utils/auth';
+import {
+  buildOtpauthUrl,
+  decryptSecretFromStorage,
+  encryptSecretForStorage,
+  generateTotpSecret,
+  isTotpRequiredForRole,
+  verifyTotpCode,
+} from './totpService';
+import {
+  disableMemberTotp,
+  enableMemberTotp,
+  findFamilyGroupByIdAndInviteCode,
+  findFamilyGroupByInviteCode,
+  findMemberById,
+  findMemberByIdWithFamily,
+  findMembersByFamilyGroupId,
+  saveMemberTotpSetup,
+} from '../repositories/memberRepository';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-
-export const generateToken = (payload: object): string => {
-  // 30年選手なら「有効期限」の重要性はご承知の通り。
-  // ここでは 7日間（7d）などで署名します。
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: '7d' });
+export type AuthMemberDto = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
 };
 
-export const verifyToken = (token: string) => {
-  try {
-    return jwt.verify(token, JWT_SECRET);
-  } catch (err) {
-    return null;
+export type AccessLoginData = {
+  token: string;
+  pendingToken: null;
+  member: AuthMemberDto;
+  requiresTotpVerification: false;
+  requiresTotpSetup: false;
+};
+
+export type PendingLoginData = {
+  token: null;
+  pendingToken: string;
+  member: AuthMemberDto;
+  requiresTotpVerification: boolean;
+  requiresTotpSetup: boolean;
+};
+
+type AuthMemberRecord = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
+  password_hash?: string | null;
+  totpSecret?: string | null;
+};
+
+function formatMember(member: AuthMemberRecord): AuthMemberDto {
+  return {
+    id: member.id,
+    name: member.name,
+    familyGroupId: member.familyGroupId,
+    role: member.role,
+    totpEnabled: member.totpEnabled,
+  };
+}
+
+function buildAccessResponse(member: AuthMemberRecord): AccessLoginData {
+  return {
+    token: generateAccessToken({
+      id: member.id,
+      name: member.name,
+      familyGroupId: member.familyGroupId,
+      role: member.role,
+    }),
+    pendingToken: null,
+    member: formatMember(member),
+    requiresTotpVerification: false,
+    requiresTotpSetup: false,
+  };
+}
+
+function buildPendingResponse(
+  member: AuthMemberRecord,
+  purpose: 'totp_pending' | 'totp_setup'
+): PendingLoginData {
+  const tokenInput = {
+    id: member.id,
+    name: member.name,
+    familyGroupId: member.familyGroupId,
+    role: member.role,
+  };
+
+  return {
+    token: null,
+    pendingToken: generatePendingToken(tokenInput, purpose),
+    member: formatMember(member),
+    requiresTotpVerification: purpose === 'totp_pending',
+    requiresTotpSetup: purpose === 'totp_setup',
+  };
+}
+
+export async function resolveFamilyByInviteCode(inviteCode: string) {
+  const trimmed = inviteCode.trim();
+  if (!trimmed) {
+    throw new AppError('招待コードを入力してください。', 400);
   }
-};
+
+  const familyGroup = await findFamilyGroupByInviteCode(trimmed);
+  if (!familyGroup) {
+    throw new AppError('招待コードが正しくありません。', 404);
+  }
+
+  return {
+    familyGroupId: familyGroup.id,
+    name: familyGroup.name,
+  };
+}
+
+export async function listFamilyMembersForInvite(familyGroupId: number, inviteCode: string) {
+  if (Number.isNaN(familyGroupId)) {
+    throw new AppError('世帯IDが不正です。', 400);
+  }
+
+  const trimmedInviteCode = inviteCode.trim();
+  if (!trimmedInviteCode) {
+    throw new AppError('招待コードを指定してください。', 400);
+  }
+
+  const familyGroup = await findFamilyGroupByIdAndInviteCode(familyGroupId, trimmedInviteCode);
+  if (!familyGroup) {
+    throw new AppError('世帯が見つからないか、招待コードが一致しません。', 404);
+  }
+
+  return findMembersByFamilyGroupId(familyGroupId);
+}
+
+export async function loginMember(input: {
+  familyGroupId: unknown;
+  memberId: unknown;
+  password: unknown;
+}): Promise<AccessLoginData | PendingLoginData> {
+  const { familyGroupId, memberId, password } = input;
+
+  if (!familyGroupId || !memberId || !password) {
+    throw new AppError('世帯ID、メンバーID、パスワードを入力してください。', 400);
+  }
+
+  const parsedFamilyGroupId = parseInt(String(familyGroupId), 10);
+  const parsedMemberId = parseInt(String(memberId), 10);
+
+  if (Number.isNaN(parsedFamilyGroupId) || Number.isNaN(parsedMemberId)) {
+    throw new AppError('世帯IDまたはメンバーIDが不正です。', 400);
+  }
+
+  const member = await findMemberByIdWithFamily(parsedMemberId);
+  if (!member || !member.familyGroup) {
+    throw new AppError('指定されたメンバーまたは世帯が見つかりません。', 404);
+  }
+
+  if (member.familyGroupId !== parsedFamilyGroupId) {
+    throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
+  }
+
+  if (!member.password_hash) {
+    throw new AppError('パスワードが設定されていません。管理者に連絡してください。', 403);
+  }
+
+  const isMatch = await bcrypt.compare(String(password), member.password_hash);
+  if (!isMatch) {
+    throw new AppError('メンバーIDまたはパスワードが正しくありません。', 401);
+  }
+
+  if (member.totpEnabled) {
+    return buildPendingResponse(member, 'totp_pending');
+  }
+
+  if (isTotpRequiredForRole(member.role)) {
+    return buildPendingResponse(member, 'totp_setup');
+  }
+
+  return buildAccessResponse(member);
+}
+
+export async function startTotpSetupForMember(memberId: number) {
+  const member = await findMemberById(memberId);
+  if (!member) {
+    throw new AppError('メンバーが見つかりません。', 404);
+  }
+  if (member.totpEnabled) {
+    throw new AppError('二要素認証は既に有効です。', 400);
+  }
+
+  const secret = generateTotpSecret();
+  await saveMemberTotpSetup(member.id, encryptSecretForStorage(secret));
+
+  return {
+    secret,
+    otpauthUrl: buildOtpauthUrl(member.name, secret),
+  };
+}
+
+export async function confirmTotpSetupForMember(
+  memberId: number,
+  code: string,
+  purpose: TokenPurpose
+): Promise<AccessLoginData | { member: AuthMemberDto; totpEnabled: true }> {
+  if (!code.trim()) {
+    throw new AppError('認証コードを入力してください。', 400);
+  }
+
+  const member = await findMemberById(memberId);
+  if (!member?.totpSecret) {
+    throw new AppError('二要素認証のセットアップが開始されていません。', 400);
+  }
+  if (member.totpEnabled) {
+    throw new AppError('二要素認証は既に有効です。', 400);
+  }
+
+  const secret = decryptSecretFromStorage(member.totpSecret);
+  if (!verifyTotpCode(secret, code.trim())) {
+    throw new AppError('認証コードが正しくありません。', 401);
+  }
+
+  const updated = await enableMemberTotp(member.id);
+  const memberDto = formatMember(updated);
+
+  if (purpose === 'totp_setup') {
+    return buildAccessResponse(updated);
+  }
+
+  return { member: memberDto, totpEnabled: true };
+}
+
+export async function verifyTotpForMember(memberId: number, code: string): Promise<AccessLoginData> {
+  if (!code.trim()) {
+    throw new AppError('認証コードを入力してください。', 400);
+  }
+
+  const member = await findMemberById(memberId);
+  if (!member?.totpEnabled || !member.totpSecret) {
+    throw new AppError('二要素認証が有効ではありません。', 400);
+  }
+
+  const secret = decryptSecretFromStorage(member.totpSecret);
+  if (!verifyTotpCode(secret, code.trim())) {
+    throw new AppError('認証コードが正しくありません。', 401);
+  }
+
+  return buildAccessResponse(member);
+}
+
+export async function disableTotpForMember(memberId: number, password: string, code: string) {
+  if (!password || !code) {
+    throw new AppError('パスワードと認証コードを入力してください。', 400);
+  }
+
+  const member = await findMemberById(memberId);
+  if (!member?.password_hash || !member.totpEnabled || !member.totpSecret) {
+    throw new AppError('二要素認証が有効ではありません。', 400);
+  }
+  if (isTotpRequiredForRole(member.role)) {
+    throw new AppError('二要素認証は必須のため無効にできません。', 403);
+  }
+
+  const passwordOk = await bcrypt.compare(password, member.password_hash);
+  if (!passwordOk) {
+    throw new AppError('パスワードが正しくありません。', 401);
+  }
+
+  const secret = decryptSecretFromStorage(member.totpSecret);
+  if (!verifyTotpCode(secret, String(code).trim())) {
+    throw new AppError('認証コードが正しくありません。', 401);
+  }
+
+  await disableMemberTotp(member.id);
+  return { totpEnabled: false as const };
+}


### PR DESCRIPTION
## Summary

- `memberRepository.ts` を新設し、FamilyGroup / FamilyMember の DB アクセスを集約
- `authService.ts` を本実装（resolve / login / TOTP setup・verify・disable）
- `authController.ts` を 358行 → 59行に縮小（Prisma 直叩き 0 件）

## 関連 Issue

- Epic: #423
- Closes #425

## Acceptance Criteria

- [x] Controller 内に `prisma.` 直叩き 0 件
- [x] 認証フロー 5 step が integration test で通過
- [x] `npm test`（backend）通過

## Test plan

- [x] `npm test`（backend）— 43 passed
- [ ] マージ後、Web / Native でログインフロー目視確認


Made with [Cursor](https://cursor.com)