### PR TITLE
refactor(fe): [Issue #100-4] Mapper 層新設と StatisticsScreen 型集約

### DIFF
--- a/frontend/src/mappers/receiptMapper.ts
+++ b/frontend/src/mappers/receiptMapper.ts
@@ -1,0 +1,8 @@
+import type { ReceiptDetail } from '../types/receipt';
+
+/** 統計画面プレビュー用。現時点は OpenAPI DTO をそのまま利用する。 */
+export function mapReceiptDetailForStatsPreview(
+  receipt: ReceiptDetail | null | undefined
+): ReceiptDetail | null {
+  return receipt ?? null;
+}

--- a/frontend/src/mappers/statsMapper.test.ts
+++ b/frontend/src/mappers/statsMapper.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapAdvancedStatsResponse,
+  mapCategoryList,
+  mapMonthlyStatsResponse,
+} from './statsMapper';
+
+describe('statsMapper', () => {
+  it('mapMonthlyStatsResponse normalizes MonthlyStatsData DTO', () => {
+    const result = mapMonthlyStatsResponse(
+      {
+        month: '2026-06',
+        totalAmount: 12000,
+        stats: [
+          {
+            categoryId: 1,
+            categoryName: '食費',
+            totalAmount: '5000',
+            color: '#ff0000',
+          },
+        ],
+        latestReceipt: null,
+      },
+      '2026-06'
+    );
+
+    expect(result).toEqual({
+      month: '2026-06',
+      totalAmount: 12000,
+      prevTotal: 0,
+      diffAmount: 0,
+      diffPercentage: 0,
+      stats: [
+        {
+          categoryId: 1,
+          categoryName: '食費',
+          totalAmount: 5000,
+          color: '#ff0000',
+        },
+      ],
+      latestReceipt: null,
+    });
+  });
+
+  it('mapMonthlyStatsResponse handles legacy array payload with total field', () => {
+    const result = mapMonthlyStatsResponse(
+      [
+        {
+          month: '2026-05',
+          total: 8000,
+          stats: [],
+          latestReceipt: null,
+        },
+        {
+          month: '2026-06',
+          total: 10000,
+          stats: [{ categoryName: '未分類', totalAmount: 10000 }],
+          latestReceipt: null,
+        },
+      ],
+      '2026-06'
+    );
+
+    expect(result?.month).toBe('2026-06');
+    expect(result?.totalAmount).toBe(10000);
+    expect(result?.stats[0]?.categoryName).toBe('未分類');
+  });
+
+  it('mapAdvancedStatsResponse maps snake_case pareto fields', () => {
+    const result = mapAdvancedStatsResponse({
+      trend: [{ period: '2026-06', total: 1000, prev_total: 800 }],
+      pareto: [{ name: '食費', amount: 500, ratio: 50, cumulative_ratio: 50 }],
+    });
+
+    expect(result).toEqual({
+      trend: [{ period: '2026-06', total: 1000, prevTotal: 800 }],
+      pareto: [{ name: '食費', amount: 500, ratio: 50, cumulativeRatio: 50 }],
+    });
+  });
+
+  it('mapCategoryList keeps id, name, color only', () => {
+    const result = mapCategoryList([
+      { id: 1, name: '食費', color: '#111111', familyGroupId: 1, keywords: [] },
+    ]);
+
+    expect(result).toEqual([{ id: 1, name: '食費', color: '#111111' }]);
+  });
+});

