### PR TITLE
refactor(fe): [Issue #100-10] Style Pattern 移行（中規模 5 画面）

### DIFF
--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -1,13 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  View, 
-  Text, 
-  StyleSheet, 
-  ActivityIndicator, 
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
   ScrollView,
 } from 'react-native';
 import { AppBackButton } from '../components/ui';
-import { theme, tableStyles } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { borderRadius } from '../theme/radii';
+import { shadows } from '../theme/shadows';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
+import { tableStyles } from '../theme/tableStyles';
 import { adminApi, type AdminCostStatRow } from '../api';
 import { getApiErrorMessage } from '../utils/apiError';
 
@@ -15,11 +21,13 @@ interface AdminStatsScreenProps {
   onBack: () => void;
 }
 
+const adm = colors.semantic.admin;
+
 export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) => {
   const [loading, setLoading] = useState(true);
   const [stats, setStats] = useState<AdminCostStatRow[]>([]);
   const [totalCost, setTotalCost] = useState(0);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null); // ★ 追加: エラー状態管理
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     fetchStats();
@@ -42,22 +50,21 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
 
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
+      <View style={[screenLayout.container, styles.loadingContainer]}>
+        <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={[screenLayout.container, styles.containerAdmin]}>
+      <View style={[screenLayout.header, styles.headerAdmin]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.headerTitle}>AIコスト統計</Text>
+        <Text style={screenLayout.headerTitle}>AIコスト統計</Text>
         <View style={{ width: 60 }} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.content}>
-        {/* ★ エラーが存在する場合は赤帯のコンテナを表示して処理をブロック */}
+      <ScrollView contentContainerStyle={[screenLayout.scrollContent, styles.content]}>
         {errorMsg ? (
           <View style={styles.errorContainer}>
             <Text style={styles.errorTitle}>アクセス権限エラー</Text>
@@ -65,40 +72,42 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
           </View>
         ) : (
           <>
-            <View style={styles.summaryCard}>
+            <View style={[cardStyles.summaryCard, styles.primarySummaryCard]}>
               <Text style={styles.summaryLabel}>累計利用コスト (概算)</Text>
               <Text style={styles.summaryAmount}>¥{totalCost.toFixed(2)}</Text>
               <Text style={styles.summaryNote}>※為替レート150円/$、Gemini 2.0 Flashでの算出</Text>
             </View>
 
-            <View style={tableStyles.wrapper}>
-              <View style={[tableStyles.row, tableStyles.headerRow]}>
-                <Text style={[tableStyles.cell, styles.colMonth, tableStyles.headerText]}>年月</Text>
-                <Text style={[tableStyles.cell, styles.colTokens, tableStyles.headerText]}>In / Out (Tokens)</Text>
-                <Text style={[tableStyles.cell, styles.colCost, tableStyles.headerText]}>概算(円)</Text>
-              </View>
-
-              {stats.length === 0 ? (
-                <View style={[tableStyles.row, styles.emptyRow]}>
-                  <Text style={[tableStyles.cell, tableStyles.bodyText]}>データがありません</Text>
+            <View style={cardStyles.section}>
+              <View style={tableStyles.wrapper}>
+                <View style={[tableStyles.row, tableStyles.headerRow]}>
+                  <Text style={[tableStyles.cell, styles.colMonth, tableStyles.headerText]}>年月</Text>
+                  <Text style={[tableStyles.cell, styles.colTokens, tableStyles.headerText]}>In / Out (Tokens)</Text>
+                  <Text style={[tableStyles.cell, styles.colCost, tableStyles.headerText]}>概算(円)</Text>
                 </View>
-              ) : (
-                stats.map((item, index) => (
-                  <View key={`${item.month}-${item.modelId}-${index}`} style={tableStyles.row}>
-                    <View style={[tableStyles.cell, styles.colMonth]}>
-                      <Text style={tableStyles.bodyText}>{item.month}</Text>
-                      <Text style={styles.cellSubText} numberOfLines={1}>{item.modelId}</Text>
-                    </View>
-                    <View style={[tableStyles.cell, styles.colTokens]}>
-                      <Text style={tableStyles.bodyText}>{item.totalPromptTokens.toLocaleString()}</Text>
-                      <Text style={styles.cellSubText}>{item.totalCandidatesTokens.toLocaleString()}</Text>
-                    </View>
-                    <Text style={[tableStyles.cell, styles.colCost, tableStyles.bodyText, tableStyles.boldText]}>
-                      ¥{item.estimatedCostJpy.toFixed(2)}
-                    </Text>
+
+                {stats.length === 0 ? (
+                  <View style={[tableStyles.row, styles.emptyRow]}>
+                    <Text style={[tableStyles.cell, tableStyles.bodyText]}>データがありません</Text>
                   </View>
-                ))
-              )}
+                ) : (
+                  stats.map((item, index) => (
+                    <View key={`${item.month}-${item.modelId}-${index}`} style={tableStyles.row}>
+                      <View style={[tableStyles.cell, styles.colMonth]}>
+                        <Text style={tableStyles.bodyText}>{item.month}</Text>
+                        <Text style={styles.cellSubText} numberOfLines={1}>{item.modelId}</Text>
+                      </View>
+                      <View style={[tableStyles.cell, styles.colTokens]}>
+                        <Text style={tableStyles.bodyText}>{item.totalPromptTokens.toLocaleString()}</Text>
+                        <Text style={styles.cellSubText}>{item.totalCandidatesTokens.toLocaleString()}</Text>
+                      </View>
+                      <Text style={[tableStyles.cell, styles.colCost, tableStyles.bodyText, tableStyles.boldText]}>
+                        ¥{item.estimatedCostJpy.toFixed(2)}
+                      </Text>
+                    </View>
+                  ))
+                )}
+              </View>
             </View>
           </>
         )}
