### PR TITLE
refactor(fe): [Issue #100-9] HomeScreen View 分離 + Style Pattern 適用

### DIFF
--- a/frontend/src/features/home/components/HomeCaptureButton.tsx
+++ b/frontend/src/features/home/components/HomeCaptureButton.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import { homeScreenStyles } from '../styles/homeScreenStyles';
+
+type Props = {
+  acceptanceMessage: string | null;
+  uploadingCount: number;
+  pendingBadgeCount: number;
+  trayItemCount: number;
+  onPress: () => void;
+};
+
+export const HomeCaptureButton: React.FC<Props> = ({
+  acceptanceMessage,
+  uploadingCount,
+  pendingBadgeCount,
+  trayItemCount,
+  onPress,
+}) => (
+  <>
+    {acceptanceMessage ? (
+      <View style={homeScreenStyles.acceptanceBanner}>
+        <Text style={homeScreenStyles.acceptanceBannerText}>{acceptanceMessage}</Text>
+      </View>
+    ) : null}
+
+    <TouchableOpacity style={homeScreenStyles.captureButton} activeOpacity={0.8} onPress={onPress}>
+      <View style={homeScreenStyles.iconCircle}>
+        {uploadingCount > 0 ? (
+          <ActivityIndicator color="white" />
+        ) : (
+          <Text style={{ fontSize: 20 }}>📷</Text>
+        )}
+      </View>
+      <View style={homeScreenStyles.captureButtonBody}>
+        <Text style={homeScreenStyles.captureButtonText}>レシートを撮影・解析</Text>
+        {pendingBadgeCount > 0 ? (
+          <Text style={homeScreenStyles.captureSubText}>
+            解析中 {pendingBadgeCount} 件 — 続けて撮影できます
+          </Text>
+        ) : null}
+      </View>
+      {trayItemCount > 0 ? (
+        <View style={homeScreenStyles.captureCountBadge}>
+          <Text style={homeScreenStyles.captureCountBadgeText}>{trayItemCount}</Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  </>
+);

--- a/frontend/src/features/home/components/HomeDashboardCard.tsx
+++ b/frontend/src/features/home/components/HomeDashboardCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { AppButton } from '../../../components/ui';
+import { getAppDisplayName, getMemberMenuTitle, isDevAppEnv } from '../../../config/appEnv';
+import { homeScreenStyles } from '../styles/homeScreenStyles';
+
+type Props = {
+  memberName?: string | null;
+  monthlyTotal: number;
+  onGoToStats: () => void;
+};
+
+export const HomeDashboardCard: React.FC<Props> = ({ memberName, monthlyTotal, onGoToStats }) => (
+  <>
+    <View style={[homeScreenStyles.header, isDevAppEnv() && homeScreenStyles.headerDev]}>
+      <Text style={homeScreenStyles.headerSubtitle}>{getAppDisplayName()}</Text>
+      <Text style={homeScreenStyles.headerTitle}>{getMemberMenuTitle(memberName)}</Text>
+    </View>
+
+    <View style={homeScreenStyles.summaryCard}>
+      <Text style={homeScreenStyles.summaryLabel}>今月の利用合計</Text>
+      <View style={homeScreenStyles.summaryAmountRow}>
+        <Text style={homeScreenStyles.summarySymbol}>¥</Text>
+        <Text style={homeScreenStyles.summaryAmount}>{monthlyTotal.toLocaleString()}</Text>
+      </View>
+      <View style={homeScreenStyles.summaryDivider} />
+      <AppButton
+        title="統計の詳細を見る ›"
+        onPress={onGoToStats}
+        variant="outline"
+        size="sm"
+        style={homeScreenStyles.summaryLinkButton}
+        textStyle={homeScreenStyles.summaryLinkText}
+      />
+    </View>
+  </>
+);

--- a/frontend/src/features/home/components/HomeMenuGrid.tsx
+++ b/frontend/src/features/home/components/HomeMenuGrid.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
+import { AppListItem } from '../../../components/ui';
+import { theme } from '../../../theme';
+import { homeScreenStyles } from '../styles/homeScreenStyles';
+
+type LatestReceipt = {
+  storeName?: string;
+  date?: string;
+  totalAmount?: number;
+};
+
+type Props = {
+  isWide: boolean;
+  isAdmin: boolean;
+  trayItemCount: number;
+  loading: boolean;
+  latestReceipt: LatestReceipt | null;
+  onGoToReceiptTray: () => void;
+  onGoToHistory: () => void;
+  onGoToStats: () => void;
+  onGoToSettlement?: () => void;
+  onGoToAdminMenu?: () => void;
+};
+
+export const HomeMenuGrid: React.FC<Props> = ({
+  isWide,
+  isAdmin,
+  trayItemCount,
+  loading,
+  latestReceipt,
+  onGoToReceiptTray,
+  onGoToHistory,
+  onGoToStats,
+  onGoToSettlement,
+  onGoToAdminMenu,
+}) => (
+  <>
+    <View style={homeScreenStyles.gridContainer}>
+      <AppListItem
+        variant="nav"
+        onPress={onGoToReceiptTray}
+        title="確認トレイ"
+        subtitle={trayItemCount > 0 ? `${trayItemCount} 件の受付` : '解析状況を確認'}
+        left={<Text style={homeScreenStyles.gridEmoji}>📥</Text>}
+        right={
+          trayItemCount > 0 ? (
+            <View style={homeScreenStyles.gridCountBadge}>
+              <Text style={homeScreenStyles.gridCountBadgeText}>{trayItemCount}</Text>
+            </View>
+          ) : (
+            <View />
+          )
+        }
+        style={homeScreenStyles.gridCard}
+      />
+      <AppListItem
+        variant="nav"
+        onPress={onGoToHistory}
+        title="履歴一覧"
+        left={<Text style={homeScreenStyles.gridEmoji}>📋</Text>}
+        right={<View />}
+        style={homeScreenStyles.gridCard}
+      />
+      <AppListItem
+        variant="nav"
+        onPress={onGoToStats}
+        title="支出統計"
+        left={<Text style={homeScreenStyles.gridEmoji}>📊</Text>}
+        right={<View />}
+        style={homeScreenStyles.gridCard}
+      />
+      {onGoToSettlement && isWide ? (
+        <AppListItem
+          variant="nav"
+          onPress={onGoToSettlement}
+          title="精算サマリー"
+          left={<Text style={homeScreenStyles.gridEmoji}>🤝</Text>}
+          right={<View />}
+          style={homeScreenStyles.gridCard}
+        />
+      ) : null}
+    </View>
+
+    {isAdmin ? (
+      <View style={homeScreenStyles.section}>
+        <AppListItem
+          variant="nav"
+          onPress={onGoToAdminMenu}
+          title="管理者メニュー"
+          subtitle="マスタ管理・システム設定"
+          style={homeScreenStyles.adminListItem}
+          left={
+            <View
+              style={[
+                homeScreenStyles.settingsIconWrapper,
+                { backgroundColor: theme.colors.semantic.icon.adminCard },
+              ]}
+            >
+              <Text>🛡️</Text>
+            </View>
+          }
+        />
+      </View>
+    ) : null}
+
+    <View style={homeScreenStyles.section}>
+      <Text style={homeScreenStyles.sectionTitle}>最近の登録</Text>
+      {loading ? (
+        <ActivityIndicator color={theme.colors.primary} style={homeScreenStyles.loadingIndicator} />
+      ) : latestReceipt ? (
+        <AppListItem
+          variant="nav"
+          onPress={onGoToHistory}
+          title={latestReceipt.storeName || '店名不明'}
+          subtitle={
+            latestReceipt.date
+              ? new Date(latestReceipt.date).toLocaleDateString('ja-JP')
+              : '日付不明'
+          }
+          right={
+            <Text style={homeScreenStyles.amountText}>
+              ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
+            </Text>
+          }
+          style={homeScreenStyles.latestCard}
+        />
+      ) : (
+        <View style={homeScreenStyles.latestCardEmpty}>
+          <Text style={homeScreenStyles.dateText}>表示できるデータがありません</Text>
+        </View>
+      )}
+    </View>
+  </>
+);

--- a/frontend/src/features/home/components/HomeTrayPreview.tsx
+++ b/frontend/src/features/home/components/HomeTrayPreview.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { ReceiptTrayPanel } from '../../../components/ReceiptTrayPanel';
+import type { ReceiptTrayItem } from '../../../types/receiptJob';
+import { homeScreenStyles } from '../styles/homeScreenStyles';
+
+const HOME_TRAY_PREVIEW_LIMIT = 2;
+
+type Props = {
+  trayItems: ReceiptTrayItem[];
+  trayItemCount: number;
+  onGoToReceiptTray: () => void;
+  onItemPress: (item: ReceiptTrayItem) => void;
+  onItemDiscard: (item: ReceiptTrayItem) => void;
+  canOpenItem: (item: ReceiptTrayItem) => boolean;
+  canDiscardItem: (item: ReceiptTrayItem) => boolean;
+};
+
+export const HomeTrayPreview: React.FC<Props> = ({
+  trayItems,
+  trayItemCount,
+  onGoToReceiptTray,
+  onItemPress,
+  onItemDiscard,
+  canOpenItem,
+  canDiscardItem,
+}) => (
+  <View style={homeScreenStyles.traySection}>
+    <View style={homeScreenStyles.traySectionHeader}>
+      <Text style={homeScreenStyles.sectionTitle}>確認トレイ</Text>
+      {trayItemCount > 0 ? (
+        <TouchableOpacity onPress={onGoToReceiptTray}>
+          <Text style={homeScreenStyles.trayOpenLink}>すべて見る</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+    <ReceiptTrayPanel
+      items={trayItems}
+      maxItems={HOME_TRAY_PREVIEW_LIMIT}
+      showSectionHeaders={trayItemCount > 0}
+      onOpenFullTray={onGoToReceiptTray}
+      onItemPress={onItemPress}
+      onItemDiscard={onItemDiscard}
+      canOpenItem={canOpenItem}
+      canDiscardItem={canDiscardItem}
+      emptyTitle="確認待ちのレシートはありません"
+      emptyDescription="撮影したレシートの解析状況がここに表示されます。"
+    />
+  </View>
+);

--- a/frontend/src/features/home/index.ts
+++ b/frontend/src/features/home/index.ts
@@ -1,2 +1,7 @@
 export { useHomeDashboard } from './hooks/useHomeDashboard';
 export { useReceiptUpload } from './hooks/useReceiptUpload';
+export { HomeDashboardCard } from './components/HomeDashboardCard';
+export { HomeCaptureButton } from './components/HomeCaptureButton';
+export { HomeTrayPreview } from './components/HomeTrayPreview';
+export { HomeMenuGrid } from './components/HomeMenuGrid';
+export { homeScreenStyles } from './styles/homeScreenStyles';

--- a/frontend/src/features/home/styles/homeScreenStyles.ts
+++ b/frontend/src/features/home/styles/homeScreenStyles.ts
@@ -1,0 +1,223 @@
+import { StyleSheet } from 'react-native';
+import { screenLayout, spacing, theme } from '../../../theme';
+
+/** Issue #100-9 (#433): ホーム画面の固有スタイル（screenLayout / cardStyles 準拠） */
+export const homeScreenStyles = StyleSheet.create({
+  container: screenLayout.container,
+  scrollContent: {
+    ...screenLayout.scrollContent,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: spacing.lg,
+    marginTop: spacing.md,
+  },
+  headerDev: {
+    borderLeftWidth: 4,
+    borderLeftColor: '#b45309',
+    paddingLeft: spacing.sm,
+  },
+  headerSubtitle: {
+    ...theme.typography.caption,
+    color: theme.colors.text.muted,
+    letterSpacing: 0.5,
+  },
+  headerTitle: {
+    ...theme.typography.h1,
+    color: theme.colors.text.main,
+    marginTop: spacing.xs,
+  },
+  summaryCard: {
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.xl,
+    marginBottom: spacing.lg,
+    elevation: 4,
+  },
+  summaryLabel: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  summaryAmountRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginTop: 5,
+  },
+  summarySymbol: {
+    color: theme.colors.text.inverse,
+    fontSize: 20,
+    marginRight: spacing.xs,
+    fontWeight: 'bold',
+  },
+  summaryAmount: {
+    color: theme.colors.text.inverse,
+    fontSize: 36,
+    fontWeight: 'bold',
+  },
+  summaryDivider: {
+    height: 1,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    marginVertical: spacing.md,
+  },
+  summaryLinkButton: {
+    alignSelf: 'flex-end',
+    marginTop: spacing.xs,
+    backgroundColor: 'transparent',
+    borderColor: 'rgba(255,255,255,0.7)',
+  },
+  summaryLinkText: {
+    color: theme.colors.text.inverse,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  acceptanceBanner: {
+    backgroundColor: theme.colors.semantic.surplus.bg,
+    borderRadius: theme.borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.md,
+    borderWidth: 1,
+    borderColor: theme.colors.semantic.surplus.border,
+  },
+  acceptanceBannerText: {
+    color: theme.colors.semantic.surplus.text,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  captureButton: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    padding: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+    borderWidth: 2,
+    borderColor: theme.colors.primary,
+    borderStyle: 'dashed',
+  },
+  captureButtonBody: {
+    flex: 1,
+  },
+  iconCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: theme.colors.primary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.md,
+  },
+  captureButtonText: {
+    ...theme.typography.h2,
+    color: theme.colors.primary,
+  },
+  captureSubText: {
+    fontSize: 12,
+    color: theme.colors.text.muted,
+    marginTop: spacing.xs,
+  },
+  captureCountBadge: {
+    minWidth: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: theme.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+  },
+  captureCountBadgeText: {
+    color: theme.colors.text.inverse,
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  traySection: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    padding: spacing.md,
+    marginBottom: spacing.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  traySectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  trayOpenLink: {
+    color: theme.colors.primary,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  gridCountBadge: {
+    minWidth: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: theme.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 6,
+  },
+  gridCountBadgeText: {
+    color: theme.colors.text.inverse,
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+    marginBottom: spacing.md,
+  },
+  gridCard: {
+    flexGrow: 1,
+    minWidth: 100,
+    flexBasis: '30%',
+  },
+  gridEmoji: {
+    fontSize: 28,
+  },
+  section: {
+    marginTop: spacing.lg,
+  },
+  sectionTitle: {
+    ...theme.typography.h2,
+    color: theme.colors.text.main,
+    marginBottom: spacing.sm,
+  },
+  settingsIconWrapper: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: theme.colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.md,
+  },
+  latestCard: {
+    marginBottom: 0,
+  },
+  latestCardEmpty: {
+    marginBottom: 0,
+    justifyContent: 'center',
+  },
+  amountText: {
+    ...theme.typography.h2,
+    color: theme.colors.primary,
+    fontWeight: 'bold',
+  },
+  dateText: {
+    ...theme.typography.caption,
+    color: theme.colors.text.muted,
+  },
+  sourcePickerActions: {
+    gap: 10,
+    width: '100%',
+  },
+  loadingIndicator: {
+    marginTop: 10,
+  },
+  adminListItem: {
+    backgroundColor: theme.colors.semantic.icon.adminSettings,
+  },
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ScrollView,
-  ActivityIndicator,
-} from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { AppButton, AppListItem, AppModal } from '../components/ui';
+import { AppButton, AppModal } from '../components/ui';
 import { ReceiptImageCropModal } from '../components/ReceiptImageCropModal';
-import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
-import { getAppDisplayName, getMemberMenuTitle, isDevAppEnv } from '../config/appEnv';
 import { useReceiptTray } from '../contexts/ReceiptTrayContext';
-import { theme } from '../theme';
-import { useHomeDashboard, useReceiptUpload } from '../features/home';
+import {
+  HomeCaptureButton,
+  HomeDashboardCard,
+  HomeMenuGrid,
+  HomeTrayPreview,
+  homeScreenStyles,
+  useHomeDashboard,
+  useReceiptUpload,
+} from '../features/home';
 import { useIsWideHomeMenu } from '../hooks/useIsWideLayout';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
 
@@ -30,11 +28,7 @@ interface HomeScreenProps {
   userRole?: string | null;
 }
 
-const HOME_TRAY_PREVIEW_LIMIT = 2;
-
-/**
- * ホーム画面（ダッシュボード）
- */
+/** [Issue #100-9] ホーム画面 — View は features/home/components へ分離 */
 export const HomeScreen: React.FC<HomeScreenProps> = ({
   onAnalysisReady: _onAnalysisReady,
   onGoToHistory,
@@ -46,207 +40,58 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   memberName,
   userRole,
 }) => {
-  const {
-    activeCount,
-    refresh: refreshJobs,
-    trayItems,
-    trayItemCount,
-    addLocalFailedJob,
-    openTrayItem,
-    discardTrayItem,
-    canOpenTrayItem,
-    canDiscardTrayItem,
-  } = useReceiptTray();
-
+  const tray = useReceiptTray();
   const { latestReceipt, monthlyTotal, loading } = useHomeDashboard(currentMemberId);
-
   const upload = useReceiptUpload({
     currentMemberId,
-    onUploadAccepted: refreshJobs,
-    registerLocalUploadFailure: addLocalFailedJob,
+    onUploadAccepted: tray.refresh,
+    registerLocalUploadFailure: tray.addLocalFailedJob,
   });
 
-  const pendingBadgeCount = activeCount + upload.uploadingCount;
+  const pendingBadgeCount = tray.activeCount + upload.uploadingCount;
   const isWide = useIsWideHomeMenu();
   const isAdmin = userRole === 'ADMIN';
 
   return (
     <>
-      <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-        <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
-          <View style={[styles.header, isDevAppEnv() && styles.headerDev]}>
-            <Text style={styles.headerSubtitle}>{getAppDisplayName()}</Text>
-            <Text style={styles.headerTitle}>{getMemberMenuTitle(memberName)}</Text>
-          </View>
+      <SafeAreaView style={homeScreenStyles.container} edges={['left', 'right', 'bottom']}>
+        <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={homeScreenStyles.scrollContent}>
+          <HomeDashboardCard
+            memberName={memberName}
+            monthlyTotal={monthlyTotal}
+            onGoToStats={onGoToStats}
+          />
 
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryLabel}>今月の利用合計</Text>
-            <View style={styles.summaryAmountRow}>
-              <Text style={styles.summarySymbol}>¥</Text>
-              <Text style={styles.summaryAmount}>{monthlyTotal.toLocaleString()}</Text>
-            </View>
-            <View style={styles.summaryDivider} />
-            <AppButton
-              title="統計の詳細を見る ›"
-              onPress={onGoToStats}
-              variant="outline"
-              size="sm"
-              style={styles.summaryLinkButton}
-              textStyle={styles.summaryLinkText}
-            />
-          </View>
-
-          {upload.acceptanceMessage ? (
-            <View style={styles.acceptanceBanner}>
-              <Text style={styles.acceptanceBannerText}>{upload.acceptanceMessage}</Text>
-            </View>
-          ) : null}
-
-          <TouchableOpacity
-            style={styles.captureButton}
-            activeOpacity={0.8}
+          <HomeCaptureButton
+            acceptanceMessage={upload.acceptanceMessage}
+            uploadingCount={upload.uploadingCount}
+            pendingBadgeCount={pendingBadgeCount}
+            trayItemCount={tray.trayItemCount}
             onPress={() => void upload.handleScan()}
-          >
-            <View style={styles.iconCircle}>
-              {upload.uploadingCount > 0 ? (
-                <ActivityIndicator color="white" />
-              ) : (
-                <Text style={{ fontSize: 20 }}>📷</Text>
-              )}
-            </View>
-            <View style={{ flex: 1 }}>
-              <Text style={styles.captureButtonText}>レシートを撮影・解析</Text>
-              {pendingBadgeCount > 0 ? (
-                <Text style={styles.captureSubText}>
-                  解析中 {pendingBadgeCount} 件 — 続けて撮影できます
-                </Text>
-              ) : null}
-            </View>
-            {trayItemCount > 0 ? (
-              <View style={styles.captureCountBadge}>
-                <Text style={styles.captureCountBadgeText}>{trayItemCount}</Text>
-              </View>
-            ) : null}
-          </TouchableOpacity>
+          />
 
-          <View style={styles.traySection}>
-            <View style={styles.traySectionHeader}>
-              <Text style={styles.sectionTitle}>確認トレイ</Text>
-              {trayItemCount > 0 ? (
-                <TouchableOpacity onPress={onGoToReceiptTray}>
-                  <Text style={styles.trayOpenLink}>すべて見る</Text>
-                </TouchableOpacity>
-              ) : null}
-            </View>
-            <ReceiptTrayPanel
-              items={trayItems}
-              maxItems={HOME_TRAY_PREVIEW_LIMIT}
-              showSectionHeaders={trayItemCount > 0}
-              onOpenFullTray={onGoToReceiptTray}
-              onItemPress={(item) => void openTrayItem(item)}
-              onItemDiscard={(item) => void discardTrayItem(item)}
-              canOpenItem={canOpenTrayItem}
-              canDiscardItem={canDiscardTrayItem}
-              emptyTitle="確認待ちのレシートはありません"
-              emptyDescription="撮影したレシートの解析状況がここに表示されます。"
-            />
-          </View>
+          <HomeTrayPreview
+            trayItems={tray.trayItems}
+            trayItemCount={tray.trayItemCount}
+            onGoToReceiptTray={onGoToReceiptTray}
+            onItemPress={(item) => void tray.openTrayItem(item)}
+            onItemDiscard={(item) => void tray.discardTrayItem(item)}
+            canOpenItem={tray.canOpenTrayItem}
+            canDiscardItem={tray.canDiscardTrayItem}
+          />
 
-          <View style={styles.gridContainer}>
-            <AppListItem
-              variant="nav"
-              onPress={onGoToReceiptTray}
-              title="確認トレイ"
-              subtitle={trayItemCount > 0 ? `${trayItemCount} 件の受付` : '解析状況を確認'}
-              left={<Text style={styles.gridEmoji}>📥</Text>}
-              right={
-                trayItemCount > 0 ? (
-                  <View style={styles.gridCountBadge}>
-                    <Text style={styles.gridCountBadgeText}>{trayItemCount}</Text>
-                  </View>
-                ) : (
-                  <View />
-                )
-              }
-              style={styles.gridCard}
-            />
-            <AppListItem
-              variant="nav"
-              onPress={onGoToHistory}
-              title="履歴一覧"
-              left={<Text style={styles.gridEmoji}>📋</Text>}
-              right={<View />}
-              style={styles.gridCard}
-            />
-            <AppListItem
-              variant="nav"
-              onPress={onGoToStats}
-              title="支出統計"
-              left={<Text style={styles.gridEmoji}>📊</Text>}
-              right={<View />}
-              style={styles.gridCard}
-            />
-            {onGoToSettlement && isWide && (
-              <AppListItem
-                variant="nav"
-                onPress={onGoToSettlement}
-                title="精算サマリー"
-                left={<Text style={styles.gridEmoji}>🤝</Text>}
-                right={<View />}
-                style={styles.gridCard}
-              />
-            )}
-          </View>
-
-          {isAdmin && (
-            <View style={styles.section}>
-              <AppListItem
-                variant="nav"
-                onPress={onGoToAdminMenu}
-                title="管理者メニュー"
-                subtitle="マスタ管理・システム設定"
-                style={{ backgroundColor: theme.colors.semantic.icon.adminSettings }}
-                left={
-                  <View
-                    style={[
-                      styles.settingsIconWrapper,
-                      { backgroundColor: theme.colors.semantic.icon.adminCard },
-                    ]}
-                  >
-                    <Text>🛡️</Text>
-                  </View>
-                }
-              />
-            </View>
-          )}
-
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>最近の登録</Text>
-            {loading ? (
-              <ActivityIndicator color={theme.colors.primary} style={{ marginTop: 10 }} />
-            ) : latestReceipt ? (
-              <AppListItem
-                variant="nav"
-                onPress={onGoToHistory}
-                title={latestReceipt.storeName || '店名不明'}
-                subtitle={
-                  latestReceipt.date
-                    ? new Date(latestReceipt.date).toLocaleDateString('ja-JP')
-                    : '日付不明'
-                }
-                right={
-                  <Text style={styles.amountText}>
-                    ¥{Math.round(latestReceipt.totalAmount || 0).toLocaleString()}
-                  </Text>
-                }
-                style={styles.latestCard}
-              />
-            ) : (
-              <View style={[styles.latestCard, { justifyContent: 'center' }]}>
-                <Text style={styles.dateText}>表示できるデータがありません</Text>
-              </View>
-            )}
-          </View>
+          <HomeMenuGrid
+            isWide={isWide}
+            isAdmin={isAdmin}
+            trayItemCount={tray.trayItemCount}
+            loading={loading}
+            latestReceipt={latestReceipt}
+            onGoToReceiptTray={onGoToReceiptTray}
+            onGoToHistory={onGoToHistory}
+            onGoToStats={onGoToStats}
+            onGoToSettlement={onGoToSettlement}
+            onGoToAdminMenu={onGoToAdminMenu}
+          />
         </ScrollView>
 
         <AppModal
@@ -255,7 +100,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           title="レシート画像"
           description="取得方法を選んでください"
           footer={
-            <View style={styles.sourcePickerActions}>
+            <View style={homeScreenStyles.sourcePickerActions}>
               <AppButton
                 title="カメラ"
                 onPress={() => {
@@ -292,132 +137,3 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
     </>
   );
 };
-
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  scrollContent: { padding: theme.spacing.lg, paddingBottom: 40 },
-  header: { marginBottom: theme.spacing.lg, marginTop: theme.spacing.md },
-  headerDev: {
-    borderLeftWidth: 4,
-    borderLeftColor: '#b45309',
-    paddingLeft: theme.spacing.sm,
-  },
-  headerSubtitle: { ...theme.typography.caption, color: theme.colors.text.muted, letterSpacing: 0.5 },
-  headerTitle: { ...theme.typography.h1, color: theme.colors.text.main, marginTop: theme.spacing.xs },
-  summaryCard: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: theme.borderRadius.lg,
-    padding: theme.spacing.xl,
-    marginBottom: theme.spacing.lg,
-    elevation: 4,
-  },
-  summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, fontWeight: '600' },
-  summaryAmountRow: { flexDirection: 'row', alignItems: 'baseline', marginTop: 5 },
-  summarySymbol: { color: theme.colors.text.inverse, fontSize: 20, marginRight: 4, fontWeight: 'bold' },
-  summaryAmount: { color: theme.colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
-  summaryDivider: { height: 1, backgroundColor: 'rgba(255,255,255,0.2)', marginVertical: theme.spacing.md },
-  summaryLinkButton: {
-    alignSelf: 'flex-end',
-    marginTop: theme.spacing.xs,
-    backgroundColor: 'transparent',
-    borderColor: 'rgba(255,255,255,0.7)',
-  },
-  summaryLinkText: { color: theme.colors.text.inverse, fontSize: 14, fontWeight: '600' },
-  acceptanceBanner: {
-    backgroundColor: theme.colors.semantic.surplus.bg,
-    borderRadius: theme.borderRadius.md,
-    padding: theme.spacing.md,
-    marginBottom: theme.spacing.md,
-    borderWidth: 1,
-    borderColor: theme.colors.semantic.surplus.border,
-  },
-  acceptanceBannerText: {
-    color: theme.colors.semantic.surplus.text,
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  captureButton: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: theme.borderRadius.lg,
-    padding: theme.spacing.lg,
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: theme.spacing.lg,
-    borderWidth: 2,
-    borderColor: theme.colors.primary,
-    borderStyle: 'dashed',
-  },
-  iconCircle: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: theme.colors.primary,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: theme.spacing.md,
-  },
-  captureButtonText: { ...theme.typography.h2, color: theme.colors.primary },
-  captureSubText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 4 },
-  captureCountBadge: {
-    minWidth: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: theme.colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 8,
-  },
-  captureCountBadgeText: { color: theme.colors.text.inverse, fontSize: 12, fontWeight: '700' },
-  traySection: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: theme.borderRadius.lg,
-    padding: theme.spacing.md,
-    marginBottom: theme.spacing.lg,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-  },
-  traySectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing.sm,
-  },
-  trayOpenLink: {
-    color: theme.colors.primary,
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  gridCountBadge: {
-    minWidth: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: theme.colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 6,
-  },
-  gridCountBadgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: '700' },
-  gridContainer: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: theme.spacing.md,
-    marginBottom: theme.spacing.md,
-  },
-  gridCard: { flexGrow: 1, minWidth: 100, flexBasis: '30%' },
-  gridEmoji: { fontSize: 28 },
-  section: { marginTop: theme.spacing.lg },
-  sectionTitle: { ...theme.typography.h2, color: theme.colors.text.main, marginBottom: theme.spacing.sm },
-  settingsIconWrapper: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: theme.colors.background,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: theme.spacing.md,
-  },
-  latestCard: { marginBottom: 0 },
-  amountText: { ...theme.typography.h2, color: theme.colors.primary, fontWeight: 'bold' },
-  dateText: { ...theme.typography.caption, color: theme.colors.text.muted },
-  sourcePickerActions: { gap: 10, width: '100%' },
-});


### PR DESCRIPTION
## Summary

- `features/home/components/` を新設
  - `HomeDashboardCard` — ヘッダー + 月次サマリーカード
  - `HomeCaptureButton` — 受付バナー + 撮影ボタン
  - `HomeTrayPreview` — 確認トレイプレビュー
  - `HomeMenuGrid` — ナビグリッド + 管理者メニュー + 最近の登録
- `styles/homeScreenStyles.ts` — `screenLayout` 準拠の Style 集約
- `HomeScreen.tsx` を **139 行**に薄型化（423行 → 139行、StyleSheet 0行）

Closes #433

## Test plan

- [x] `cd frontend && npm test` — 46 tests passed
- [ ] 月次合計・撮影・トレイプレビュー・メニューグリッドが従来通り（Web / Native 目視）
- [ ] 管理者メニュー・最近の登録セクションが従来通り


Made with [Cursor](https://cursor.com)