### PR TITLE
refactor(fe): [Issue #100-11] Style Pattern 移行（小規模残存 7 画面）

### DIFF
--- a/frontend/src/screens/AdminMenuScreen.tsx
+++ b/frontend/src/screens/AdminMenuScreen.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { AppBackButton, AppListItem } from '../components/ui';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 
 interface AdminMenuScreenProps {
   onBack: () => void;
@@ -11,32 +14,34 @@ interface AdminMenuScreenProps {
   onGoToAdminStats: () => void;
 }
 
+const adm = colors.semantic.admin;
+
 export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
   onBack,
   onGoToCategories,
   onGoToProductMaster,
   onGoToPromptEditor,
-  onGoToAdminStats
+  onGoToAdminStats,
 }) => {
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={[screenLayout.container, styles.containerAdmin]}>
+      <View style={[screenLayout.header, styles.headerAdmin]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.headerTitle}>管理者メニュー</Text>
+        <Text style={screenLayout.headerTitle}>管理者メニュー</Text>
         <View style={{ width: 60 }} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.content}>
-        <View style={styles.section}>
+      <ScrollView contentContainerStyle={screenLayout.scrollContent}>
+        <View style={cardStyles.section}>
           <Text style={styles.sectionTitle}>マスタデータ管理</Text>
-          
+
           <AppListItem
             variant="nav"
             onPress={onGoToCategories}
             title="カテゴリー設定"
             subtitle="支出カテゴリの追加・編集・色変更"
             left={
-              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.settings }]}>
+              <View style={[styles.iconWrapper, { backgroundColor: colors.semantic.icon.settings }]}>
                 <Text>⚙️</Text>
               </View>
             }
@@ -48,23 +53,23 @@ export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
             title="学習マスタ管理"
             subtitle="商品名からの自動カテゴリ分類の修正"
             left={
-              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.product }]}>
+              <View style={[styles.iconWrapper, { backgroundColor: colors.semantic.icon.product }]}>
                 <Text>🧠</Text>
               </View>
             }
           />
         </View>
 
-        <View style={styles.section}>
+        <View style={cardStyles.section}>
           <Text style={styles.sectionTitle}>システム・AI設定</Text>
-          
+
           <AppListItem
             variant="nav"
             onPress={onGoToPromptEditor}
             title="プロンプト・外税ヒント編集"
             subtitle="Geminiへの指示と店舗特有の計算ルール"
             left={
-              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.prompt }]}>
+              <View style={[styles.iconWrapper, { backgroundColor: colors.semantic.icon.prompt }]}>
                 <Text>📝</Text>
               </View>
             }
@@ -76,7 +81,7 @@ export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
             title="AIコスト統計"
             subtitle="API利用量と概算コストの確認"
             left={
-              <View style={[styles.iconWrapper, { backgroundColor: theme.colors.semantic.icon.stats }]}>
+              <View style={[styles.iconWrapper, { backgroundColor: colors.semantic.icon.stats }]}>
                 <Text>📈</Text>
               </View>
             }
@@ -87,25 +92,16 @@ export const AdminMenuScreen: React.FC<AdminMenuScreenProps> = ({
   );
 };
 
-const adm = theme.colors.semantic.admin;
-
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: adm.background },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: adm.surface,
-    paddingTop: 16,
-    paddingBottom: 16,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: adm.border,
+  containerAdmin: { backgroundColor: adm.background },
+  headerAdmin: { backgroundColor: adm.surface, borderBottomColor: adm.border },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: colors.text.muted,
+    marginBottom: spacing.md - 4,
+    marginLeft: spacing.xs,
   },