@@ -107,32 +116,18 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
   );
 };
 
-const adm = theme.colors.semantic.admin;
-
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: adm.background },
-  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: adm.surface,
-    paddingTop: 16,
-    paddingBottom: 16,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: adm.border,
-  },
-  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
-  content: { padding: 16, paddingBottom: 40 },
-  
+  containerAdmin: { backgroundColor: adm.background },
+  loadingContainer: { justifyContent: 'center', alignItems: 'center' },
+  headerAdmin: { backgroundColor: adm.surface, borderBottomColor: adm.border },
+  content: { paddingBottom: 40 },
   errorContainer: {
     backgroundColor: adm.errorBg,
-    padding: 16,
-    borderRadius: 8,
+    padding: spacing.md,
+    borderRadius: borderRadius.sm,
     borderWidth: 1,
     borderColor: adm.errorBorder,
-    marginTop: 8,
+    marginTop: spacing.sm,
   },
   errorTitle: {
     color: adm.errorText,
@@ -144,20 +139,17 @@ const styles = StyleSheet.create({
     color: adm.errorText,
     fontSize: 14,
   },
-
-  summaryCard: {
-    backgroundColor: theme.colors.primary,
-    padding: 20,
-    borderRadius: 12,
-    marginBottom: 24,
-    ...theme.shadows.md,
+  primarySummaryCard: {
+    backgroundColor: colors.primary,
+    alignItems: 'flex-start',
+    ...shadows.md,
   },
-  summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, marginBottom: 8 },
-  summaryAmount: { color: theme.colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
-  summaryNote: { color: 'rgba(255,255,255,0.6)', fontSize: 12, marginTop: 8 },
+  summaryLabel: { color: 'rgba(255,255,255,0.8)', fontSize: 14, marginBottom: spacing.sm },
+  summaryAmount: { color: colors.text.inverse, fontSize: 36, fontWeight: 'bold' },
+  summaryNote: { color: 'rgba(255,255,255,0.6)', fontSize: 12, marginTop: spacing.sm },
   colMonth: { flex: 1.5 },
   colTokens: { flex: 2 },
   colCost: { flex: 1.5, textAlign: 'right' },
-  cellSubText: { fontSize: 12, color: theme.colors.text.muted, marginTop: 4 },
-  emptyRow: { justifyContent: 'center', paddingVertical: 24 },
+  cellSubText: { fontSize: 12, color: colors.text.muted, marginTop: 4 },
+  emptyRow: { justifyContent: 'center', paddingVertical: spacing.lg },
 });

--- a/frontend/src/screens/BiometricLockScreen.tsx
+++ b/frontend/src/screens/BiometricLockScreen.tsx
@@ -6,8 +6,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { authScreenStyles } from '../features/auth';
 import { authenticateWithBiometric } from '../services/biometricService';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
 
 type Props = {
   memberName?: string;
@@ -42,25 +44,25 @@ export function BiometricLockScreen({ memberName, onUnlocked, onUsePassword }: P
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>ロック中</Text>
+      <Text style={authScreenStyles.title}>ロック中</Text>
       {memberName ? (
-        <Text style={styles.subtitle}>{memberName} としてログイン済み</Text>
+        <Text style={authScreenStyles.subtitle}>{memberName} としてログイン済み</Text>
       ) : (
-        <Text style={styles.subtitle}>生体認証でロックを解除してください</Text>
+        <Text style={authScreenStyles.subtitle}>生体認証でロックを解除してください</Text>
       )}
 
       {isAuthenticating ? (
-        <ActivityIndicator size="large" color="white" style={styles.spinner} />
+        <ActivityIndicator size="large" color={colors.text.inverse} style={styles.spinner} />
       ) : (
-        <TouchableOpacity style={styles.primaryButton} onPress={tryUnlock}>
-          <Text style={styles.primaryButtonText}>生体認証で解除</Text>
+        <TouchableOpacity style={authScreenStyles.primaryButton} onPress={tryUnlock}>
+          <Text style={[authScreenStyles.primaryButtonText, { color: colors.primary }]}>生体認証で解除</Text>
         </TouchableOpacity>
       )}
 
       {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
 
-      <TouchableOpacity style={styles.linkButton} onPress={onUsePassword} disabled={isAuthenticating}>
-        <Text style={styles.linkButtonText}>パスワードでログイン</Text>
+      <TouchableOpacity style={authScreenStyles.linkButton} onPress={onUsePassword} disabled={isAuthenticating}>
+        <Text style={authScreenStyles.linkButtonText}>パスワードでログイン</Text>
       </TouchableOpacity>
     </View>
   );
@@ -68,52 +70,19 @@ export function BiometricLockScreen({ memberName, onUnlocked, onUsePassword }: P
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    ...authScreenStyles.container,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: theme.colors.primary,
-    padding: 40,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: 'white',
-    marginBottom: 12,
-  },
-  subtitle: {
-    fontSize: 16,
-    color: 'rgba(255,255,255,0.85)',
-    marginBottom: 32,
-    textAlign: 'center',
+    backgroundColor: colors.primary,
+    padding: spacing.xl + spacing.sm,
   },
   spinner: {
-    marginVertical: 24,
-  },
-  primaryButton: {
-    backgroundColor: 'white',
-    width: '100%',
-    padding: 18,
-    borderRadius: 15,
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  primaryButtonText: {
-    color: theme.colors.primary,
-    fontWeight: 'bold',
-    fontSize: 16,
+    marginVertical: spacing.lg,
   },
   error: {
-    color: '#ffcccc',
+    color: 'rgba(255, 204, 204, 1)',
     fontSize: 14,
     textAlign: 'center',
-    marginBottom: 12,
-  },
-  linkButton: {
-    padding: 12,
-  },
-  linkButtonText: {
-    color: 'rgba(255,255,255,0.8)',
-    fontSize: 14,
-    textDecorationLine: 'underline',
+    marginBottom: spacing.md - 4,
   },
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -13,7 +13,10 @@ import { categoryApi, receiptApi } from '../api';
 import { getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
 // Issue #66: BREAKPOINTS 参照
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 import type { CategorySummary, ReceiptDetail } from '../types/receipt';
@@ -152,7 +155,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
 
     return (
       <TouchableOpacity 
-        style={[styles.card, isSelected && isWide && styles.activeCard]} 
+        style={[cardStyles.chartCard, styles.listCard, isSelected && isWide && styles.activeCard]} 
         onPress={() => setSelectedReceipt(item)}
         activeOpacity={0.7}
       >
@@ -160,7 +163,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
           <Text style={styles.date}>
             {item.date ? new Date(item.date).toLocaleDateString('ja-JP') : '日付不明'}
           </Text>
-          <Text style={[styles.store, isSelected && isWide && { color: theme.colors.primary }]} numberOfLines={1}>
+          <Text style={[styles.store, isSelected && isWide && { color: colors.primary }]} numberOfLines={1}>
             {item.storeName || '店名不明'}
           </Text>
         </View>
@@ -177,11 +180,11 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
   };
 
   return (
-    <View style={styles.container}>
+    <View style={screenLayout.container}>
       <View style={styles.mainWrapper}>
-        <View style={styles.header}>
+        <View style={screenLayout.header}>
           <AppBackButton onPress={onBack} />
-          <Text style={styles.title}>レシート履歴</Text>
+          <Text style={screenLayout.headerTitle}>レシート履歴</Text>
           <View style={{ width: 40 }} />
         </View>
 
@@ -210,7 +213,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
           <View style={isWide ? styles.masterPane : styles.fullPane}>
             {loading ? (
               <View style={styles.centerLoading}>
-                <ActivityIndicator size="large" color={theme.colors.primary} />
+                <ActivityIndicator size="large" color={colors.primary} />
               </View>
             ) : (
               <FlatList
@@ -271,31 +274,28 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
   mainWrapper: { flex: 1, width: '100%', alignSelf: 'stretch', paddingTop: Platform.OS === 'ios' ? 60 : 20 },
-  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: theme.spacing.lg, marginBottom: theme.spacing.md },
-  title: { ...theme.typography.h2, color: theme.colors.text.main },
-  filterContainer: { paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.md, gap: 8 },
+  filterContainer: { paddingHorizontal: spacing.md, marginBottom: spacing.md, gap: 8 },
   filterContainerMobile: { flexDirection: 'column' },
   filterContainerWide: { flexDirection: 'row', justifyContent: 'flex-start' },
   filterSelectWrap: { width: '100%', justifyContent: 'center' },
   filterSelectWrapWide: { flex: 1, width: undefined, minWidth: 160, maxWidth: 220 },
   mainContentMobile: { flex: 1 },
-  mainContentWide: { flex: 1, flexDirection: 'row', borderTopWidth: 1, borderTopColor: theme.colors.border },
-  masterPane: { width: 350, height: '100%', backgroundColor: theme.colors.surface, borderRightWidth: 1, borderRightColor: theme.colors.border },
+  mainContentWide: { flex: 1, flexDirection: 'row', borderTopWidth: 1, borderTopColor: colors.border },
+  masterPane: { width: 350, height: '100%', backgroundColor: colors.surface, borderRightWidth: 1, borderRightColor: colors.border },
   fullPane: { flex: 1 },
-  detailPane: { flex: 1, height: '100%', backgroundColor: theme.colors.background },
-  list: { padding: theme.spacing.md },
-  card: { backgroundColor: theme.colors.surface, borderRadius: 12, padding: 15, marginBottom: 10, borderWidth: 1, borderColor: theme.colors.border },
-  activeCard: { borderColor: theme.colors.primary, backgroundColor: theme.colors.semantic.active.bg, elevation: 0 },
+  detailPane: { flex: 1, height: '100%', backgroundColor: colors.background },
+  list: { padding: spacing.md },
+  listCard: { minHeight: undefined, alignItems: 'stretch', marginBottom: 10, justifyContent: 'flex-start' },
+  activeCard: { borderColor: colors.primary, backgroundColor: colors.semantic.active.bg, elevation: 0 },
   cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 },
-  date: { fontSize: 12, color: theme.colors.text.muted },
-  store: { fontWeight: '700', color: theme.colors.text.main, flex: 1, marginLeft: 10, textAlign: 'right' },
+  date: { fontSize: 12, color: colors.text.muted },
+  store: { fontWeight: '700', color: colors.text.main, flex: 1, marginLeft: 10, textAlign: 'right' },
   cardBody: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  amount: { fontSize: 18, fontWeight: 'bold', color: theme.colors.primary },
-  itemCountBadge: { backgroundColor: theme.colors.background, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
-  itemCountText: { fontSize: 10, color: theme.colors.secondary },
-  empty: { textAlign: 'center', marginTop: 50, color: theme.colors.text.muted },
+  amount: { fontSize: 18, fontWeight: 'bold', color: colors.primary },
+  itemCountBadge: { backgroundColor: colors.background, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
+  itemCountText: { fontSize: 10, color: colors.secondary },
+  empty: { textAlign: 'center', marginTop: 50, color: colors.text.muted },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center', marginTop: 50 },
-  emptyDetailWrapper: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+  emptyDetailWrapper: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 });

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -155,7 +155,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
 
     return (
       <TouchableOpacity 
-        style={[cardStyles.chartCard, styles.listCard, isSelected && isWide && styles.activeCard]} 
+        style={[cardStyles.listCard, styles.listCardExtra, isSelected && isWide && styles.activeCard]} 
         onPress={() => setSelectedReceipt(item)}
         activeOpacity={0.7}
       >
@@ -286,7 +286,7 @@ const styles = StyleSheet.create({
   fullPane: { flex: 1 },
   detailPane: { flex: 1, height: '100%', backgroundColor: colors.background },
   list: { padding: spacing.md },
-  listCard: { minHeight: undefined, alignItems: 'stretch', marginBottom: 10, justifyContent: 'flex-start' },
+  listCardExtra: { marginBottom: 10 },
   activeCard: { borderColor: colors.primary, backgroundColor: colors.semantic.active.bg, elevation: 0 },
   cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 },
   date: { fontSize: 12, color: colors.text.muted },

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -13,17 +13,21 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { receiptApi } from '../api/receiptApi';
 import { AppBackButton, AppButton, AppFormField, AppSelect, AppTextInput } from '../components/ui';
-import { modalStyles } from '../theme';
+import { modalStyles } from '../theme/modalStyles';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { borderRadius } from '../theme/radii';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme } from '../theme';
 import { useReceiptImageSource } from '../utils/receiptImageSource';
 import { showAlert } from '../utils/alertMessage';
 import { getApiErrorMessage, getApiErrorResponseData } from '../utils/apiError';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
 import type { ParsedReceiptItemInput } from '../types/receipt';
 
-const c = theme.colors;
-const s = theme.colors.semantic.scan;
+const c = colors;
+const s = colors.semantic.scan;
 
 interface ReceiptScanScreenProps {
   initialData: ReceiptScanInitialData;
@@ -133,11 +137,11 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={[screenLayout.container, styles.containerScan]}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
-        <View style={styles.header}>
+        <View style={[screenLayout.header, styles.headerScan]}>
           <AppBackButton onPress={onCancel} style={styles.headerBack} />
-          <Text style={styles.headerTitle}>解析結果の確認</Text>
+          <Text style={[screenLayout.headerTitle, styles.headerTitleScan]}>解析結果の確認</Text>
           <AppButton
             title={BUTTON_LABELS.save}
             onPress={handleCommit}
@@ -168,7 +172,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
             </View>
           )}
 
-          <View style={styles.card}>
+          <View style={[cardStyles.chartCard, styles.card]}>
             <Text style={styles.sectionLabel}>基本情報</Text>
             <AppFormField label="店舗名">
               <AppTextInput
@@ -214,7 +218,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
           </View>
 
           {receiptData.items.map((item, idx) => (
-            <View key={idx} style={styles.itemCard}>
+            <View key={idx} style={[cardStyles.chartCard, styles.itemCard]}>
               <View style={styles.itemHeaderRow}>
                 <AppTextInput
                   style={styles.itemNameInput}
@@ -270,51 +274,51 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: s.background },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: theme.spacing.md,
-    backgroundColor: c.surface,
-    borderBottomWidth: 1,
-    borderBottomColor: s.borderLight,
-  },
-  headerTitle: { fontSize: 17, fontWeight: 'bold', color: s.textTitle },
+  containerScan: { backgroundColor: s.background },
+  headerScan: { backgroundColor: c.surface, borderBottomColor: s.borderLight },
+  headerTitleScan: { fontSize: 17, color: s.textTitle },
   headerBack: { minWidth: 50 },
   duplicateBanner: {
-    marginHorizontal: theme.spacing.md,
-    marginTop: theme.spacing.md,
-    marginBottom: theme.spacing.sm,
-    padding: theme.spacing.md,
-    borderRadius: theme.borderRadius.md,
-    backgroundColor: theme.colors.semantic.warning.bg,
+    marginHorizontal: spacing.md,
+    marginTop: spacing.md,
+    marginBottom: spacing.sm,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.semantic.warning.bg,
     borderWidth: 1,
-    borderColor: theme.colors.semantic.warning.border,
+    borderColor: colors.semantic.warning.border,
   },
   duplicateBannerTitle: {
     fontSize: 14,
     fontWeight: '700',
-    color: theme.colors.semantic.warning.text,
+    color: colors.semantic.warning.text,
     marginBottom: 4,
   },
   duplicateBannerText: {
     fontSize: 13,
-    color: theme.colors.semantic.warning.text,
+    color: colors.semantic.warning.text,
     lineHeight: 20,
   },
   scrollView: { flex: 1 },
-  imageContainer: { width: '100%', height: 260, backgroundColor: s.imageBg, marginBottom: theme.spacing.md, position: 'relative' },
+  imageContainer: { width: '100%', height: 260, backgroundColor: s.imageBg, marginBottom: spacing.md, position: 'relative' },
   receiptImage: { width: '100%', height: '100%' },
-  imageLabel: { position: 'absolute', bottom: 8, right: 8, backgroundColor: 'rgba(0,0,0,0.6)', paddingHorizontal: 8, paddingVertical: 4, borderRadius: theme.borderRadius.sm },
+  imageLabel: { position: 'absolute', bottom: 8, right: 8, backgroundColor: 'rgba(0,0,0,0.6)', paddingHorizontal: 8, paddingVertical: 4, borderRadius: borderRadius.sm },
   imageLabelText: { color: c.text.inverse, fontSize: 10, fontWeight: 'bold' },
-  card: { backgroundColor: c.surface, margin: theme.spacing.md, marginTop: 0, borderRadius: theme.spacing.md, padding: theme.spacing.md, elevation: 2 },
+  card: { minHeight: undefined, alignItems: 'stretch', margin: spacing.md, marginTop: 0, elevation: 2 },
   sectionLabel: { fontSize: 12, fontWeight: 'bold', color: s.textMuted, textTransform: 'uppercase', marginBottom: 12 },
-  totalDisplay: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 8, paddingTop: theme.spacing.md, borderTopWidth: 1, borderTopColor: s.borderInput },
+  totalDisplay: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 8, paddingTop: spacing.md, borderTopWidth: 1, borderTopColor: s.borderInput },
   totalLabel: { fontSize: 14, color: s.textSecondary },
   totalValue: { fontSize: 24, fontWeight: 'bold', color: c.primary },
-  itemsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginHorizontal: theme.spacing.md, marginBottom: 12 },
-  itemCard: { backgroundColor: c.surface, marginHorizontal: theme.spacing.md, marginBottom: 12, borderRadius: theme.spacing.md, padding: theme.spacing.md, borderLeftWidth: 4, borderLeftColor: c.primary, elevation: 1 },
+  itemsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginHorizontal: spacing.md, marginBottom: 12 },
+  itemCard: {
+    minHeight: undefined,
+    alignItems: 'stretch',
+    marginHorizontal: spacing.md,
+    marginBottom: 12,
+    borderLeftWidth: 4,
+    borderLeftColor: c.primary,
+    elevation: 1,
+  },
   itemHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
   itemNameInput: { flex: 1, marginRight: 8 },
   deleteIcon: { fontSize: 18, color: s.deleteIcon },

--- a/frontend/src/screens/SplitEditorScreen.tsx
+++ b/frontend/src/screens/SplitEditorScreen.tsx
@@ -8,7 +8,10 @@ import {
 } from 'react-native';
 import { AppBackButton, AppButton } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import {
   useSplitEditor,
@@ -33,17 +36,17 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({
 
   if (editor.loading) {
     return (
-      <View style={styles.centerLoading}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
+      <View style={[screenLayout.container, styles.centerLoading]}>
+        <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={screenLayout.container}>
+      <View style={[screenLayout.header, styles.headerSplit]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.headerTitle}>割り勘エディタ</Text>
+        <Text style={[screenLayout.headerTitle, styles.headerTitleSplit]}>割り勘エディタ</Text>
         <View style={styles.headerRight}>
           <AppButton
             title={BUTTON_LABELS.save}
@@ -64,7 +67,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({
 
       <View style={[styles.mainLayout, isWide ? styles.rowLayout : styles.colLayout]}>
         <View style={[styles.imagePane, isWide && { width: 350 }]}>
-          <View style={styles.imageBox}>
+          <View style={[cardStyles.chartCard, styles.imageBox]}>
             {imageSource ? (
               <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
             ) : (
@@ -73,7 +76,7 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({
           </View>
         </View>
 
-        <View style={styles.editorPane}>
+        <View style={[cardStyles.chartCard, styles.editorPane]}>
           <View style={styles.editorToolbar}>
             <Text style={styles.storeName}>{receipt.storeName || '店名不明'}</Text>
           </View>
@@ -98,51 +101,36 @@ export const SplitEditorScreen: React.FC<SplitEditorScreenProps> = ({
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 20,
-    backgroundColor: theme.colors.surface,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  headerTitle: { fontSize: 20, fontWeight: 'bold', color: theme.colors.text.main },
+  centerLoading: { justifyContent: 'center', alignItems: 'center' },
+  headerSplit: { padding: spacing.lg },
+  headerTitleSplit: { fontSize: 20 },
   headerRight: { minWidth: 100, alignItems: 'flex-end' },
-  mainLayout: { flex: 1, padding: 20, gap: 20 },
+  mainLayout: { flex: 1, padding: spacing.lg, gap: spacing.lg },
   rowLayout: { flexDirection: 'row' },
   colLayout: { flexDirection: 'column' },
   imagePane: { height: '100%', minHeight: 300 },
   imageBox: {
     flex: 1,
-    backgroundColor: theme.colors.surface,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
+    minHeight: undefined,
     justifyContent: 'center',
-    alignItems: 'center',
     overflow: 'hidden',
   },
   receiptImage: { width: '100%', height: '100%' },
-  noImageText: { color: theme.colors.text.muted },
+  noImageText: { color: colors.text.muted },
   editorPane: {
     flex: 1,
-    backgroundColor: theme.colors.surface,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
+    minHeight: undefined,
+    alignItems: 'stretch',
     overflow: 'hidden',
   },
   editorToolbar: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: 15,
+    padding: spacing.md,
     borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-    backgroundColor: theme.colors.surface,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
   },
-  storeName: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
+  storeName: { fontSize: 18, fontWeight: 'bold', color: colors.text.main },
 });

--- a/frontend/src/theme/cardStyles.ts
+++ b/frontend/src/theme/cardStyles.ts
@@ -37,4 +37,17 @@ export const cardStyles = StyleSheet.create({
     minHeight: 220,
     justifyContent: 'center',
   },
+  /** 一覧行用 — chartCard と異なり minHeight なし */
+  listCard: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    alignItems: 'stretch',
+    borderWidth: 1,
+    borderColor: colors.border,
+    ...Platform.select({
+      web: { paddingVertical: spacing.sm },
+      default: {},
+    }),
+  },
 });


### PR DESCRIPTION
## Summary

Issue #100-10 対象 5 画面に Design System Pattern（#100-6）を適用。

| 画面 | 適用内容 |
|------|---------|
| ReceiptScanScreen | `screenLayout`（container/header）、`cardStyles.chartCard` |
| HistoryScreen | `screenLayout`（container/header）、`cardStyles.chartCard`（一覧カード） |
| AdminStatsScreen | `screenLayout`、`cardStyles.summaryCard` / `section` |
| BiometricLockScreen | `authScreenStyles`（ログイン画面と共通 UI） |
| SplitEditorScreen | `screenLayout`、`cardStyles.chartCard`（画像/エディタペイン） |

- theme バレル import を避け、個別モジュール import に統一（#450 教訓）
- 5 画面とも Screen 内 hex 直書き 0 件

Closes #434

## Test plan

- [x] `cd frontend && npm test` — 46 tests passed
- [ ] ReceiptScan: 解析結果確認・保存フロー
- [ ] History: 一覧・詳細・フィルタ
- [ ] AdminStats: コスト統計表示（管理者）
- [ ] BiometricLock: 生体認証解除
- [ ] SplitEditor: 割り勘編集


Made with [Cursor](https://cursor.com)