--- a/frontend/src/mappers/statsMapper.ts
+++ b/frontend/src/mappers/statsMapper.ts
@@ -1,0 +1,113 @@
+import type {
+  AdvancedStatsData,
+  AdvancedStatsViewModel,
+  CategoryStatRow,
+  MonthlyStatsData,
+  MonthlyStatsViewModel,
+  MonthlyStatItem,
+  StatsCategoryOption,
+  TrendStatItem,
+  ParetoStatItem,
+} from '../types/stats';
+import type { Category, ReceiptDetail } from '../api/generated';
+
+type LegacyMonthlyStatsRow = {
+  month?: string;
+  total?: number | string;
+  totalAmount?: number | string;
+  prevTotal?: number | string;
+  diffAmount?: number | string;
+  diffPercentage?: number | string;
+  stats?: CategoryStatRow[];
+  latestReceipt?: ReceiptDetail | null;
+};
+
+function toNumber(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function mapStatRow(row: CategoryStatRow): MonthlyStatItem {
+  return {
+    categoryId: row.categoryId ?? null,
+    categoryName: row.categoryName ?? '未分類',
+    totalAmount: toNumber(row.totalAmount),
+    color: row.color ?? '',
+  };
+}
+
+function mapMonthlyStatsDto(dto: MonthlyStatsData | LegacyMonthlyStatsRow): MonthlyStatsViewModel {
+  return {
+    month: dto.month ?? '',
+    totalAmount: toNumber('totalAmount' in dto && dto.totalAmount != null ? dto.totalAmount : dto.total),
+    prevTotal: toNumber(dto.prevTotal),
+    diffAmount: toNumber(dto.diffAmount),
+    diffPercentage: toNumber(dto.diffPercentage),
+    stats: (dto.stats ?? []).map(mapStatRow),
+    latestReceipt: dto.latestReceipt ?? null,
+  };
+}
+
+/**
+ * 月次統計 API レスポンスを ViewModel に正規化する。
+ * 旧 API（配列 + `total` フィールド）との互換をここで吸収する。
+ */
+export function mapMonthlyStatsResponse(
+  raw: MonthlyStatsData | MonthlyStatsData[] | LegacyMonthlyStatsRow | LegacyMonthlyStatsRow[] | null | undefined,
+  selectedMonth: string
+): MonthlyStatsViewModel | null {
+  if (raw == null) return null;
+
+  if (Array.isArray(raw)) {
+    const target = raw.find((item) => item.month === selectedMonth) ?? raw[0];
+    if (!target) {
+      return {
+        month: selectedMonth,
+        totalAmount: 0,
+        prevTotal: 0,
+        diffAmount: 0,
+        diffPercentage: 0,
+        stats: [],
+        latestReceipt: null,
+      };
+    }
+    return {
+      ...mapMonthlyStatsDto(target),
+      month: target.month ?? selectedMonth,
+      prevTotal: 0,
+      diffAmount: 0,
+      diffPercentage: 0,
+    };
+  }
+
+  return mapMonthlyStatsDto(raw);
+}
+
+export function mapAdvancedStatsResponse(
+  raw: AdvancedStatsData | null | undefined
+): AdvancedStatsViewModel | null {
+  if (!raw) return null;
+
+  const trend: TrendStatItem[] = (raw.trend ?? []).map((row) => ({
+    period: row.period,
+    total: toNumber(row.total),
+    prevTotal: row.prev_total == null ? null : toNumber(row.prev_total),
+  }));
+
+  const pareto: ParetoStatItem[] = (raw.pareto ?? []).map((row) => ({
+    name: row.name,
+    amount: toNumber(row.amount),
+    ratio: toNumber(row.ratio),
+    cumulativeRatio: toNumber(row.cumulative_ratio),
+  }));
+
+  return { trend, pareto };
+}
+
+export function mapCategoryList(categories: Category[]): StatsCategoryOption[] {
+  return categories.map((category) => ({
+    id: category.id,
+    name: category.name,
+    color: category.color,
+  }));
+}

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -7,7 +7,6 @@ import {
   ActivityIndicator, 
   Image, 
   TouchableOpacity, 
-  Alert, 
   FlatList, 
   useWindowDimensions, 
 } from 'react-native';
@@ -19,38 +18,19 @@ import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { theme } from '../theme';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
-import type { ReceiptDetail } from '../types/receipt';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
-
-// --- interface 定義 ---
-interface Category { id: number; name: string; color: string; }
-interface StatItem { categoryId: number | null; categoryName: string; totalAmount: number | string; color: string; }
-interface ReceiptItem { id: number; name: string; price: number; quantity: number; categoryId: number; category?: { name: string; color: string }; }
-
-// [Issue #71] taxAmount を追加
-interface ReceiptInfo { 
-  id: number; 
-  imagePath: string | null; 
-  storeName: string; 
-  totalAmount: number; 
-  taxAmount?: number; 
-  items: ReceiptItem[]; 
-  date?: string; 
-}
-
-interface MonthlyData { 
-  month: string; 
-  totalAmount: number; 
-  prevTotal: number; 
-  diffAmount: number; 
-  diffPercentage: number; 
-  stats: StatItem[]; 
-  latestReceipt: ReceiptInfo | null; 
-}
-
-interface TrendData { period: string; total: number; prev_total: number | null; }
-interface ParetoData { name: string; amount: number; ratio: number; cumulative_ratio: number; }
-interface AdvancedStats { trend: TrendData[]; pareto: ParetoData[]; }
+import {
+  mapAdvancedStatsResponse,
+  mapCategoryList,
+  mapMonthlyStatsResponse,
+} from '../mappers/statsMapper';
+import type {
+  AdvancedStatsViewModel,
+  MonthlyStatsViewModel,
+  StatsCategoryOption,
+} from '../types/stats';
+import { showAlert } from '../utils/alertMessage';
+import { getApiErrorMessage } from '../utils/apiError';
 
 interface StatisticsScreenProps { 
   currentMemberId: number; 
@@ -68,9 +48,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
 
   const [loading, setLoading] = useState(true);
   const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
-  const [data, setData] = useState<MonthlyData | null>(null);
-  const [advancedData, setAdvancedData] = useState<AdvancedStats | null>(null);
-  const [allCategories, setAllCategories] = useState<Category[]>([]);
+  const [data, setData] = useState<MonthlyStatsViewModel | null>(null);
+  const [advancedData, setAdvancedData] = useState<AdvancedStatsViewModel | null>(null);
+  const [allCategories, setAllCategories] = useState<StatsCategoryOption[]>([]);
   
   const [isMainModalVisible, setMainModalVisible] = useState(false);
 
@@ -93,25 +73,13 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       ]);
 
       if (statsRes.success) {
-        const raw = statsRes.data;
-        if (Array.isArray(raw)) {
-          const target = raw.find(item => item.month === selectedMonth) || raw[0];
-          setData({
-            month: target?.month || selectedMonth,
-            totalAmount: Number(target?.total || 0),
-            prevTotal: 0, diffAmount: 0, diffPercentage: 0,
-            stats: target?.stats || [], 
-            latestReceipt: target?.latestReceipt || null
-          });
-        } else {
-          setData(raw);
-        }
+        setData(mapMonthlyStatsResponse(statsRes.data, selectedMonth));
       }
