### PR TITLE
refactor(backend): [Issue #100-3] 残存 Prisma 直叩きを Repository 経由に統一

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import { prisma } from '../utils/prismaClient';
 import { AppError } from '../utils/appError';
 import { receiptQueue } from '../queues/receiptQueue';
+import { findCategoriesByFamilyGroup } from '../repositories/categoryRepository';
 import {
   enrichCompletedJobPayload,
   listReceiptJobsForMember,
@@ -74,7 +74,8 @@ export const discardReceiptJob = async (req: Request<{ jobId: string }>, res: Re
 
 export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } });
+    const { familyGroupId } = requireTenantContext();
+    const categories = await findCategoriesByFamilyGroup(familyGroupId);
     res.json({ success: true, data: categories });
   } catch (error) {
     next(error);

--- a/backend/src/repositories/apiUsageLogRepository.ts
+++ b/backend/src/repositories/apiUsageLogRepository.ts
@@ -1,0 +1,51 @@
+import { prisma } from '../utils/prismaClient';
+
+export async function createApiUsageLog(data: {
+  familyMemberId: number | null;
+  modelId: string;
+  promptTokens: number;
+  candidatesTokens: number;
+  totalTokens: number;
+}) {
+  return prisma.apiUsageLog.create({ data });
+}
+
+export async function incrementApiUsageLogTokens(
+  id: number,
+  tokens: {
+    promptTokens: number;
+    candidatesTokens: number;
+    totalTokens: number;
+  }
+) {
+  return prisma.apiUsageLog.update({
+    where: { id },
+    data: {
+      promptTokens: { increment: tokens.promptTokens },
+      candidatesTokens: { increment: tokens.candidatesTokens },
+      totalTokens: { increment: tokens.totalTokens },
+    },
+  });
+}
+
+export async function queryAdminCostStatsByFamilyGroup(familyGroupId: number) {
+  return prisma.$queryRaw<
+    Array<{
+      month: string;
+      modelId: string;
+      totalPromptTokens: number;
+      totalCandidatesTokens: number;
+    }>
+  >`
+    SELECT
+      TO_CHAR(l."createdAt", 'YYYY-MM') AS month,
+      l."modelId",
+      SUM(l."promptTokens")::int AS "totalPromptTokens",
+      SUM(l."candidatesTokens")::int AS "totalCandidatesTokens"
+    FROM "ApiUsageLog" l
+    INNER JOIN "FamilyMember" fm ON l."familyMemberId" = fm.id
+    WHERE fm."familyGroupId" = ${familyGroupId}
+    GROUP BY month, l."modelId"
+    ORDER BY month DESC;
+  `;
+}

--- a/backend/src/repositories/categoryRepository.ts
+++ b/backend/src/repositories/categoryRepository.ts
@@ -1,4 +1,5 @@
 import { prisma } from '../utils/prismaClient';
+import type { PrismaTx } from '../utils/prismaTransaction';
 
 export async function findCategoriesByFamilyGroup(familyGroupId: number) {
   return prisma.category.findMany({
@@ -45,5 +46,25 @@ export async function updateCategoryKeywords(categoryId: number, keywords: strin
   return prisma.category.update({
     where: { id: categoryId },
     data: { keywords },
+  });
+}
+
+export async function findCategoryIdByKeywordInTx(
+  tx: PrismaTx,
+  familyGroupId: number,
+  itemName: string
+) {
+  return tx.$queryRaw<{ id: number }[]>`
+    SELECT c.id FROM "Category" c, jsonb_array_elements_text(c.keywords) AS kw
+    WHERE c."familyGroupId" = ${familyGroupId}
+      AND ${itemName} LIKE '%' || kw || '%'
+    LIMIT 1;
+  `;
+}
+
+export async function findFallbackCategoryIdInTx(tx: PrismaTx, familyGroupId: number) {
+  return tx.category.findFirst({
+    where: { familyGroupId, name: 'その他' },
+    select: { id: true },
   });
 }

--- a/backend/src/repositories/productMasterRepository.ts
+++ b/backend/src/repositories/productMasterRepository.ts
@@ -23,6 +23,38 @@ export async function findProductMasterByIdAndFamilyGroup(id: number, familyGrou
   });
 }
 
+export async function findProductMasterByCompositeKey(
+  name: string,
+  storeName: string,
+  familyGroupId: number
+) {
+  return prisma.productMaster.findUnique({
+    where: {
+      name_storeName_familyGroupId: { name, storeName, familyGroupId },
+    },
+  });
+}
+
+export async function findProductMasterForEstimateInTx(
+  tx: PrismaTx,
+  input: { name: string; storeName: string; familyGroupId: number }
+) {
+  return tx.productMaster.findFirst({
+    where: { name: input.name, storeName: input.storeName, familyGroupId: input.familyGroupId },
+    select: { categoryId: true },
+  });
+}
+
+export async function findProductMasterByNameInTx(
+  tx: PrismaTx,
+  input: { name: string; familyGroupId: number }
+) {
+  return tx.productMaster.findFirst({
+    where: { name: input.name, familyGroupId: input.familyGroupId },
+    select: { categoryId: true },
+  });
+}
+
 export async function updateProductMasterRecord(
   id: number,
   data: { name: string; storeName: string; categoryId: number }

--- a/backend/src/repositories/promptRepository.ts
+++ b/backend/src/repositories/promptRepository.ts
@@ -1,0 +1,82 @@
+import { prisma } from '../utils/prismaClient';
+
+export async function findPromptTemplatesByFamilyGroup(familyGroupId: number) {
+  return prisma.promptTemplate.findMany({
+    where: { familyGroupId },
+    orderBy: [{ key: 'asc' }, { isActive: 'desc' }, { updatedAt: 'desc' }],
+  });
+}
+
+export async function findAllPromptTemplatesForSync(familyGroupId: number) {
+  return prisma.promptTemplate.findMany({
+    where: { familyGroupId },
+    orderBy: { id: 'asc' },
+  });
+}
+
+export async function findActivePromptTemplateByKey(key: string) {
+  return prisma.promptTemplate.findFirst({
+    where: { key, isActive: true },
+    orderBy: { updatedAt: 'desc' },
+  });
+}
+
+export async function deactivatePromptTemplatesByKey(familyGroupId: number, key: string) {
+  return prisma.promptTemplate.updateMany({
+    where: { key, familyGroupId },
+    data: { isActive: false },
+  });
+}
+
+export async function createPromptTemplateRecord(data: {
+  key: string;
+  name?: string;
+  description?: string;
+  systemPrompt: string;
+  domainHints?: unknown;
+  isActive?: boolean;
+  version: number;
+  familyGroupId: number;
+}) {
+  return prisma.promptTemplate.create({ data });
+}
+
+export async function findPromptTemplateById(familyGroupId: number, id: number) {
+  return prisma.promptTemplate.findFirst({
+    where: { id, familyGroupId },
+  });
+}
+
+export async function updatePromptTemplateRecord(
+  id: number,
+  data: {
+    name?: string;
+    description?: string;
+    systemPrompt?: string;
+    domainHints?: unknown;
+    version?: { increment: number };
+  }
+) {
+  return prisma.promptTemplate.update({ where: { id }, data });
+}
+
+export async function activatePromptTemplateInTransaction(
+  familyGroupId: number,
+  targetId: number,
+  key: string
+) {
+  return prisma.$transaction([
+    prisma.promptTemplate.updateMany({
+      where: { key, familyGroupId },
+      data: { isActive: false },
+    }),
+    prisma.promptTemplate.update({
+      where: { id: targetId },
+      data: { isActive: true },
+    }),
+  ]);
+}
+
+export async function deletePromptTemplateById(id: number) {
+  return prisma.promptTemplate.delete({ where: { id } });
+}

--- a/backend/src/services/admin/adminService.ts
+++ b/backend/src/services/admin/adminService.ts
@@ -1,9 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import prisma from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { AppError } from '../../utils/appError';
 import type { TenantContext } from '../../utils/context';
+import {
+  activatePromptTemplateInTransaction,
+  createPromptTemplateRecord,
+  deactivatePromptTemplatesByKey,
+  deletePromptTemplateById,
+  findAllPromptTemplatesForSync,
+  findPromptTemplateById,
+  findPromptTemplatesByFamilyGroup,
+  updatePromptTemplateRecord,
+} from '../../repositories/promptRepository';
+import { queryAdminCostStatsByFamilyGroup } from '../../repositories/apiUsageLogRepository';
 
 const RATE_USD_TO_JPY = 150;
 const PRICE_USD_PER_INPUT = 0.075 / 1000000;
@@ -11,10 +21,7 @@ const PRICE_USD_PER_OUTPUT = 0.3 / 1000000;
 
 const syncPromptsToJson = async (familyGroupId: number) => {
   try {
-    const prompts = await prisma.promptTemplate.findMany({
-      where: { familyGroupId },
-      orderBy: { id: 'asc' },
-    });
+    const prompts = await findAllPromptTemplatesForSync(familyGroupId);
     const seedsDir = path.join(__dirname, '../../../prisma/seeds');
     const filePath = path.join(seedsDir, 'prompt_templates.json');
 
@@ -30,10 +37,7 @@ const syncPromptsToJson = async (familyGroupId: number) => {
 };
 
 export async function listPromptTemplates(ctx: TenantContext) {
-  return prisma.promptTemplate.findMany({
-    where: { familyGroupId: ctx.familyGroupId },
-    orderBy: [{ key: 'asc' }, { isActive: 'desc' }, { updatedAt: 'desc' }],
-  });
+  return findPromptTemplatesByFamilyGroup(ctx.familyGroupId);
 }
 
 export async function createPromptTemplate(
@@ -55,23 +59,18 @@ export async function createPromptTemplate(
   const { familyGroupId } = ctx;
 
   if (isActive) {
-    await prisma.promptTemplate.updateMany({
-      where: { key, familyGroupId },
-      data: { isActive: false },
-    });
+    await deactivatePromptTemplatesByKey(familyGroupId, key);
   }
 
-  const newPrompt = await prisma.promptTemplate.create({
-    data: {
-      key,
-      name,
-      description,
-      systemPrompt,
-      domainHints,
-      isActive,
-      version: 1,
-      familyGroupId,
-    },
+  const newPrompt = await createPromptTemplateRecord({
+    key,
+    name,
+    description,
+    systemPrompt,
+    domainHints,
+    isActive,
+    version: 1,
+    familyGroupId,
   });
 
   await syncPromptsToJson(familyGroupId);
@@ -88,22 +87,17 @@ export async function updatePromptTemplate(
     domainHints?: unknown;
   }
 ) {
-  const existing = await prisma.promptTemplate.findFirst({
-    where: { id, familyGroupId: ctx.familyGroupId },
-  });
+  const existing = await findPromptTemplateById(ctx.familyGroupId, id);
   if (!existing) {
     throw new AppError('対象のプロンプトが見つかりません', 404);
   }
 
-  const updated = await prisma.promptTemplate.update({
-    where: { id: existing.id },
-    data: {
-      name: input.name,
-      description: input.description,
-      systemPrompt: input.systemPrompt,
-      domainHints: input.domainHints,
-      version: { increment: 1 },
-    },
+  const updated = await updatePromptTemplateRecord(existing.id, {
+    name: input.name,
+    description: input.description,
+    systemPrompt: input.systemPrompt,
+    domainHints: input.domainHints,
+    version: { increment: 1 },
   });
 
   await syncPromptsToJson(ctx.familyGroupId);
@@ -111,31 +105,17 @@ export async function updatePromptTemplate(
 }
 
 export async function activatePromptTemplate(ctx: TenantContext, id: number) {
-  const target = await prisma.promptTemplate.findFirst({
-    where: { id, familyGroupId: ctx.familyGroupId },
-  });
+  const target = await findPromptTemplateById(ctx.familyGroupId, id);
   if (!target) {
     throw new AppError('対象のプロンプトが見つかりません', 404);
   }
 
-  await prisma.$transaction([
-    prisma.promptTemplate.updateMany({
-      where: { key: target.key, familyGroupId: ctx.familyGroupId },
-      data: { isActive: false },
-    }),
-    prisma.promptTemplate.update({
-      where: { id: target.id },
-      data: { isActive: true },
-    }),
-  ]);
-
+  await activatePromptTemplateInTransaction(ctx.familyGroupId, target.id, target.key);
   await syncPromptsToJson(ctx.familyGroupId);
 }
 
 export async function deletePromptTemplate(ctx: TenantContext, id: number) {
-  const target = await prisma.promptTemplate.findFirst({
-    where: { id, familyGroupId: ctx.familyGroupId },
-  });
+  const target = await findPromptTemplateById(ctx.familyGroupId, id);
   if (!target) {
     throw new AppError('対象のプロンプトが見つかりません', 404);
   }
@@ -143,7 +123,7 @@ export async function deletePromptTemplate(ctx: TenantContext, id: number) {
     throw new AppError('使用中のプロンプトは削除できません', 400);
   }
 
-  await prisma.promptTemplate.delete({ where: { id: target.id } });
+  await deletePromptTemplateById(target.id);
   await syncPromptsToJson(ctx.familyGroupId);
 }
 
@@ -156,25 +136,7 @@ type CostStatRow = {
 };
 
 export async function getAdminCostStats(ctx: TenantContext): Promise<CostStatRow[]> {
-  const stats = await prisma.$queryRaw<
-    Array<{
-      month: string;
-      modelId: string;
-      totalPromptTokens: number;
-      totalCandidatesTokens: number;
-    }>
-  >`
-    SELECT
-      TO_CHAR(l."createdAt", 'YYYY-MM') AS month,
-      l."modelId",
-      SUM(l."promptTokens")::int AS "totalPromptTokens",
-      SUM(l."candidatesTokens")::int AS "totalCandidatesTokens"
-    FROM "ApiUsageLog" l
-    INNER JOIN "FamilyMember" fm ON l."familyMemberId" = fm.id
-    WHERE fm."familyGroupId" = ${ctx.familyGroupId}
-    GROUP BY month, l."modelId"
-    ORDER BY month DESC;
-  `;
+  const stats = await queryAdminCostStatsByFamilyGroup(ctx.familyGroupId);
 
   return stats.map((row) => {
     const costUsd =

--- a/backend/src/services/categoryService.ts
+++ b/backend/src/services/categoryService.ts
@@ -1,5 +1,13 @@
-import { Prisma } from '@prisma/client';
-import { prisma as db } from '../utils/prismaClient';
+import type { PrismaTx } from '../utils/prismaTransaction';
+import { prisma } from '../utils/prismaClient';
+import {
+  findCategoryIdByKeywordInTx,
+  findFallbackCategoryIdInTx,
+} from '../repositories/categoryRepository';
+import {
+  findProductMasterByNameInTx,
+  findProductMasterForEstimateInTx,
+} from '../repositories/productMasterRepository';
 
 /**
  * [Issue #39 / #93-4] カテゴリー推定（世帯スコープ）
@@ -8,36 +16,28 @@ export const estimateCategoryId = async (
   itemName: string,
   storeName: string,
   familyGroupId: number,
-  tx: Prisma.TransactionClient = db as any
+  tx: PrismaTx = prisma
 ): Promise<number> => {
   try {
-    const matchWithStore = await tx.productMaster.findFirst({
-      where: { name: itemName, storeName, familyGroupId },
-      select: { categoryId: true },
+    const matchWithStore = await findProductMasterForEstimateInTx(tx, {
+      name: itemName,
+      storeName,
+      familyGroupId,
     });
     if (matchWithStore) return matchWithStore.categoryId;
 
-    const matchAnyStore = await tx.productMaster.findFirst({
-      where: { name: itemName, familyGroupId },
-      select: { categoryId: true },
+    const matchAnyStore = await findProductMasterByNameInTx(tx, {
+      name: itemName,
+      familyGroupId,
     });
     if (matchAnyStore) return matchAnyStore.categoryId;
 
-    const categoryByKeyword = await tx.$queryRaw<{ id: number }[]>`
-      SELECT c.id FROM "Category" c, jsonb_array_elements_text(c.keywords) AS kw
-      WHERE c."familyGroupId" = ${familyGroupId}
-        AND ${itemName} LIKE '%' || kw || '%'
-      LIMIT 1;
-    `;
-
+    const categoryByKeyword = await findCategoryIdByKeywordInTx(tx, familyGroupId, itemName);
     if (categoryByKeyword.length > 0) {
       return categoryByKeyword[0].id;
     }
 
-    const fallback = await tx.category.findFirst({
-      where: { familyGroupId, name: 'その他' },
-      select: { id: true },
-    });
+    const fallback = await findFallbackCategoryIdInTx(tx, familyGroupId);
     return fallback?.id ?? 0;
   } catch (error) {
     console.error('[CategoryService] Estimation Error:', error);

--- a/backend/src/services/geminiService.ts
+++ b/backend/src/services/geminiService.ts
@@ -1,9 +1,13 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import * as fs from "fs";
 import * as path from "path";
-import prisma from "../utils/prismaClient"; 
 import logger from "../utils/logger";
 import type { ParsedReceipt } from "../types/receipt";
+import { findActivePromptTemplateByKey } from "../repositories/promptRepository";
+import {
+  createApiUsageLog,
+  incrementApiUsageLogTokens,
+} from "../repositories/apiUsageLogRepository";
 
 export type { ParsedItem, ParsedReceipt } from "../types/receipt";
 
@@ -48,12 +52,7 @@ async function withRetry<T>(
  * [Issue #72/76] プロンプトをDBから取得し、ドメインヒントを結合
  */
 async function buildPrompt(): Promise<string> {
-  // ★修正: @unique制約を外したため、findUniqueからfindFirstへ変更。
-  // 現在アクティブ(isActive: true)なRECEIPT_ANALYSISプロンプトを取得する。
-  const template = await prisma.promptTemplate.findFirst({
-    where: { key: "RECEIPT_ANALYSIS", isActive: true },
-    orderBy: { updatedAt: 'desc' } // 念のため最新のものを優先
-  });
+  const template = await findActivePromptTemplateByKey("RECEIPT_ANALYSIS");
 
   if (!template) {
     throw new Error("プロンプトテンプレート(RECEIPT_ANALYSIS)がDBに見つかりません。");
@@ -128,26 +127,19 @@ export const analyzeReceiptImage = async (
     if (usage) {
       try {
         if (existingLogId) {
-          // 自己修復リトライ時は、既存のログレコードにトークン使用量を合算（累積）
-          await prisma.apiUsageLog.update({
-            where: { id: existingLogId },
-            data: {
-              promptTokens: { increment: usage.promptTokenCount },
-              candidatesTokens: { increment: usage.candidatesTokenCount },
-              totalTokens: { increment: usage.totalTokenCount },
-            }
+          await incrementApiUsageLogTokens(existingLogId, {
+            promptTokens: usage.promptTokenCount ?? 0,
+            candidatesTokens: usage.candidatesTokenCount ?? 0,
+            totalTokens: usage.totalTokenCount ?? 0,
           });
           logger.info(`[Gemini_Log] 自己修復リトライ分のトークンを合算しました (LogID: ${existingLogId})`);
         } else {
-          // 初回解析時は新規ログレコードを作成
-          const log = await prisma.apiUsageLog.create({
-            data: {
-              familyMemberId: familyMemberId || null,
-              modelId: GEMINI_MODEL,
-              promptTokens: usage.promptTokenCount,
-              candidatesTokens: usage.candidatesTokenCount,
-              totalTokens: usage.totalTokenCount,
-            }
+          const log = await createApiUsageLog({
+            familyMemberId: familyMemberId || null,
+            modelId: GEMINI_MODEL,
+            promptTokens: usage.promptTokenCount ?? 0,
+            candidatesTokens: usage.candidatesTokenCount ?? 0,
+            totalTokens: usage.totalTokenCount ?? 0,
           });
           usageLogId = log.id;
         }

--- a/backend/src/services/imageAccessService.ts
+++ b/backend/src/services/imageAccessService.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { prisma } from '../utils/prismaClient';
 import { receiptQueue } from '../queues/receiptQueue';
+import { findReceiptIdByImagePath } from '../repositories/receiptRepository';
 
 function normalizeImagePath(imagePath: string): string {
   return imagePath.replace(/\\/g, '/');
@@ -35,10 +35,7 @@ export async function canAccessReceiptImage(
 ): Promise<boolean> {
   const normalized = normalizeImagePath(imagePath);
 
-  const receipt = await prisma.receipt.findFirst({
-    where: { familyGroupId, imagePath: normalized },
-    select: { id: true },
-  });
+  const receipt = await findReceiptIdByImagePath(familyGroupId, normalized);
   if (receipt) return true;
 
   return hasQueueJobForImage(familyGroupId, normalized);

--- a/backend/src/services/receipt/receiptAnalysisService.ts
+++ b/backend/src/services/receipt/receiptAnalysisService.ts
@@ -1,10 +1,10 @@
-import { prisma } from '../../utils/prismaClient';
 import logger from '../../utils/logger';
 import { getCleanText } from '../../utils/normalizer';
 import { getReceiptAnalysisProvider } from '../../ai';
 import { estimateCategoryId } from '../categoryService';
 import { validateReceiptItems } from '../validationService';
 import type { TenantContext } from '../../utils/context';
+import { findProductMasterByCompositeKey } from '../../repositories/productMasterRepository';
 
 /**
  * [Issue #49-8 / #72 / #63] 解析のみを実行し、推論カテゴリを付与して返す
@@ -23,14 +23,10 @@ export async function analyzeOnly(ctx: TenantContext, imagePath: string) {
       let initialCategoryId = null;
 
       if (familyGroupId) {
-        const mastered = await prisma.productMaster.findUnique({
-          where: {
-            name_storeName_familyGroupId: { name: cleanName, storeName: cleanStore, familyGroupId },
-          },
-        });
+        const mastered = await findProductMasterByCompositeKey(cleanName, cleanStore, familyGroupId);
         initialCategoryId = mastered
           ? mastered.categoryId
-          : await estimateCategoryId(cleanName, cleanStore, familyGroupId, prisma);
+          : await estimateCategoryId(cleanName, cleanStore, familyGroupId);
       }
 
       return {

--- a/backend/src/services/receiptJobService.ts
+++ b/backend/src/services/receiptJobService.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { receiptQueue } from '../queues/receiptQueue';
 import { checkDuplicateReceipt } from './duplicateReceiptService';
-import { prisma } from '../utils/prismaClient';
+import { findReceiptIdByImagePath } from '../repositories/receiptRepository';
 import { AppError } from '../utils/appError';
 
 const LIST_JOB_STATES = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused'] as const;
@@ -176,10 +176,7 @@ async function deletePendingJobImage(
   if (!imagePath || typeof imagePath !== 'string') return;
 
   const normalized = imagePath.replace(/\\/g, '/');
-  const saved = await prisma.receipt.findFirst({
-    where: { familyGroupId, imagePath: normalized },
-    select: { id: true },
-  });
+  const saved = await findReceiptIdByImagePath(familyGroupId, normalized);
   if (saved) return;
 
   try {


### PR DESCRIPTION
## Summary

- `promptRepository.ts` / `apiUsageLogRepository.ts` を新設
- `categoryRepository` / `productMasterRepository` に推定・統計用クエリを追加
- 以下から Prisma 直叩きを除去:
  - `receiptController.ts` → `categoryRepository`
  - `adminService.ts` → `promptRepository` + `apiUsageLogRepository`
  - `receiptJobService.ts` / `imageAccessService.ts` → `findReceiptIdByImagePath`
  - `geminiService.ts` → `promptRepository` + `apiUsageLogRepository`
  - `categoryService.ts` / `receiptAnalysisService.ts` → Repository 経由

## 関連 Issue

- Epic: #423
- Closes #427

## Acceptance Criteria

- [x] `controllers/` 内 Prisma 直叩き 0 件
- [x] `services/` 内 Prisma 直叩き 0 件
- [x] integration test 通過
- [x] `npm test`（backend）通過

## Test plan

- [x] `npm test`（backend）— 43 passed


Made with [Cursor](https://cursor.com)