### PR TITLE
fix(fe): theme バレル循環参照による ScreenStyles クラッシュ修正

### DIFF
--- a/frontend/src/features/auth/styles/authScreenStyles.ts
+++ b/frontend/src/features/auth/styles/authScreenStyles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native';
-import { borderRadius, spacing } from '../../../theme';
+import { borderRadius } from '../../../theme/radii';
+import { spacing } from '../../../theme/spacing';
 
 /** Issue #100-7 (#431): ログイン画面の共通スタイル（theme token + formStyles 準拠） */
 export const authScreenStyles = StyleSheet.create({

--- a/frontend/src/features/home/styles/homeScreenStyles.ts
+++ b/frontend/src/features/home/styles/homeScreenStyles.ts
@@ -1,5 +1,9 @@
 import { StyleSheet } from 'react-native';
-import { screenLayout, spacing, theme } from '../../../theme';
+import { colors } from '../../../theme/colors';
+import { borderRadius } from '../../../theme/radii';
+import { screenLayout } from '../../../theme/screenLayout';
+import { spacing } from '../../../theme/spacing';
+import { typography } from '../../../theme/typography';
 
 /** Issue #100-9 (#433): ホーム画面の固有スタイル（screenLayout / cardStyles 準拠） */
 export const homeScreenStyles = StyleSheet.create({
@@ -18,19 +22,19 @@ export const homeScreenStyles = StyleSheet.create({
     paddingLeft: spacing.sm,
   },
   headerSubtitle: {
-    ...theme.typography.caption,
-    color: theme.colors.text.muted,
+    ...typography.caption,
+    color: colors.text.muted,
     letterSpacing: 0.5,
   },
   headerTitle: {
-    ...theme.typography.h1,
-    color: theme.colors.text.main,
+    ...typography.h1,
+    color: colors.text.main,
     marginTop: spacing.xs,
   },
   summaryCard: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: theme.borderRadius.lg,
-    padding: theme.spacing.xl,
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.lg,
+    padding: spacing.xl,
     marginBottom: spacing.lg,
     elevation: 4,
   },
@@ -45,13 +49,13 @@ export const homeScreenStyles = StyleSheet.create({
     marginTop: 5,
   },
   summarySymbol: {
-    color: theme.colors.text.inverse,
+    color: colors.text.inverse,
     fontSize: 20,
     marginRight: spacing.xs,
     fontWeight: 'bold',
   },
   summaryAmount: {
-    color: theme.colors.text.inverse,
+    color: colors.text.inverse,
     fontSize: 36,
     fontWeight: 'bold',
   },
@@ -67,32 +71,32 @@ export const homeScreenStyles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.7)',
   },
   summaryLinkText: {
-    color: theme.colors.text.inverse,
+    color: colors.text.inverse,
     fontSize: 14,
     fontWeight: '600',
   },
   acceptanceBanner: {
-    backgroundColor: theme.colors.semantic.surplus.bg,
-    borderRadius: theme.borderRadius.md,
+    backgroundColor: colors.semantic.surplus.bg,
+    borderRadius: borderRadius.md,
     padding: spacing.md,
     marginBottom: spacing.md,
     borderWidth: 1,
-    borderColor: theme.colors.semantic.surplus.border,
+    borderColor: colors.semantic.surplus.border,
   },
   acceptanceBannerText: {
-    color: theme.colors.semantic.surplus.text,
+    color: colors.semantic.surplus.text,
     fontSize: 14,
     fontWeight: '600',
   },
   captureButton: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: theme.borderRadius.lg,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.lg,
     padding: spacing.lg,
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: spacing.lg,
     borderWidth: 2,
-    borderColor: theme.colors.primary,
+    borderColor: colors.primary,
     borderStyle: 'dashed',
   },
   captureButtonBody: {
@@ -102,41 +106,41 @@ export const homeScreenStyles = StyleSheet.create({
     width: 44,
     height: 44,
     borderRadius: 22,
-    backgroundColor: theme.colors.primary,
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: spacing.md,
   },
   captureButtonText: {
-    ...theme.typography.h2,
-    color: theme.colors.primary,
+    ...typography.h2,
+    color: colors.primary,
   },
   captureSubText: {
     fontSize: 12,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
     marginTop: spacing.xs,
   },
   captureCountBadge: {
     minWidth: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: theme.colors.primary,
+    backgroundColor: colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: spacing.sm,
   },
   captureCountBadgeText: {
-    color: theme.colors.text.inverse,
+    color: colors.text.inverse,
     fontSize: 12,
     fontWeight: '700',
   },
   traySection: {
-    backgroundColor: theme.colors.surface,
-    borderRadius: theme.borderRadius.lg,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.lg,
     padding: spacing.md,
     marginBottom: spacing.lg,
     borderWidth: 1,
-    borderColor: theme.colors.border,
+    borderColor: colors.border,
   },
   traySectionHeader: {
     flexDirection: 'row',
@@ -145,7 +149,7 @@ export const homeScreenStyles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   trayOpenLink: {
-    color: theme.colors.primary,
+    color: colors.primary,
     fontSize: 13,
     fontWeight: '700',
   },
@@ -153,13 +157,13 @@ export const homeScreenStyles = StyleSheet.create({
     minWidth: 24,
     height: 24,
     borderRadius: 12,
-    backgroundColor: theme.colors.primary,
+    backgroundColor: colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 6,
   },
   gridCountBadgeText: {
-    color: theme.colors.text.inverse,
+    color: colors.text.inverse,
     fontSize: 11,
     fontWeight: '700',
   },
@@ -181,15 +185,15 @@ export const homeScreenStyles = StyleSheet.create({
     marginTop: spacing.lg,
   },
   sectionTitle: {
-    ...theme.typography.h2,
-    color: theme.colors.text.main,
+    ...typography.h2,
+    color: colors.text.main,
     marginBottom: spacing.sm,
   },
   settingsIconWrapper: {
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: theme.colors.background,
+    backgroundColor: colors.background,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: spacing.md,
@@ -202,13 +206,13 @@ export const homeScreenStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   amountText: {
-    ...theme.typography.h2,
-    color: theme.colors.primary,
+    ...typography.h2,
+    color: colors.primary,
     fontWeight: 'bold',
   },
   dateText: {
-    ...theme.typography.caption,
-    color: theme.colors.text.muted,
+    ...typography.caption,
+    color: colors.text.muted,
   },
   sourcePickerActions: {
     gap: 10,
@@ -218,6 +222,6 @@ export const homeScreenStyles = StyleSheet.create({
     marginTop: 10,
   },
   adminListItem: {
-    backgroundColor: theme.colors.semantic.icon.adminSettings,
+    backgroundColor: colors.semantic.icon.adminSettings,
   },
 });

--- a/frontend/src/features/stats/components/StatsPieChart.tsx
+++ b/frontend/src/features/stats/components/StatsPieChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, View } from 'react-native';
 import { PieChart } from 'react-native-chart-kit';
-import { cardStyles } from '../../../theme';
+import { cardStyles } from '../../../theme/cardStyles';
 import type { StatsChartSlice } from '../hooks/useStatistics';
 import { statsScreenStyles } from '../styles/statsScreenStyles';
 

--- a/frontend/src/features/stats/components/StatsSummaryCard.tsx
+++ b/frontend/src/features/stats/components/StatsSummaryCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { cardStyles, theme } from '../../../theme';
+import { colors } from '../../../theme/colors';
+import { cardStyles } from '../../../theme/cardStyles';
 import type { MonthlyStatsViewModel } from '../../../types/stats';
 import { statsScreenStyles } from '../styles/statsScreenStyles';
 
@@ -19,7 +20,7 @@ export const StatsSummaryCard: React.FC<Props> = ({ data }) => (
       <Text
         style={[
           statsScreenStyles.diffValue,
-          { color: (data?.diffAmount || 0) > 0 ? theme.colors.error : theme.colors.success },
+          { color: (data?.diffAmount || 0) > 0 ? colors.error : colors.success },
         ]}
       >
         {(data?.diffAmount || 0) > 0 ? '▲' : '▼'} ¥

--- a/frontend/src/features/stats/components/StatsTrendSection.tsx
+++ b/frontend/src/features/stats/components/StatsTrendSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { cardStyles, theme } from '../../../theme';
+import { colors } from '../../../theme/colors';
+import { cardStyles } from '../../../theme/cardStyles';
 import type { ParetoStatItem, TrendStatItem } from '../../../types/stats';
 import { statsScreenStyles } from '../styles/statsScreenStyles';
 
@@ -23,7 +24,7 @@ export const StatsTrendSection: React.FC<TrendProps> = ({ trend }) => (
             <Text
               style={[
                 statsScreenStyles.trendDiff,
-                { color: diff > 0 ? theme.colors.error : theme.colors.success },
+                { color: diff > 0 ? colors.error : colors.success },
               ]}
             >
               {t.prevTotal !== null ? `${diff > 0 ? '+' : ''}${Math.round(diff).toLocaleString()}` : '-'}
@@ -59,8 +60,8 @@ export const StatsParetoSection: React.FC<ParetoProps> = ({ pareto }) => (
                   width: `${p.ratio}%`,
                   backgroundColor:
                     p.cumulativeRatio <= 80
-                      ? theme.colors.primary
-                      : theme.colors.semantic.chart.barInactive,
+                      ? colors.primary
+                      : colors.semantic.chart.barInactive,
                 },
               ]}
             />

--- a/frontend/src/features/stats/hooks/useStatistics.ts
+++ b/frontend/src/features/stats/hooks/useStatistics.ts
@@ -7,7 +7,7 @@ import {
   mapCategoryList,
   mapMonthlyStatsResponse,
 } from '../../../mappers/statsMapper';
-import { theme } from '../../../theme';
+import { colors } from '../../../theme/colors';
 import type {
   AdvancedStatsViewModel,
   MonthlyStatsViewModel,
@@ -89,8 +89,8 @@ export function useStatistics(currentMemberId: number) {
         return {
           name: s.categoryName || '未分類',
           population: val,
-          color: s.color || theme.colors.secondary,
-          legendFontColor: theme.colors.text.main,
+          color: s.color || colors.secondary,
+          legendFontColor: colors.text.main,
           legendFontSize: 12,
         };
       })

--- a/frontend/src/features/stats/styles/statsScreenStyles.ts
+++ b/frontend/src/features/stats/styles/statsScreenStyles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from 'react-native';
-import { borderRadius, spacing, theme } from '../../../theme';
+import { colors } from '../../../theme/colors';
+import { borderRadius } from '../../../theme/radii';
+import { spacing } from '../../../theme/spacing';
 
 /** Issue #100-8 (#432): 統計画面の固有スタイル（screenLayout / cardStyles 準拠） */
 export const statsScreenStyles = StyleSheet.create({
@@ -8,7 +10,7 @@ export const statsScreenStyles = StyleSheet.create({
   },
   headerSubtitle: {
     fontSize: 10,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
     letterSpacing: 1,
   },
   monthPickerContainer: {
@@ -38,17 +40,17 @@ export const statsScreenStyles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: spacing.md,
     borderLeftWidth: 4,
-    borderLeftColor: theme.colors.primary,
+    borderLeftColor: colors.primary,
     paddingLeft: spacing.sm,
   },
   summaryLabel: {
     fontSize: 12,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
   },
   totalValue: {
     fontSize: 36,
     fontWeight: 'bold',
-    color: theme.colors.primary,
+    color: colors.primary,
     marginVertical: spacing.xs,
   },
   comparisonRow: {
@@ -64,18 +66,18 @@ export const statsScreenStyles = StyleSheet.create({
     fontSize: 16,
   },
   statsCard: {
-    backgroundColor: theme.colors.surface,
+    backgroundColor: colors.surface,
     borderRadius: borderRadius.md,
     padding: spacing.md,
     borderWidth: 1,
-    borderColor: theme.colors.border,
+    borderColor: colors.border,
   },
   trendRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingVertical: 10,
     borderBottomWidth: 1,
-    borderBottomColor: theme.colors.background,
+    borderBottomColor: colors.background,
   },
   trendPeriod: {
     flex: 1,
@@ -105,11 +107,11 @@ export const statsScreenStyles = StyleSheet.create({
   },
   paretoValue: {
     fontSize: 12,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
   },
   paretoBarContainer: {
     height: 16,
-    backgroundColor: theme.colors.semantic.chart.barBg,
+    backgroundColor: colors.semantic.chart.barBg,
     borderRadius: spacing.sm,
     flexDirection: 'row',
     alignItems: 'center',
@@ -123,23 +125,23 @@ export const statsScreenStyles = StyleSheet.create({
     position: 'absolute',
     right: spacing.sm,
     fontWeight: '700',
-    color: theme.colors.text.main,
+    color: colors.text.main,
   },
   noDataText: {
     fontSize: 12,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
   },
   receiptPreviewCard: {
-    backgroundColor: theme.colors.surface,
+    backgroundColor: colors.surface,
     borderRadius: borderRadius.md,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: theme.colors.border,
+    borderColor: colors.border,
   },
   receiptImage: {
     width: '100%',
     height: 160,
-    backgroundColor: theme.colors.border,
+    backgroundColor: colors.border,
   },
   receiptInfoOverlay: {
     padding: spacing.md,
@@ -150,23 +152,23 @@ export const statsScreenStyles = StyleSheet.create({
   },
   receiptStoreName: {
     fontWeight: '700',
-    color: theme.colors.text.main,
+    color: colors.text.main,
   },
   receiptAmount: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: theme.colors.primary,
+    color: colors.primary,
     minWidth: 80,
     textAlign: 'right',
   },
   taxSubText: {
     fontSize: 11,
-    color: theme.colors.text.muted,
+    color: colors.text.muted,
     marginTop: 2,
   },
   noImageBox: {
     height: 100,
-    backgroundColor: theme.colors.border,
+    backgroundColor: colors.border,
     borderRadius: borderRadius.md,
     justifyContent: 'center',
     alignItems: 'center',

--- a/frontend/src/screens/StatisticsScreen.tsx
+++ b/frontend/src/screens/StatisticsScreen.tsx
@@ -12,7 +12,9 @@ import {
   statsScreenStyles,
   useStatistics,
 } from '../features/stats';
-import { screenLayout, theme, cardStyles } from '../theme';
+import { colors } from '../theme/colors';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 
 interface StatisticsScreenProps {
   currentMemberId: number;
@@ -58,7 +60,7 @@ export const StatisticsScreen: React.FC<StatisticsScreenProps> = ({ currentMembe
         {stats.loading && !stats.data ? (
           <ActivityIndicator
             size="large"
-            color={theme.colors.primary}
+            color={colors.primary}
             style={statsScreenStyles.loadingIndicator}
           />
         ) : (


### PR DESCRIPTION
## Summary

#100-7〜#100-9 マージ後、Web / Android で以下のランタイムエラーが発生していた。

```
TypeError: Cannot read property 'container' of undefined  (homeScreenStyles)
TypeError: Cannot read property 'md' of undefined           (statsScreenStyles)
TypeError: Cannot read property 'xl' of undefined           (authScreenStyles)
```

**原因**: `*ScreenStyles.ts` が `StyleSheet.create()` 実行時（モジュール初期化）に `theme/index.ts` バレルから `spacing` / `screenLayout` を import しており、feature → theme → feature の循環参照により export が未初期化の状態で参照されていた。

**修正**: 3 ファイルすべてで `theme/colors`, `theme/spacing`, `theme/screenLayout` 等の個別モジュールから直接 import するよう変更。

## Test plan

- [x] `cd frontend && npm test` — 46 tests passed
- [ ] Web / Android でログイン・ホーム・統計画面が正常表示されること


Made with [Cursor](https://cursor.com)