-      if (advRes.success) setAdvancedData(advRes.data);
-      if (catRes.success) setAllCategories(catRes.data);
+      if (advRes.success) setAdvancedData(mapAdvancedStatsResponse(advRes.data));
+      if (catRes.success) setAllCategories(mapCategoryList(catRes.data));
     } catch (error: unknown) {
       console.error('[DEBUG-STATS] Fetch Error:', error);
-      Alert.alert("エラー", "データの取得に失敗しました");
+      showAlert('エラー', getApiErrorMessage(error, 'データの取得に失敗しました'));
     } finally {
       setLoading(false);
     }
@@ -125,7 +93,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
       await receiptApi.updateItemCategory(itemId, Number(categoryId));
       await fetchData(); 
     } catch (error) {
-      Alert.alert("エラー", "カテゴリーの更新に失敗しました");
+      showAlert('エラー', getApiErrorMessage(error, 'カテゴリーの更新に失敗しました'));
     }
   };
 
@@ -238,13 +206,13 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                 <Text style={styles.sectionTitle}>月次推移 (MoM Trend)</Text>
                 <View style={styles.statsCard}>
                   {advancedData?.trend.map((t, i) => {
-                    const diff = t.prev_total ? t.total - t.prev_total : 0;
+                    const diff = t.prevTotal != null ? t.total - t.prevTotal : 0;
                     return (
                       <View key={i} style={styles.trendRow}>
                         <Text style={styles.trendPeriod}>{t.period}</Text>
                         <Text style={styles.trendAmount}>¥{Math.round(Number(t.total) || 0).toLocaleString()}</Text>
                         <Text style={[styles.trendDiff, { color: diff > 0 ? theme.colors.error : theme.colors.success }]}>
-                          {t.prev_total !== null ? `${diff > 0 ? '+' : ''}${Math.round(diff).toLocaleString()}` : '-'}
+                          {t.prevTotal !== null ? `${diff > 0 ? '+' : ''}${Math.round(diff).toLocaleString()}` : '-'}
                         </Text>
                       </View>
                     );
@@ -264,9 +232,9 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
                       <View style={styles.paretoBarContainer}>
                         <View style={[
                           styles.paretoBar, 
-                          { width: `${p.ratio}%`, backgroundColor: p.cumulative_ratio <= 80 ? theme.colors.primary : theme.colors.semantic.chart.barInactive }
+                          { width: `${p.ratio}%`, backgroundColor: p.cumulativeRatio <= 80 ? theme.colors.primary : theme.colors.semantic.chart.barInactive }
                         ]} />
-                        <Text style={styles.cumText}>{p.cumulative_ratio}%</Text>
+                        <Text style={styles.cumText}>{p.cumulativeRatio}%</Text>
                       </View>
                     </View>
                   ))}