-  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
-  content: { padding: 16 },
-  section: { marginBottom: 24 },
-  sectionTitle: { fontSize: 14, fontWeight: 'bold', color: theme.colors.text.muted, marginBottom: 12, marginLeft: 4 },
   iconWrapper: {
     width: 44,
     height: 44,

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -4,16 +4,20 @@ import { categoryApi, type Category } from '../api';
 import { getApiErrorStatus } from '../utils/apiError';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { typography } from '../theme/typography';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 import { pickNextCategoryColor } from '../utils/categoryColor';
 import { showConfirmDialog } from '../utils/confirmDialog';
 
-export const CategoryManagementScreen = ({ 
-  onBack, 
-  currentMemberId 
-}: { 
-  onBack: () => void, 
-  currentMemberId: number | null 
+export const CategoryManagementScreen = ({
+  onBack,
+  currentMemberId,
+}: {
+  onBack: () => void;
+  currentMemberId: number | null;
 }) => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [newName, setNewName] = useState('');
@@ -32,9 +36,9 @@ export const CategoryManagementScreen = ({
       setCategories(res.data ?? []);
     } catch (e: unknown) {
       if (getApiErrorStatus(e) === 401) {
-        Alert.alert("セッション切れ", "再度ログインしてください。");
+        Alert.alert('セッション切れ', '再度ログインしてください。');
       } else {
-        Alert.alert("エラー", "カテゴリーの取得に失敗しました。");
+        Alert.alert('エラー', 'カテゴリーの取得に失敗しました。');
       }
     } finally {
       setLoading(false);
@@ -50,8 +54,8 @@ export const CategoryManagementScreen = ({
       await categoryApi.createCategory({ name: newName, color });
       setNewName('');
       fetchCategories();
-    } catch (e) {
-      Alert.alert("エラー", "追加に失敗しました。");
+    } catch {
+      Alert.alert('エラー', '追加に失敗しました。');
     }
   };
 
@@ -92,7 +96,7 @@ export const CategoryManagementScreen = ({
               const res = await categoryApi.optimizeCategories();
               Alert.alert('完了', res.data?.message ?? '最適化が完了しました。');
               fetchCategories();
-            } catch (e) {
+            } catch {
               Alert.alert('エラー', '最適化処理に失敗しました。');
             } finally {
               setOptimizing(false);
@@ -104,13 +108,13 @@ export const CategoryManagementScreen = ({
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={[screenLayout.container, styles.containerCategory]}>
+      <View style={[screenLayout.header, styles.headerCategory]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.title}>カテゴリー設定</Text>
+        <Text style={[typography.h1, styles.titleCategory]}>カテゴリー設定</Text>
       </View>
 
-      <View style={styles.inputSection}>
+      <View style={[cardStyles.section, styles.inputSection]}>
         <AppTextInput
           style={styles.nameInput}
           value={newName}
@@ -127,13 +131,13 @@ export const CategoryManagementScreen = ({
         disabled={optimizing}
         fullWidth
         size="md"
-        style={{ backgroundColor: theme.colors.semantic.category.optimize, marginBottom: 20 }}
+        style={{ backgroundColor: colors.semantic.category.optimize, marginBottom: spacing.lg }}
       />
 
       {!currentMemberId ? (
         <Text style={styles.emptyText}>メンバーを選択してください</Text>
       ) : loading ? (
-        <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 50 }} />
+        <ActivityIndicator size="large" color={colors.primary} style={{ marginTop: 50 }} />
       ) : (
         <FlatList
           data={categories}
@@ -142,7 +146,7 @@ export const CategoryManagementScreen = ({
           renderItem={({ item }) => (
             <AppListItem
               title={item.name}
-              left={<AppListColorDot color={item.color ?? theme.colors.semantic.placeholder.badge} />}
+              left={<AppListColorDot color={item.color ?? colors.semantic.placeholder.badge} />}
               right={
                 <AppButton
                   title={BUTTON_LABELS.delete}
@@ -160,11 +164,14 @@ export const CategoryManagementScreen = ({
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background, padding: 20, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
-  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 30 },
-  title: { ...theme.typography.h1, marginLeft: 8, flex: 1 },
-  inputSection: { flexDirection: 'row', marginBottom: 15, gap: 10, alignItems: 'center' },
+  containerCategory: {
+    padding: spacing.lg,
+    paddingTop: Platform.OS === 'ios' ? 60 : spacing.lg,
+  },
+  headerCategory: { borderBottomWidth: 0, marginBottom: spacing.lg, paddingHorizontal: 0, paddingVertical: 0 },
+  titleCategory: { marginLeft: spacing.sm, flex: 1, color: colors.text.main },
+  inputSection: { flexDirection: 'row', marginBottom: spacing.md, gap: spacing.sm + 2, alignItems: 'center' },
   nameInput: { flex: 1 },
   list: { paddingBottom: 40 },
-  emptyText: { textAlign: 'center', marginTop: 30, color: theme.colors.text.muted },
+  emptyText: { textAlign: 'center', marginTop: 30, color: colors.text.muted },
 });

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -3,14 +3,16 @@ import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } 
 import { productMasterApi, type ProductMaster } from '../api';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { screenLayout } from '../theme/screenLayout';
 
 export const ProductMasterScreen = ({
   onBack,
-  currentMemberId
+  currentMemberId,
 }: {
-  onBack: () => void,
-  currentMemberId: number | null
+  onBack: () => void;
+  currentMemberId: number | null;
 }) => {
   const [masters, setMasters] = useState<ProductMaster[]>([]);
   const [loading, setLoading] = useState(true);
@@ -43,50 +45,60 @@ export const ProductMasterScreen = ({
   const handleDelete = (id: number) => {
     Alert.alert('確認', 'この学習データを削除しますか？', [
       { text: 'キャンセル', style: 'cancel' },
-      { text: '削除', style: 'destructive', onPress: async () => {
-        try {
-          await productMasterApi.deleteProductMaster(id);
-          fetchMasters();
-        } catch (e) {
-          Alert.alert('エラー', '削除に失敗しました');
-        }
-      }}
+      {
+        text: '削除',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await productMasterApi.deleteProductMaster(id);
+            fetchMasters();
+          } catch {
+            Alert.alert('エラー', '削除に失敗しました');
+          }
+        },
+      },
     ]);
   };
 
   const handleMergeStores = () => {
     if (Platform.OS === 'ios') {
       Alert.prompt(
-        "店舗名の統合",
-        "統合元の店舗名を入力（例: ｾﾌﾞﾝ）",
+        '店舗名の統合',
+        '統合元の店舗名を入力（例: ｾﾌﾞﾝ）',
         [
-          { text: "キャンセル", style: "cancel" },
-          { text: "次へ", onPress: (source: string | undefined) => {
-            if (!source) return;
-            Alert.prompt(
-              "統合先名称",
-              `${source} をどの名称に統合しますか？`,
-              [
-                { text: "実行", onPress: async (target: string | undefined) => {
-                  if (!target) return;
-                  try {
-                    await productMasterApi.mergeStoreNames({
-                      sourceStoreName: source,
-                      targetStoreName: target,
-                    });
-                    Alert.alert("完了", "統合完了しました");
-                    fetchMasters();
-                  } catch (e) {
-                    Alert.alert("エラー", "統合失敗");
-                  }
-                }}
-              ]
-            );
-          }}
+          { text: 'キャンセル', style: 'cancel' },
+          {
+            text: '次へ',
+            onPress: (source: string | undefined) => {
+              if (!source) return;
+              Alert.prompt(
+                '統合先名称',
+                `${source} をどの名称に統合しますか？`,
+                [
+                  {
+                    text: '実行',
+                    onPress: async (target: string | undefined) => {
+                      if (!target) return;
+                      try {
+                        await productMasterApi.mergeStoreNames({
+                          sourceStoreName: source,
+                          targetStoreName: target,
+                        });
+                        Alert.alert('完了', '統合完了しました');
+                        fetchMasters();
+                      } catch {
+                        Alert.alert('エラー', '統合失敗');
+                      }
+                    },
+                  },
+                ]
+              );
+            },
+          },
         ]
       );
     } else {
-      Alert.alert("通知", "店舗統合機能は現在iOSのみの対応です。");
+      Alert.alert('通知', '店舗統合機能は現在iOSのみの対応です。');
     }
   };
 
@@ -106,7 +118,7 @@ export const ProductMasterScreen = ({
       <View
         style={[
           styles.badge,
-          { backgroundColor: item.category?.color || theme.colors.semantic.placeholder.badge },
+          { backgroundColor: item.category?.color || colors.semantic.placeholder.badge },
         ]}
       >
         <Text style={styles.badgeText}>{item.category?.name || '未分類'}</Text>
@@ -115,16 +127,13 @@ export const ProductMasterScreen = ({
   );
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={[screenLayout.container, styles.containerProduct]}>
+      <View style={[screenLayout.header, styles.headerProduct]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.title}>学習マスタ ({currentMemberId === 1 ? '個人' : 'その他'})</Text>
-        <AppButton
-          title="店舗統合"
-          onPress={handleMergeStores}
-          variant="ghost"
-          size="sm"
-        />
+        <Text style={[screenLayout.headerTitle, styles.titleProduct]}>
+          学習マスタ ({currentMemberId === 1 ? '個人' : 'その他'})
+        </Text>
+        <AppButton title="店舗統合" onPress={handleMergeStores} variant="ghost" size="sm" />
       </View>
 
       <View style={styles.searchBar}>
@@ -145,7 +154,7 @@ export const ProductMasterScreen = ({
       {!currentMemberId ? (
         <Text style={styles.empty}>メンバーを選択してください</Text>
       ) : loading ? (
-        <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginTop: 20 }} />
+        <ActivityIndicator size="large" color={colors.primary} style={{ marginTop: 20 }} />
       ) : (
         <FlatList
           data={masters}
@@ -161,21 +170,24 @@ export const ProductMasterScreen = ({
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: Platform.OS === 'ios' ? 60 : 20 },
-  header: {
+  containerProduct: { paddingTop: Platform.OS === 'ios' ? 60 : 20 },
+  headerProduct: { paddingBottom: spacing.md },
+  titleProduct: { flex: 1, textAlign: 'center' },
+  searchBar: {
+    padding: spacing.sm + 2,
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingBottom: 15,
-    alignItems: 'center',
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border
+    gap: spacing.sm + 2,
+    backgroundColor: colors.surface,
   },
-  title: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main, flex: 1, textAlign: 'center' },
-  searchBar: { padding: 10, flexDirection: 'row', gap: 10, backgroundColor: theme.colors.surface },
   searchInput: { flex: 1 },
-  listContent: { paddingHorizontal: 15, paddingBottom: 40 },
-  badge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 3, borderRadius: 12, marginTop: 4 },
-  badgeText: { color: theme.colors.text.inverse, fontSize: 11, fontWeight: 'bold' },
-  empty: { textAlign: 'center', marginTop: 40, color: theme.colors.text.muted }
+  listContent: { paddingHorizontal: spacing.md, paddingBottom: 40 },
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: 12,
+    marginTop: spacing.xs,
+  },
+  badgeText: { color: colors.text.inverse, fontSize: 11, fontWeight: 'bold' },
+  empty: { textAlign: 'center', marginTop: 40, color: colors.text.muted },
 });

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -13,7 +13,13 @@ import { adminApi, type PromptTemplate } from '../api';
 import { getApiErrorMessage } from '../utils/apiError';
 import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { borderRadius } from '../theme/radii';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
+
+const adm = colors.semantic.admin;
 
 interface PromptEditorScreenProps {
   onBack: () => void;
@@ -168,22 +174,22 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
 
   if (isLoading && templates.length === 0) {
     return (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
+      <View style={[screenLayout.container, styles.center]}>
+        <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.loadingText}>プロンプトを読み込み中...</Text>
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
+    <View style={[screenLayout.container, styles.containerAdmin]}>
+      <View style={[screenLayout.header, styles.headerAdmin]}>
         <AppBackButton onPress={onBack} />
-        <Text style={styles.headerTitle}>プロンプト管理</Text>
+        <Text style={screenLayout.headerTitle}>プロンプト管理</Text>
         <View style={{ width: 60 }} />
       </View>
 
-      <ScrollView contentContainerStyle={styles.contentContainer}>
+      <ScrollView contentContainerStyle={[screenLayout.scrollContent, styles.contentContainer]}>
         {error && (
           <View style={styles.errorContainer}>
             <Text style={styles.errorText}>{error}</Text>
@@ -192,7 +198,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
 
         {/* フォーム画面（編集 または 新規作成） */}
         {(editingTemplate || isCreatingNew) ? (
-          <View style={styles.formContainer}>
+          <View style={[cardStyles.listCard, styles.formContainer]}>
             <View style={styles.formHeader}>
               <Text style={styles.formTitle}>
                 {isCreatingNew ? '新規プロンプトの作成' : 'プロンプトの編集'}
@@ -256,7 +262,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
             />
 
             {templates.map((tpl) => (
-              <View key={tpl.id} style={[styles.card, tpl.isActive && styles.activeCard]}>
+              <View key={tpl.id} style={[cardStyles.listCard, styles.card, tpl.isActive && styles.activeCard]}>
                 <View style={styles.cardHeader}>
                   {/* ★修正: タイトル部分に flex: 1 を当てて右側の要素を押し出さないようにする */}
                   <View style={styles.titleContainer}>
@@ -306,33 +312,48 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
   );
 };
 
-const adm = theme.colors.semantic.admin;
-
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: adm.background },
-  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', backgroundColor: adm.surface, paddingVertical: 16, paddingHorizontal: 16, borderBottomWidth: 1, borderBottomColor: adm.border },
-  headerTitle: { fontSize: 18, fontWeight: 'bold', color: theme.colors.text.main },
-  contentContainer: { padding: 16, paddingBottom: 40 },
-  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  loadingText: { marginTop: 12, color: adm.textMuted },
-  errorContainer: { backgroundColor: adm.errorBg, padding: 12, borderRadius: 6, marginBottom: 16 },
+  containerAdmin: { backgroundColor: adm.background },
+  headerAdmin: { backgroundColor: adm.surface, borderBottomColor: adm.border },
+  contentContainer: { paddingBottom: 40 },
+  center: { justifyContent: 'center', alignItems: 'center' },
+  loadingText: { marginTop: spacing.md - 4, color: adm.textMuted },
+  errorContainer: {
+    backgroundColor: adm.errorBg,
+    padding: spacing.md - 4,
+    borderRadius: borderRadius.sm,
+    marginBottom: spacing.md,
+  },
   errorText: { color: adm.errorText },
-  
-  card: { backgroundColor: adm.surface, padding: 16, borderRadius: 8, marginBottom: 12, borderWidth: 2, borderColor: adm.border },
-  activeCard: { borderColor: theme.colors.primary },
-  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 },
-  titleContainer: { flex: 1, paddingRight: 8 },
+
+  card: {
+    backgroundColor: adm.surface,
+    marginBottom: spacing.md - 4,
+    borderWidth: 2,
+    borderColor: adm.border,
+  },
+  activeCard: { borderColor: colors.primary },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: spacing.sm },
+  titleContainer: { flex: 1, paddingRight: spacing.sm },
   cardTitle: { fontSize: 16, fontWeight: 'bold', color: adm.textDark, lineHeight: 22 },
   versionText: { fontSize: 12, color: adm.textMuted, fontWeight: 'normal' },
   badgeContainer: { justifyContent: 'flex-start', paddingTop: 2 },
-  badge: { backgroundColor: theme.colors.primary, paddingHorizontal: 8, paddingVertical: 4, borderRadius: 12 },
-  badgeText: { color: theme.colors.text.inverse, fontSize: 10, fontWeight: 'bold' },
-  
-  cardDesc: { fontSize: 13, color: adm.textMuted, marginBottom: 12 },
-  cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' },
+  badge: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.md,
+  },
+  badgeText: { color: colors.text.inverse, fontSize: 10, fontWeight: 'bold' },
 
-  formContainer: { backgroundColor: adm.surface, padding: 16, borderRadius: 8, borderWidth: 1, borderColor: adm.border },
-  formHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 },
+  cardDesc: { fontSize: 13, color: adm.textMuted, marginBottom: spacing.md - 4 },
+  cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm, flexWrap: 'wrap' },
+
+  formContainer: {
+    backgroundColor: adm.surface,
+    borderColor: adm.border,
+  },
+  formHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: spacing.md },
   formTitle: { fontSize: 18, fontWeight: 'bold', flex: 1 },
   promptTextArea: { minHeight: 200 },
   jsonTextArea: { minHeight: 150 },

--- a/frontend/src/screens/ReceiptTrayScreen.tsx
+++ b/frontend/src/screens/ReceiptTrayScreen.tsx
@@ -4,7 +4,10 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { AppBackButton } from '../components/ui';
 import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
 import { useReceiptTray } from '../contexts/ReceiptTrayContext';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { typography } from '../theme/typography';
+import { screenLayout } from '../theme/screenLayout';
 
 type Props = {
   onBack: () => void;
@@ -23,8 +26,8 @@ export function ReceiptTrayScreen({ onBack }: Props) {
   } = useReceiptTray();
 
   return (
-    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <View style={styles.header}>
+    <SafeAreaView style={screenLayout.container} edges={['left', 'right', 'bottom']}>
+      <View style={[screenLayout.header, styles.headerTray]}>
         <AppBackButton onPress={onBack} />
         <View style={styles.headerText}>
           <Text style={styles.title}>確認トレイ</Text>
@@ -42,13 +45,13 @@ export function ReceiptTrayScreen({ onBack }: Props) {
       </View>
 
       <ScrollView
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[screenLayout.scrollContent, styles.scrollContentTray]}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
             onRefresh={() => void refresh({ userInitiated: true })}
-            colors={[theme.colors.primary]}
-            tintColor={theme.colors.primary}
+            colors={[colors.primary]}
+            tintColor={colors.primary}
           />
         }
       >
@@ -68,33 +71,25 @@ export function ReceiptTrayScreen({ onBack }: Props) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: theme.spacing.sm,
-    paddingHorizontal: theme.spacing.md,
-    paddingVertical: theme.spacing.sm,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-    backgroundColor: theme.colors.surface,
+  headerTray: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.surface,
   },
   headerText: { flex: 1 },
-  title: { ...theme.typography.h1, color: theme.colors.text.main, fontSize: 22 },
-  subtitle: { ...theme.typography.caption, color: theme.colors.text.muted, marginTop: 2 },
+  title: { ...typography.h1, color: colors.text.main, fontSize: 22 },
+  subtitle: { ...typography.caption, color: colors.text.muted, marginTop: 2 },
   countBadge: {
     minWidth: 32,
     height: 32,
     borderRadius: 16,
-    backgroundColor: theme.colors.primary,
+    backgroundColor: colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 10,
   },
-  countBadgeText: { color: theme.colors.text.inverse, fontWeight: '700' },
+  countBadgeText: { color: colors.text.inverse, fontWeight: '700' },
   headerSpacer: { width: 32 },
-  scrollContent: {
-    padding: theme.spacing.lg,
-    paddingBottom: theme.spacing.xl,
-  },
+  scrollContentTray: { paddingBottom: spacing.xl },
 });

--- a/frontend/src/screens/SettlementSummaryScreen.tsx
+++ b/frontend/src/screens/SettlementSummaryScreen.tsx
@@ -5,7 +5,9 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { screenLayout } from '../theme/screenLayout';
 import { useIsWideLayout } from '../hooks/useIsWideLayout';
 import {
   useSettlementSummary,
@@ -42,7 +44,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
   };
 
   return (
-    <View style={styles.container}>
+    <View style={screenLayout.container}>
       <SettlementSummaryHeader
         isWide={isWide}
         selectedMonth={settlement.selectedMonth}
@@ -54,12 +56,12 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
 
       {settlement.loading ? (
         <View style={styles.centerLoading}>
-          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
         <ScrollView
           style={styles.scrollContainer}
-          contentContainerStyle={styles.scrollContent}
+          contentContainerStyle={[screenLayout.scrollContent, styles.scrollContentSettlement]}
         >
           <SettlementMemberCards
             summaryData={settlement.summaryData}
@@ -98,8 +100,7 @@ export const SettlementSummaryScreen: React.FC<SettlementSummaryScreenProps> = (
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: theme.colors.background },
   centerLoading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   scrollContainer: { flex: 1 },
-  scrollContent: { padding: 20, paddingBottom: 40 },
+  scrollContentSettlement: { paddingBottom: 40 },
 });

--- a/frontend/src/screens/TotpSettingsScreen.tsx
+++ b/frontend/src/screens/TotpSettingsScreen.tsx
@@ -9,7 +9,11 @@ import {
   View,
 } from 'react-native';
 import { loginService } from '../services/loginService';
-import { theme } from '../theme';
+import { colors } from '../theme/colors';
+import { spacing } from '../theme/spacing';
+import { borderRadius } from '../theme/radii';
+import { cardStyles } from '../theme/cardStyles';
+import { screenLayout } from '../theme/screenLayout';
 
 type Props = {
   totpEnabled: boolean;
@@ -55,7 +59,7 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[screenLayout.container, styles.content]}>
       <TouchableOpacity onPress={onBack} style={styles.backButton}>
         <Text style={styles.backText}>← 戻る</Text>
       </TouchableOpacity>
@@ -71,9 +75,11 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
       ) : secret ? (
         <>
           <Text style={styles.subtitle}>認証アプリに以下のキーを登録してください</Text>
-          <Text style={styles.secret} selectable>
-            {secret}
-          </Text>
+          <View style={[cardStyles.listCard, styles.secretBox]}>
+            <Text style={styles.secret} selectable>
+              {secret}
+            </Text>
+          </View>
           <TextInput
             style={styles.input}
             placeholder="6桁コード"
@@ -88,7 +94,7 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
             disabled={loading}
           >
             {loading ? (
-              <ActivityIndicator color={theme.colors.primary} />
+              <ActivityIndicator color={colors.primary} />
             ) : (
               <Text style={styles.primaryButtonText}>有効化</Text>
             )}
@@ -103,7 +109,7 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
             disabled={loading}
           >
             {loading ? (
-              <ActivityIndicator color={theme.colors.primary} />
+              <ActivityIndicator color={colors.primary} />
             ) : (
               <Text style={styles.primaryButtonText}>セットアップを開始</Text>
             )}
@@ -115,33 +121,30 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 24, backgroundColor: theme.colors.background },
-  backButton: { marginBottom: 16 },
-  backText: { color: theme.colors.primary, fontSize: 16 },
-  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 8, color: theme.colors.text.main },
-  subtitle: { fontSize: 15, color: theme.colors.text.muted, marginBottom: 20 },
+  content: { padding: spacing.lg },
+  backButton: { marginBottom: spacing.md },
+  backText: { color: colors.primary, fontSize: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: spacing.sm, color: colors.text.main },
+  subtitle: { fontSize: 15, color: colors.text.muted, marginBottom: spacing.lg },
+  secretBox: { marginBottom: spacing.md },
   secret: {
     fontFamily: 'monospace',
     fontSize: 14,
-    backgroundColor: theme.colors.surface,
-    padding: 12,
-    borderRadius: 8,
-    marginBottom: 16,
   },
   input: {
     borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: 10,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
     padding: 14,
-    marginBottom: 12,
+    marginBottom: spacing.md - 4,
     fontSize: 16,
-    backgroundColor: theme.colors.surface,
+    backgroundColor: colors.surface,
   },
   primaryButton: {
-    backgroundColor: theme.colors.primary,
-    padding: 16,
-    borderRadius: 12,
+    backgroundColor: colors.primary,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
     alignItems: 'center',
   },
-  primaryButtonText: { color: 'white', fontWeight: 'bold' },
+  primaryButtonText: { color: colors.text.inverse, fontWeight: 'bold' },
 });


### PR DESCRIPTION
## Summary

Issue #100-11 対象 7 画面に Design System Pattern を適用し、**全 15 Screen** の Style 移行を完了。

| 画面 | 適用内容 |
|------|---------|
| TotpSettingsScreen | `screenLayout`、`cardStyles.listCard` |
| AdminMenuScreen | `screenLayout`、`cardStyles.section` |
| ReceiptTrayScreen | `screenLayout` |
| PromptEditorScreen | `screenLayout`、`cardStyles.listCard` |
| ProductMasterScreen | `screenLayout` |
| SettlementSummaryScreen | `screenLayout` |
| CategoryManagementScreen | `screenLayout`、`cardStyles.section` |

- theme バレル import を避け、個別モジュール import に統一（#450 教訓）
- 7 画面とも Screen 内 hex 直書き 0 件

Closes #435

## Test plan

- [x] `cd frontend && npm test` — 46 tests passed
- [ ] 各画面の主要フロー目視（Web / Android）


Made with [Cursor](https://cursor.com)