### PR TITLE
refactor(fe): [Issue #100-7] LoginScreen 分解 + Style Pattern 適用

### DIFF
--- a/frontend/src/features/auth/components/InviteCodeStep.tsx
+++ b/frontend/src/features/auth/components/InviteCodeStep.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { formStyles } from '../../../theme';
+import { authScreenStyles } from '../styles/authScreenStyles';
+
+type Props = {
+  inviteCode: string;
+  loading: boolean;
+  accentColor: string;
+  onInviteCodeChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+export const InviteCodeStep: React.FC<Props> = ({
+  inviteCode,
+  loading,
+  accentColor,
+  onInviteCodeChange,
+  onSubmit,
+}) => (
+  <>
+    <Text style={authScreenStyles.subtitle}>招待コードを入力してください</Text>
+    <View style={[formStyles.field, authScreenStyles.inputWrapper]}>
+      <TextInput
+        style={authScreenStyles.input}
+        placeholder="例: YAMAMOTO-2026"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+        value={inviteCode}
+        onChangeText={onInviteCodeChange}
+        autoCapitalize="characters"
+        autoCorrect={false}
+        editable={!loading}
+      />
+    </View>
+    <TouchableOpacity
+      style={[authScreenStyles.primaryButton, loading && authScreenStyles.buttonDisabled]}
+      onPress={onSubmit}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color={accentColor} />
+      ) : (
+        <Text style={[authScreenStyles.primaryButtonText, { color: accentColor }]}>次へ</Text>
+      )}
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/auth/components/MemberSelectStep.tsx
+++ b/frontend/src/features/auth/components/MemberSelectStep.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ScrollView, Text, TouchableOpacity } from 'react-native';
+import type { AuthFamilyMember } from '../../../types/auth';
+import { authScreenStyles } from '../styles/authScreenStyles';
+
+type Props = {
+  familyName?: string;
+  members: AuthFamilyMember[];
+  loading: boolean;
+  accentColor: string;
+  onSelectMember: (member: AuthFamilyMember) => void;
+  onResetToInvite: () => void;
+};
+
+export const MemberSelectStep: React.FC<Props> = ({
+  familyName,
+  members,
+  loading,
+  accentColor,
+  onSelectMember,
+  onResetToInvite,
+}) => (
+  <>
+    <Text style={authScreenStyles.familyLabel}>{familyName}</Text>
+    <Text style={authScreenStyles.subtitle}>ログインするメンバーを選択</Text>
+    <ScrollView style={authScreenStyles.memberList} contentContainerStyle={authScreenStyles.memberListContent}>
+      {members.map((member) => (
+        <TouchableOpacity
+          key={member.id}
+          style={authScreenStyles.memberButton}
+          onPress={() => onSelectMember(member)}
+          disabled={loading}
+        >
+          <Text style={[authScreenStyles.memberButtonText, { color: accentColor }]}>{member.name}</Text>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+    <TouchableOpacity style={authScreenStyles.linkButton} onPress={onResetToInvite} disabled={loading}>
+      <Text style={authScreenStyles.linkButtonText}>別の世帯でログイン</Text>
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/auth/components/PasswordStep.tsx
+++ b/frontend/src/features/auth/components/PasswordStep.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { formStyles } from '../../../theme';
+import { authScreenStyles } from '../styles/authScreenStyles';
+
+type Props = {
+  familyName?: string;
+  memberName?: string;
+  password: string;
+  loading: boolean;
+  accentColor: string;
+  onPasswordChange: (value: string) => void;
+  onSubmit: () => void;
+  onBackToMember: () => void;
+  onResetToInvite: () => void;
+};
+
+export const PasswordStep: React.FC<Props> = ({
+  familyName,
+  memberName,
+  password,
+  loading,
+  accentColor,
+  onPasswordChange,
+  onSubmit,
+  onBackToMember,
+  onResetToInvite,
+}) => (
+  <>
+    <Text style={authScreenStyles.familyLabel}>{familyName}</Text>
+    <Text style={authScreenStyles.subtitle}>{memberName} としてログイン</Text>
+    <View style={[formStyles.field, authScreenStyles.inputWrapper]}>
+      <TextInput
+        style={authScreenStyles.input}
+        placeholder="パスワードを入力"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+        secureTextEntry
+        value={password}
+        onChangeText={onPasswordChange}
+        autoCapitalize="none"
+        autoCorrect={false}
+        editable={!loading}
+        onSubmitEditing={onSubmit}
+      />
+    </View>
+    <TouchableOpacity
+      style={[authScreenStyles.primaryButton, loading && authScreenStyles.buttonDisabled]}
+      onPress={onSubmit}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color={accentColor} />
+      ) : (
+        <Text style={[authScreenStyles.primaryButtonText, { color: accentColor }]}>ログイン</Text>
+      )}
+    </TouchableOpacity>
+    <TouchableOpacity style={authScreenStyles.secondaryButton} onPress={onBackToMember} disabled={loading}>
+      <Text style={authScreenStyles.secondaryButtonText}>メンバー選択に戻る</Text>
+    </TouchableOpacity>
+    <TouchableOpacity style={authScreenStyles.linkButton} onPress={onResetToInvite} disabled={loading}>
+      <Text style={authScreenStyles.linkButtonText}>別の世帯でログイン</Text>
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/auth/components/TotpSetupStep.tsx
+++ b/frontend/src/features/auth/components/TotpSetupStep.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { formStyles } from '../../../theme';
+import { authScreenStyles } from '../styles/authScreenStyles';
+
+type Props = {
+  familyName?: string;
+  totpSecret: string | null;
+  totpCode: string;
+  loading: boolean;
+  accentColor: string;
+  onTotpCodeChange: (value: string) => void;
+  onSubmit: () => void;
+  onInputFocus: () => void;
+};
+
+export const TotpSetupStep: React.FC<Props> = ({
+  familyName,
+  totpSecret,
+  totpCode,
+  loading,
+  accentColor,
+  onTotpCodeChange,
+  onSubmit,
+  onInputFocus,
+}) => (
+  <>
+    <Text style={authScreenStyles.familyLabel}>{familyName}</Text>
+    <Text style={authScreenStyles.subtitle}>二要素認証の設定（初回ログイン）</Text>
+    {totpSecret ? (
+      <View style={authScreenStyles.secretBox}>
+        <Text style={authScreenStyles.secretLabel}>認証アプリに登録するキー</Text>
+        <Text style={authScreenStyles.secretText} selectable>
+          {totpSecret}
+        </Text>
+      </View>
+    ) : null}
+    <View style={[formStyles.field, authScreenStyles.inputWrapper]}>
+      <TextInput
+        style={authScreenStyles.input}
+        placeholder="6桁コード"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+        value={totpCode}
+        onChangeText={onTotpCodeChange}
+        onFocus={onInputFocus}
+        keyboardType="number-pad"
+        maxLength={6}
+        editable={!loading}
+      />
+    </View>
+    <TouchableOpacity
+      style={[authScreenStyles.primaryButton, loading && authScreenStyles.buttonDisabled]}
+      onPress={onSubmit}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color={accentColor} />
+      ) : (
+        <Text style={[authScreenStyles.primaryButtonText, { color: accentColor }]}>設定を完了</Text>
+      )}
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/auth/components/TotpVerifyStep.tsx
+++ b/frontend/src/features/auth/components/TotpVerifyStep.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ActivityIndicator, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { formStyles } from '../../../theme';
+import { authScreenStyles } from '../styles/authScreenStyles';
+
+type Props = {
+  familyName?: string;
+  totpCode: string;
+  loading: boolean;
+  accentColor: string;
+  onTotpCodeChange: (value: string) => void;
+  onSubmit: () => void;
+  onInputFocus: () => void;
+};
+
+export const TotpVerifyStep: React.FC<Props> = ({
+  familyName,
+  totpCode,
+  loading,
+  accentColor,
+  onTotpCodeChange,
+  onSubmit,
+  onInputFocus,
+}) => (
+  <>
+    <Text style={authScreenStyles.familyLabel}>{familyName}</Text>
+    <Text style={authScreenStyles.subtitle}>二要素認証コードを入力</Text>
+    <View style={[formStyles.field, authScreenStyles.inputWrapper]}>
+      <TextInput
+        style={authScreenStyles.input}
+        placeholder="6桁コード"
+        placeholderTextColor="rgba(255,255,255,0.6)"
+        value={totpCode}
+        onChangeText={onTotpCodeChange}
+        onFocus={onInputFocus}
+        keyboardType="number-pad"
+        maxLength={6}
+        editable={!loading}
+      />
+    </View>
+    <TouchableOpacity
+      style={[authScreenStyles.primaryButton, loading && authScreenStyles.buttonDisabled]}
+      onPress={onSubmit}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color={accentColor} />
+      ) : (
+        <Text style={[authScreenStyles.primaryButtonText, { color: accentColor }]}>確認</Text>
+      )}
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/auth/hooks/useLoginFlow.ts
+++ b/frontend/src/features/auth/hooks/useLoginFlow.ts
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ScrollView } from 'react-native';
+import { devUiColors, isDevAppEnv } from '../../../config/appEnv';
+import { loginService } from '../../../services/loginService';
+import { theme } from '../../../theme';
+import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../../../types/auth';
+import { showAlert } from '../../../utils/alertMessage';
+import { getApiErrorMessage } from '../../../utils/apiError';
+import type { LoginStep } from '../types';
+
+type LoginSuccessContext = {
+  familyName: string;
+  inviteCode: string;
+};
+
+type UseLoginFlowOptions = {
+  onLoginSuccess: (result: LoginResult, context: LoginSuccessContext) => void;
+};
+
+export function useLoginFlow({ onLoginSuccess }: UseLoginFlowOptions) {
+  const scrollRef = useRef<ScrollView>(null);
+  const [step, setStep] = useState<LoginStep>('invite');
+  const [inviteCode, setInviteCode] = useState('');
+  const [family, setFamily] = useState<ResolvedFamily | null>(null);
+  const [members, setMembers] = useState<AuthFamilyMember[]>([]);
+  const [selectedMember, setSelectedMember] = useState<AuthFamilyMember | null>(null);
+  const [password, setPassword] = useState('');
+  const [pendingToken, setPendingToken] = useState<string | null>(null);
+  const [totpSecret, setTotpSecret] = useState<string | null>(null);
+  const [totpCode, setTotpCode] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const accentColor = isDevAppEnv() ? devUiColors.loginPrimary : theme.colors.primary;
+  const isTotpStep = step === 'totp_setup' || step === 'totp_verify';
+
+  const finishLogin = (result: LoginResult) => {
+    if (!family) return;
+    onLoginSuccess(result, { familyName: family.name, inviteCode: inviteCode.trim() });
+  };
+
+  const resetToInvite = () => {
+    setStep('invite');
+    setFamily(null);
+    setMembers([]);
+    setSelectedMember(null);
+    setPassword('');
+    setPendingToken(null);
+    setTotpSecret(null);
+    setTotpCode('');
+  };
+
+  const goBackToMember = () => {
+    setSelectedMember(null);
+    setPassword('');
+    setStep('member');
+  };
+
+  const scrollToFormBottom = () => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  };
+
+  const handleResolveFamily = async () => {
+    if (!inviteCode.trim()) {
+      showAlert('入力エラー', '招待コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const resolved = await loginService.resolveFamily(inviteCode);
+      const memberList = await loginService.getFamilyMembers(resolved.familyGroupId, inviteCode);
+      setFamily(resolved);
+      setMembers(memberList);
+      setStep('member');
+    } catch (e: unknown) {
+      const message = getApiErrorMessage(
+        e,
+        '招待コードの確認に失敗しました。ネットワーク接続を確認してください。'
+      );
+      showAlert('エラー', message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectMember = (member: AuthFamilyMember) => {
+    setSelectedMember(member);
+    setPassword('');
+    setStep('password');
+  };
+
+  const handleLogin = async () => {
+    if (!family || !selectedMember) return;
+    if (!password) {
+      showAlert('入力エラー', 'パスワードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await loginService.login(family.familyGroupId, selectedMember.id, password);
+
+      if (response.token) {
+        finishLogin({ token: response.token, member: response.member });
+        return;
+      }
+
+      if (!response.pendingToken) {
+        throw new Error('認証トークンを取得できませんでした。');
+      }
+
+      setPendingToken(response.pendingToken);
+
+      if (response.requiresTotpSetup) {
+        const setup = await loginService.startTotpSetup(response.pendingToken);
+        setTotpSecret(setup.secret);
+        setTotpCode('');
+        setStep('totp_setup');
+        return;
+      }
+
+      if (response.requiresTotpVerification) {
+        setTotpCode('');
+        setStep('totp_verify');
+        return;
+      }
+
+      throw new Error('想定外のログイン応答です。');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'ログインに失敗しました。';
+      showAlert('認証エラー', message);
+      setPassword('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmTotpSetup = async () => {
+    if (!pendingToken || !totpCode.trim()) {
+      showAlert('入力エラー', '認証アプリの6桁コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await loginService.confirmTotpSetup(pendingToken, totpCode);
+      finishLogin(result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '認証コードの確認に失敗しました。';
+      showAlert('エラー', message);
+      setTotpCode('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyTotp = async () => {
+    if (!pendingToken || !totpCode.trim()) {
+      showAlert('入力エラー', '認証アプリの6桁コードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await loginService.verifyTotp(pendingToken, totpCode);
+      finishLogin(result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '認証コードが正しくありません。';
+      showAlert('認証エラー', message);
+      setTotpCode('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isTotpStep) return;
+    const timer = setTimeout(scrollToFormBottom, 150);
+    return () => clearTimeout(timer);
+  }, [isTotpStep, totpSecret]);
+
+  return {
+    step,
+    inviteCode,
+    setInviteCode,
+    family,
+    members,
+    selectedMember,
+    password,
+    setPassword,
+    totpSecret,
+    totpCode,
+    setTotpCode,
+    loading,
+    accentColor,
+    scrollRef,
+    isTotpStep,
+    scrollToFormBottom,
+    handleResolveFamily,
+    handleSelectMember,
+    handleLogin,
+    handleConfirmTotpSetup,
+    handleVerifyTotp,
+    resetToInvite,
+    goBackToMember,
+  };
+}
+
+export type LoginFlow = ReturnType<typeof useLoginFlow>;

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,0 +1,9 @@
+export { useLoginFlow } from './hooks/useLoginFlow';
+export type { LoginFlow } from './hooks/useLoginFlow';
+export type { LoginStep } from './types';
+export { InviteCodeStep } from './components/InviteCodeStep';
+export { MemberSelectStep } from './components/MemberSelectStep';
+export { PasswordStep } from './components/PasswordStep';
+export { TotpSetupStep } from './components/TotpSetupStep';
+export { TotpVerifyStep } from './components/TotpVerifyStep';
+export { authScreenStyles } from './styles/authScreenStyles';

--- a/frontend/src/features/auth/styles/authScreenStyles.ts
+++ b/frontend/src/features/auth/styles/authScreenStyles.ts
@@ -1,0 +1,132 @@
+import { StyleSheet } from 'react-native';
+import { borderRadius, spacing } from '../../../theme';
+
+/** Issue #100-7 (#431): ログイン画面の共通スタイル（theme token + formStyles 準拠） */
+export const authScreenStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: spacing.xl + spacing.sm,
+    paddingBottom: spacing.xl + spacing.md,
+  },
+  scrollContentCentered: {
+    justifyContent: 'center',
+  },
+  scrollContentTotp: {
+    justifyContent: 'flex-start',
+    paddingTop: spacing.lg,
+    paddingBottom: 160,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: 'white',
+    marginBottom: spacing.xs,
+    textAlign: 'center',
+  },
+  tagline: {
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.75)',
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+  familyLabel: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: 'white',
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: 'rgba(255,255,255,0.8)',
+    marginBottom: spacing.lg,
+    textAlign: 'center',
+  },
+  secretBox: {
+    width: '100%',
+    backgroundColor: 'rgba(0,0,0,0.2)',
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  secretLabel: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 13,
+    marginBottom: spacing.sm,
+  },
+  secretText: {
+    color: 'white',
+    fontSize: 14,
+    fontFamily: 'monospace',
+  },
+  inputWrapper: {
+    width: '100%',
+    marginBottom: spacing.lg,
+  },
+  input: {
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    color: 'white',
+    fontSize: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+    minHeight: 48,
+  },
+  primaryButton: {
+    backgroundColor: 'white',
+    width: '100%',
+    padding: spacing.md + 2,
+    borderRadius: borderRadius.lg,
+    marginBottom: spacing.md - 4,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  secondaryButton: {
+    width: '100%',
+    padding: 14,
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  secondaryButtonText: {
+    color: 'rgba(255,255,255,0.9)',
+    fontSize: 15,
+  },
+  linkButton: {
+    width: '100%',
+    padding: spacing.md - 4,
+    alignItems: 'center',
+  },
+  linkButtonText: {
+    color: 'rgba(255,255,255,0.75)',
+    fontSize: 14,
+    textDecorationLine: 'underline',
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  memberList: {
+    maxHeight: 280,
+    width: '100%',
+    marginBottom: spacing.md,
+  },
+  memberListContent: {
+    gap: spacing.md - 4,
+  },
+  memberButton: {
+    backgroundColor: 'white',
+    padding: spacing.md + 2,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+  },
+  memberButtonText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -1,0 +1,1 @@
+export type LoginStep = 'invite' | 'member' | 'password' | 'totp_setup' | 'totp_verify';

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -1,487 +1,99 @@
-import React, { useEffect, useRef, useState } from 'react';
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
-import { loginService } from '../services/loginService';
-import type { AuthFamilyMember, LoginResult, ResolvedFamily } from '../types/auth';
-import { getAppDisplayName, devUiColors, isDevAppEnv } from '../config/appEnv';
+import React from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, Text } from 'react-native';
 import { DevEnvironmentBanner } from '../components/DevEnvironmentBanner';
-import { theme } from '../theme';
-import { showAlert } from '../utils/alertMessage';
-import { getApiErrorMessage } from '../utils/apiError';
-
-type LoginStep = 'invite' | 'member' | 'password' | 'totp_setup' | 'totp_verify';
+import { getAppDisplayName } from '../config/appEnv';
+import {
+  authScreenStyles,
+  InviteCodeStep,
+  MemberSelectStep,
+  PasswordStep,
+  TotpSetupStep,
+  TotpVerifyStep,
+  useLoginFlow,
+} from '../features/auth';
+import type { LoginResult } from '../types/auth';
 
 type Props = {
   onLoginSuccess: (result: LoginResult, context: { familyName: string; inviteCode: string }) => void;
 };
 
+/** Issue #100-7 (#431): step router のみ — 認証ロジックは features/auth/useLoginFlow */
 export function LoginScreen({ onLoginSuccess }: Props) {
-  const scrollRef = useRef<ScrollView>(null);
-  const [step, setStep] = useState<LoginStep>('invite');
-  const [inviteCode, setInviteCode] = useState('');
-  const [family, setFamily] = useState<ResolvedFamily | null>(null);
-  const [members, setMembers] = useState<AuthFamilyMember[]>([]);
-  const [selectedMember, setSelectedMember] = useState<AuthFamilyMember | null>(null);
-  const [password, setPassword] = useState('');
-  const [pendingToken, setPendingToken] = useState<string | null>(null);
-  const [totpSecret, setTotpSecret] = useState<string | null>(null);
-  const [totpCode, setTotpCode] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const accentColor = isDevAppEnv() ? devUiColors.loginPrimary : theme.colors.primary;
-
-  const finishLogin = (result: LoginResult) => {
-    if (!family) return;
-    onLoginSuccess(result, { familyName: family.name, inviteCode: inviteCode.trim() });
-  };
-
-  const resetToInvite = () => {
-    setStep('invite');
-    setFamily(null);
-    setMembers([]);
-    setSelectedMember(null);
-    setPassword('');
-    setPendingToken(null);
-    setTotpSecret(null);
-    setTotpCode('');
-  };
-
-  const handleResolveFamily = async () => {
-    if (!inviteCode.trim()) {
-      showAlert('入力エラー', '招待コードを入力してください。');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const resolved = await loginService.resolveFamily(inviteCode);
-      const memberList = await loginService.getFamilyMembers(
-        resolved.familyGroupId,
-        inviteCode
-      );
-      setFamily(resolved);
-      setMembers(memberList);
-      setStep('member');
-    } catch (e: unknown) {
-      const message = getApiErrorMessage(
-        e,
-        '招待コードの確認に失敗しました。ネットワーク接続を確認してください。'
-      );
-      showAlert('エラー', message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleSelectMember = (member: AuthFamilyMember) => {
-    setSelectedMember(member);
-    setPassword('');
-    setStep('password');
-  };
-
-  const handleLogin = async () => {
-    if (!family || !selectedMember) return;
-    if (!password) {
-      showAlert('入力エラー', 'パスワードを入力してください。');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const response = await loginService.login(
-        family.familyGroupId,
-        selectedMember.id,
-        password
-      );
-
-      if (response.token) {
-        finishLogin({ token: response.token, member: response.member });
-        return;
-      }
-
-      if (!response.pendingToken) {
-        throw new Error('認証トークンを取得できませんでした。');
-      }
-
-      setPendingToken(response.pendingToken);
-
-      if (response.requiresTotpSetup) {
-        const setup = await loginService.startTotpSetup(response.pendingToken);
-        setTotpSecret(setup.secret);
-        setTotpCode('');
-        setStep('totp_setup');
-        return;
-      }
-
-      if (response.requiresTotpVerification) {
-        setTotpCode('');
-        setStep('totp_verify');
-        return;
-      }
-
-      throw new Error('想定外のログイン応答です。');
-    } catch (e: unknown) {
-      const message =
-        e instanceof Error ? e.message : 'ログインに失敗しました。';
-      showAlert('認証エラー', message);
-      setPassword('');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleConfirmTotpSetup = async () => {
-    if (!pendingToken || !totpCode.trim()) {
-      showAlert('入力エラー', '認証アプリの6桁コードを入力してください。');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const result = await loginService.confirmTotpSetup(pendingToken, totpCode);
-      finishLogin(result);
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : '認証コードの確認に失敗しました。';
-      showAlert('エラー', message);
-      setTotpCode('');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleVerifyTotp = async () => {
-    if (!pendingToken || !totpCode.trim()) {
-      showAlert('入力エラー', '認証アプリの6桁コードを入力してください。');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const result = await loginService.verifyTotp(pendingToken, totpCode);
-      finishLogin(result);
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : '認証コードが正しくありません。';
-      showAlert('認証エラー', message);
-      setTotpCode('');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const scrollToFormBottom = () => {
-    scrollRef.current?.scrollToEnd({ animated: true });
-  };
-
-  useEffect(() => {
-    if (step !== 'totp_setup' && step !== 'totp_verify') return;
-    const timer = setTimeout(scrollToFormBottom, 150);
-    return () => clearTimeout(timer);
-  }, [step, totpSecret]);
-
-  const renderTotpStep = (isSetup: boolean) => (
-    <>
-      <Text style={styles.familyLabel}>{family?.name}</Text>
-      <Text style={styles.subtitle}>
-        {isSetup
-          ? '二要素認証の設定（初回ログイン）'
-          : '二要素認証コードを入力'}
-      </Text>
-      {isSetup && totpSecret ? (
-        <View style={styles.secretBox}>
-          <Text style={styles.secretLabel}>認証アプリに登録するキー</Text>
-          <Text style={styles.secretText} selectable>
-            {totpSecret}
-          </Text>
-        </View>
-      ) : null}
-      <View style={styles.inputWrapper}>
-        <TextInput
-          style={styles.input}
-          placeholder="6桁コード"
-          placeholderTextColor="rgba(255,255,255,0.6)"
-          value={totpCode}
-          onChangeText={setTotpCode}
-          onFocus={scrollToFormBottom}
-          keyboardType="number-pad"
-          maxLength={6}
-          editable={!loading}
-        />
-      </View>
-      <TouchableOpacity
-        style={[styles.primaryButton, loading && styles.buttonDisabled]}
-        onPress={isSetup ? handleConfirmTotpSetup : handleVerifyTotp}
-        disabled={loading}
-      >
-        {loading ? (
-          <ActivityIndicator color={accentColor} />
-        ) : (
-          <Text style={[styles.primaryButtonText, { color: accentColor }]}>
-            {isSetup ? '設定を完了' : '確認'}
-          </Text>
-        )}
-      </TouchableOpacity>
-    </>
-  );
-
-  const renderInviteStep = () => (
-    <>
-      <Text style={styles.subtitle}>招待コードを入力してください</Text>
-      <View style={styles.inputWrapper}>
-        <TextInput
-          style={styles.input}
-          placeholder="例: YAMAMOTO-2026"
-          placeholderTextColor="rgba(255,255,255,0.6)"
-          value={inviteCode}
-          onChangeText={setInviteCode}
-          autoCapitalize="characters"
-          autoCorrect={false}
-          editable={!loading}
-        />
-      </View>
-      <TouchableOpacity
-        style={[styles.primaryButton, loading && styles.buttonDisabled]}
-        onPress={handleResolveFamily}
-        disabled={loading}
-      >
-        {loading ? (
-          <ActivityIndicator color={accentColor} />
-        ) : (
-          <Text style={[styles.primaryButtonText, { color: accentColor }]}>次へ</Text>
-        )}
-      </TouchableOpacity>
-    </>
-  );
-
-  const renderMemberStep = () => (
-    <>
-      <Text style={styles.familyLabel}>{family?.name}</Text>
-      <Text style={styles.subtitle}>ログインするメンバーを選択</Text>
-      <ScrollView style={styles.memberList} contentContainerStyle={styles.memberListContent}>
-        {members.map((member) => (
-          <TouchableOpacity
-            key={member.id}
-            style={styles.memberButton}
-            onPress={() => handleSelectMember(member)}
-            disabled={loading}
-          >
-            <Text style={[styles.memberButtonText, { color: accentColor }]}>{member.name}</Text>
-          </TouchableOpacity>
-        ))}
-      </ScrollView>
-      <TouchableOpacity style={styles.linkButton} onPress={resetToInvite} disabled={loading}>
-        <Text style={styles.linkButtonText}>別の世帯でログイン</Text>
-      </TouchableOpacity>
-    </>
-  );
-
-  const renderPasswordStep = () => (
-    <>
-      <Text style={styles.familyLabel}>{family?.name}</Text>
-      <Text style={styles.subtitle}>{selectedMember?.name} としてログイン</Text>
-      <View style={styles.inputWrapper}>
-        <TextInput
-          style={styles.input}
-          placeholder="パスワードを入力"
-          placeholderTextColor="rgba(255,255,255,0.6)"
-          secureTextEntry
-          value={password}
-          onChangeText={setPassword}
-          autoCapitalize="none"
-          autoCorrect={false}
-          editable={!loading}
-          onSubmitEditing={handleLogin}
-        />
-      </View>
-      <TouchableOpacity
-        style={[styles.primaryButton, loading && styles.buttonDisabled]}
-        onPress={handleLogin}
-        disabled={loading}
-      >
-        {loading ? (
-          <ActivityIndicator color={accentColor} />
-        ) : (
-          <Text style={[styles.primaryButtonText, { color: accentColor }]}>ログイン</Text>
-        )}
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={styles.secondaryButton}
-        onPress={() => {
-          setSelectedMember(null);
-          setPassword('');
-          setStep('member');
-        }}
-        disabled={loading}
-      >
-        <Text style={styles.secondaryButtonText}>メンバー選択に戻る</Text>
-      </TouchableOpacity>
-      <TouchableOpacity style={styles.linkButton} onPress={resetToInvite} disabled={loading}>
-        <Text style={styles.linkButtonText}>別の世帯でログイン</Text>
-      </TouchableOpacity>
-    </>
-  );
-
-  const isTotpStep = step === 'totp_setup' || step === 'totp_verify';
+  const flow = useLoginFlow({ onLoginSuccess });
 
   return (
     <KeyboardAvoidingView
-      style={[styles.container, { backgroundColor: accentColor }]}
+      style={[authScreenStyles.container, { backgroundColor: flow.accentColor }]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <ScrollView
-        ref={scrollRef}
+        ref={flow.scrollRef}
         contentContainerStyle={[
-          styles.scrollContent,
-          isTotpStep ? styles.scrollContentTotp : styles.scrollContentCentered,
+          authScreenStyles.scrollContent,
+          flow.isTotpStep ? authScreenStyles.scrollContentTotp : authScreenStyles.scrollContentCentered,
         ]}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
         <DevEnvironmentBanner />
-        <Text style={styles.title}>{getAppDisplayName()}</Text>
-        <Text style={styles.tagline}>レシートで家計を管理</Text>
-        {step === 'invite' && renderInviteStep()}
-        {step === 'member' && renderMemberStep()}
-        {step === 'password' && renderPasswordStep()}
-        {step === 'totp_setup' && renderTotpStep(true)}
-        {step === 'totp_verify' && renderTotpStep(false)}
+        <Text style={authScreenStyles.title}>{getAppDisplayName()}</Text>
+        <Text style={authScreenStyles.tagline}>レシートで家計を管理</Text>
+        {flow.step === 'invite' && (
+          <InviteCodeStep
+            inviteCode={flow.inviteCode}
+            loading={flow.loading}
+            accentColor={flow.accentColor}
+            onInviteCodeChange={flow.setInviteCode}
+            onSubmit={flow.handleResolveFamily}
+          />
+        )}
+        {flow.step === 'member' && (
+          <MemberSelectStep
+            familyName={flow.family?.name}
+            members={flow.members}
+            loading={flow.loading}
+            accentColor={flow.accentColor}
+            onSelectMember={flow.handleSelectMember}
+            onResetToInvite={flow.resetToInvite}
+          />
+        )}
+        {flow.step === 'password' && (
+          <PasswordStep
+            familyName={flow.family?.name}
+            memberName={flow.selectedMember?.name}
+            password={flow.password}
+            loading={flow.loading}
+            accentColor={flow.accentColor}
+            onPasswordChange={flow.setPassword}
+            onSubmit={flow.handleLogin}
+            onBackToMember={flow.goBackToMember}
+            onResetToInvite={flow.resetToInvite}
+          />
+        )}
+        {flow.step === 'totp_setup' && (
+          <TotpSetupStep
+            familyName={flow.family?.name}
+            totpSecret={flow.totpSecret}
+            totpCode={flow.totpCode}
+            loading={flow.loading}
+            accentColor={flow.accentColor}
+            onTotpCodeChange={flow.setTotpCode}
+            onSubmit={flow.handleConfirmTotpSetup}
+            onInputFocus={flow.scrollToFormBottom}
+          />
+        )}
+        {flow.step === 'totp_verify' && (
+          <TotpVerifyStep
+            familyName={flow.family?.name}
+            totpCode={flow.totpCode}
+            loading={flow.loading}
+            accentColor={flow.accentColor}
+            onTotpCodeChange={flow.setTotpCode}
+            onSubmit={flow.handleVerifyTotp}
+            onInputFocus={flow.scrollToFormBottom}
+          />
+        )}
       </ScrollView>
     </KeyboardAvoidingView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  scrollContent: {
-    flexGrow: 1,
-    padding: 40,
-    paddingBottom: 48,
-  },
-  scrollContentCentered: {
-    justifyContent: 'center',
-  },
-  scrollContentTotp: {
-    justifyContent: 'flex-start',
-    paddingTop: 24,
-    paddingBottom: 160,
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    color: 'white',
-    marginBottom: 4,
-    textAlign: 'center',
-  },
-  tagline: {
-    fontSize: 14,
-    color: 'rgba(255,255,255,0.75)',
-    marginBottom: 16,
-    textAlign: 'center',
-  },
-  familyLabel: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: 'white',
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 16,
-    color: 'rgba(255,255,255,0.8)',
-    marginBottom: 24,
-    textAlign: 'center',
-  },
-  secretBox: {
-    width: '100%',
-    backgroundColor: 'rgba(0,0,0,0.2)',
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 16,
-  },
-  secretLabel: {
-    color: 'rgba(255,255,255,0.8)',
-    fontSize: 13,
-    marginBottom: 8,
-  },
-  secretText: {
-    color: 'white',
-    fontSize: 14,
-    fontFamily: 'monospace',
-  },
-  inputWrapper: {
-    width: '100%',
-    marginBottom: 20,
-  },
-  input: {
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    borderRadius: 12,
-    padding: 15,
-    color: 'white',
-    fontSize: 18,
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.3)',
-  },
-  primaryButton: {
-    backgroundColor: 'white',
-    width: '100%',
-    padding: 18,
-    borderRadius: 15,
-    marginBottom: 12,
-    alignItems: 'center',
-  },
-  primaryButtonText: {
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-  secondaryButton: {
-    width: '100%',
-    padding: 14,
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  secondaryButtonText: {
-    color: 'rgba(255,255,255,0.9)',
-    fontSize: 15,
-  },
-  linkButton: {
-    width: '100%',
-    padding: 12,
-    alignItems: 'center',
-  },
-  linkButtonText: {
-    color: 'rgba(255,255,255,0.75)',
-    fontSize: 14,
-    textDecorationLine: 'underline',
-  },
-  buttonDisabled: {
-    opacity: 0.7,
-  },
-  memberList: {
-    maxHeight: 280,
-    width: '100%',
-    marginBottom: 16,
-  },
-  memberListContent: {
-    gap: 12,
-  },
-  memberButton: {
-    backgroundColor: 'white',
-    padding: 18,
-    borderRadius: 15,
-    alignItems: 'center',
-  },
-  memberButtonText: {
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-});


### PR DESCRIPTION
## Summary

- `features/auth/` を新設
  - `hooks/useLoginFlow.ts` — 認証フロー state / API 呼び出し
  - `components/` — InviteCodeStep, MemberSelectStep, PasswordStep, TotpSetupStep, TotpVerifyStep
  - `styles/authScreenStyles.ts` — theme token + `formStyles.field` 準拠
- `LoginScreen.tsx` を **99 行**の step router のみに薄型化（487行 → 99行）
- StyleSheet を Screen から feature 層へ移行（Screen 内 Style 行数 127 → 0）

Closes #431

## Test plan

- [x] `cd frontend && npm test` — 46 tests passed
- [ ] 招待コード → メンバー選択 → パスワード → ログイン（Web / Native 目視）
- [ ] TOTP 設定 / 検証フロー（該当アカウントで目視）


Made with [Cursor](https://cursor.com)