@@ -285,7 +253,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         title="解析レシート詳細"
       >
         <ReceiptDetailComponent
-          receipt={data?.latestReceipt as ReceiptDetail | null | undefined}
+          receipt={data?.latestReceipt}
           categories={allCategories}
           onCategoryChange={handleCategoryChange}
           baseUrl={BASE_URL}

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,0 +1,53 @@
+import type { Category, ReceiptDetail } from '../api/generated';
+
+/** 画面表示用カテゴリ（セレクト等） */
+export type StatsCategoryOption = Pick<Category, 'id' | 'name' | 'color'>;
+
+/** 月次カテゴリ別統計行（ViewModel） */
+export type MonthlyStatItem = {
+  categoryId: number | null;
+  categoryName: string;
+  totalAmount: number;
+  color: string;
+};
+
+/** 月次統計画面 ViewModel */
+export type MonthlyStatsViewModel = {
+  month: string;
+  totalAmount: number;
+  prevTotal: number;
+  diffAmount: number;
+  diffPercentage: number;
+  stats: MonthlyStatItem[];
+  latestReceipt: ReceiptDetail | null;
+};
+
+/** 月次推移行（ViewModel） */
+export type TrendStatItem = {
+  period: string;
+  total: number;
+  prevTotal: number | null;
+};
+
+/** パレート分析行（ViewModel） */
+export type ParetoStatItem = {
+  name: string;
+  amount: number;
+  ratio: number;
+  cumulativeRatio: number;
+};
+
+/** 高度統計 ViewModel */
+export type AdvancedStatsViewModel = {
+  trend: TrendStatItem[];
+  pareto: ParetoStatItem[];
+};
+
+/** OpenAPI DTO 再 export（Mapper 入力用） */
+export type {
+  AdvancedStatsData,
+  CategoryStatRow,
+  MonthlyStatsData,
+  ParetoRow,
+  TrendRow,
+} from '../api/generated';


### PR DESCRIPTION
## Summary

- `frontend/src/types/stats.ts` — 統計 ViewModel 型を新設
- `frontend/src/mappers/statsMapper.ts` — 月次/高度統計の DTO→ViewModel 変換（旧配列 API 互換含む）
- `frontend/src/mappers/receiptMapper.ts` — 統計プレビュー用（最小）
- `StatisticsScreen.tsx` — ローカル interface 削除、Mapper 利用、`showAlert` 統一
- `statsMapper.test.ts` — 正規化ロジックの単体テスト追加

## 関連 Issue

- Epic: #423
- Closes #428

## Acceptance Criteria

- [x] StatisticsScreen 内ローカル interface 0 件
- [x] API 型は `api/generated` / `types/stats` 経由
- [x] `Array.isArray(raw)` 分岐を mapper 内に集約
- [x] `npm test`（frontend）通過

## Test plan

- [x] `npm test`（frontend）— 46 passed（statsMapper.test 4件含む）


Made with [Cursor](https://cursor.com)