### PR TITLE
refactor(fe): [Issue #100-13] Alert → showAlert / showConfirmDialog 統一

### DIFF
--- a/frontend/src/features/app/hooks/useAppSession.ts
+++ b/frontend/src/features/app/hooks/useAppSession.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Alert, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { categoryApi } from '../../../api/categoryApi';
 import { setOnUnauthorized } from '../../../utils/apiClient';
+import { showAlert } from '../../../utils/alertMessage';
+import { showConfirmDialog } from '../../../utils/confirmDialog';
 import { authService } from '../../../services/authService';
 import { canUseBiometric } from '../../../services/biometricService';
 import type { LoginResult, StoredSession } from '../../../types/auth';
@@ -88,7 +90,7 @@ export function useAppSession() {
   useEffect(() => {
     setOnUnauthorized(() => {
       void handleLogout();
-      Alert.alert('セッション切れ', '有効期限が切れたため、再度ログインしてください。');
+      showAlert('セッション切れ', '有効期限が切れたため、再度ログインしてください。');
     });
   }, [handleLogout]);
 
@@ -97,7 +99,7 @@ export function useAppSession() {
     const available = await canUseBiometric();
     if (!available) return;
 
-    Alert.alert(
+    showConfirmDialog(
       '生体認証',
       '次回起動時に生体認証でロック解除しますか？',
       [
@@ -155,7 +157,7 @@ export function useAppSession() {
   const handleDisableBiometric = useCallback(async () => {
     await authService.setBiometricEnabled(false);
     setBiometricEnabled(false);
-    Alert.alert('生体認証', '生体認証によるロック解除をオフにしました。');
+    showAlert('生体認証', '生体認証によるロック解除をオフにしました。');
   }, []);
 
   const fetchCategories = useCallback(async () => {

--- a/frontend/src/features/home/hooks/useReceiptUpload.ts
+++ b/frontend/src/features/home/hooks/useReceiptUpload.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Alert, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { receiptApi } from '../../../api';
 import { buildReceiptUploadFormData } from '../../../utils/receiptUploadFormData';
@@ -67,11 +67,7 @@ export function useReceiptUpload({
         const message =
           err instanceof Error ? err.message : '画像のアップロードに失敗しました。';
         registerLocalUploadFailure(message);
-        if (Platform.OS === 'web') {
-          showAlert('エラー', message);
-        } else {
-          Alert.alert('エラー', message);
-        }
+        showAlert('エラー', message);
       } finally {
         setUploadingCount((count) => Math.max(0, count - 1));
       }
@@ -114,7 +110,7 @@ export function useReceiptUpload({
   const pickImageNative = useCallback(async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('権限エラー', 'カメラの使用を許可してください。');
+      showAlert('権限エラー', 'カメラの使用を許可してください。');
       return;
     }
 
@@ -138,7 +134,7 @@ export function useReceiptUpload({
       await pickImageNative();
     } catch (err) {
       console.error('handleScan Error:', err);
-      Alert.alert('エラー', '画像のアップロードに失敗しました。');
+      showAlert('エラー', '画像のアップロードに失敗しました。');
     }
   }, [pickImageNative]);
 

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, Text, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
+import { StyleSheet, View, Text, FlatList, ActivityIndicator, Platform } from 'react-native';
 import { categoryApi, type Category } from '../api';
 import { getApiErrorStatus } from '../utils/apiError';
+import { showAlert } from '../utils/alertMessage';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { colors } from '../theme/colors';
@@ -36,9 +37,9 @@ export const CategoryManagementScreen = ({
       setCategories(res.data ?? []);
     } catch (e: unknown) {
       if (getApiErrorStatus(e) === 401) {
-        Alert.alert('セッション切れ', '再度ログインしてください。');
+        showAlert('セッション切れ', '再度ログインしてください。');
       } else {
-        Alert.alert('エラー', 'カテゴリーの取得に失敗しました。');
+        showAlert('エラー', 'カテゴリーの取得に失敗しました。');
       }
     } finally {
       setLoading(false);
@@ -55,7 +56,7 @@ export const CategoryManagementScreen = ({
       setNewName('');
       fetchCategories();
     } catch {
-      Alert.alert('エラー', '追加に失敗しました。');
+      showAlert('エラー', '追加に失敗しました。');
     }
   };
 
@@ -72,9 +73,9 @@ export const CategoryManagementScreen = ({
           } catch (e: unknown) {
             const status = getApiErrorStatus(e);
             if (status === 400 || status === 409) {
-              Alert.alert('制限', 'このカテゴリーは既に使用されているため削除できません。');
+              showAlert('制限', 'このカテゴリーは既に使用されているため削除できません。');
             } else {
-              Alert.alert('エラー', '削除に失敗しました。');
+              showAlert('エラー', '削除に失敗しました。');
             }
           }
         },
@@ -94,10 +95,10 @@ export const CategoryManagementScreen = ({
             setOptimizing(true);
             try {
               const res = await categoryApi.optimizeCategories();
-              Alert.alert('完了', res.data?.message ?? '最適化が完了しました。');
+              showAlert('完了', res.data?.message ?? '最適化が完了しました。');
               fetchCategories();
             } catch {
-              Alert.alert('エラー', '最適化処理に失敗しました。');
+              showAlert('エラー', '最適化処理に失敗しました。');
             } finally {
               setOptimizing(false);
             }

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -7,10 +7,10 @@ import {
   TouchableOpacity, 
   ActivityIndicator, 
   Platform, 
-  Alert,
 } from 'react-native';
 import { categoryApi, receiptApi } from '../api';
 import { getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
+import { showAlert } from '../utils/alertMessage';
 // Issue #66: BREAKPOINTS 参照
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
 import { colors } from '../theme/colors';
@@ -106,9 +106,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
       }
     } catch (err) {
       console.error('履歴取得失敗', err);
-      if (Platform.OS !== 'web') {
-        Alert.alert('エラー', '履歴の取得に失敗しました');
-      }
+      showAlert('エラー', '履歴の取得に失敗しました');
     } finally {
       setLoading(false);
     }
@@ -143,9 +141,7 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
       }
     } catch (err) {
       console.error('カテゴリー更新失敗', err);
-      if (Platform.OS !== 'web') {
-        Alert.alert('エラー', 'カテゴリーの更新に失敗しました');
-      }
+      showAlert('エラー', 'カテゴリーの更新に失敗しました');
     }
   };
 

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
 import { productMasterApi, type ProductMaster } from '../api';
+import { showAlert } from '../utils/alertMessage';
+import { showConfirmDialog } from '../utils/confirmDialog';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { colors } from '../theme/colors';
@@ -43,7 +45,7 @@ export const ProductMasterScreen = ({
   }, [fetchMasters, currentMemberId]);
 
   const handleDelete = (id: number) => {
-    Alert.alert('確認', 'この学習データを削除しますか？', [
+    showConfirmDialog('確認', 'この学習データを削除しますか？', [
       { text: 'キャンセル', style: 'cancel' },
       {
         text: '削除',
@@ -53,7 +55,7 @@ export const ProductMasterScreen = ({
             await productMasterApi.deleteProductMaster(id);
             fetchMasters();
           } catch {
-            Alert.alert('エラー', '削除に失敗しました');
+            showAlert('エラー', '削除に失敗しました');
           }
         },
       },
@@ -84,10 +86,10 @@ export const ProductMasterScreen = ({
                           sourceStoreName: source,
                           targetStoreName: target,
                         });
-                        Alert.alert('完了', '統合完了しました');
+                        showAlert('完了', '統合完了しました');
                         fetchMasters();
                       } catch {
-                        Alert.alert('エラー', '統合失敗');
+                        showAlert('エラー', '統合失敗');
                       }
                     },
                   },
@@ -98,7 +100,7 @@ export const ProductMasterScreen = ({
         ]
       );
     } else {
-      Alert.alert('通知', '店舗統合機能は現在iOSのみの対応です。');
+      showAlert('通知', '店舗統合機能は現在iOSのみの対応です。');
     }
   };
 

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -5,12 +5,12 @@ import {
   Text,
   ScrollView,
   ActivityIndicator,
-  Alert,
-  Platform,
 } from 'react-native';
 
 import { adminApi, type PromptTemplate } from '../api';
 import { getApiErrorMessage } from '../utils/apiError';
+import { showAlert } from '../utils/alertMessage';
+import { showConfirmDialog } from '../utils/confirmDialog';
 import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { colors } from '../theme/colors';
@@ -66,7 +66,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       await adminApi.activatePrompt(id);
       fetchPrompts();
     } catch (err: unknown) {
-      Alert.alert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
+      showAlert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
     }
   };
 
@@ -76,25 +76,19 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
         await adminApi.deletePrompt(id);
         fetchPrompts();
       } catch (err: unknown) {
-        Alert.alert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
+        showAlert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
       }
     };
 
-    if (Platform.OS === 'web') {
-      if (window.confirm('本当にこのプロンプトを削除しますか？')) {
-        executeDelete();
-      }
-    } else {
-      Alert.alert('削除確認', '本当にこのプロンプトを削除しますか？', [
-        { text: 'キャンセル', style: 'cancel' },
-        { text: '削除', style: 'destructive', onPress: executeDelete }
-      ]);
-    }
+    showConfirmDialog('削除確認', '本当にこのプロンプトを削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      { text: '削除', style: 'destructive', onPress: executeDelete },
+    ]);
   };
 
   const handleSave = async () => {
     if (!formSystemPrompt.trim() || !formName.trim()) {
-      Alert.alert('入力エラー', '名前とシステムプロンプトは必須です。');
+      showAlert('入力エラー', '名前とシステムプロンプトは必須です。');
       return;
     }
 
@@ -103,7 +97,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       try {
         parsedHints = JSON.parse(formDomainHints);
       } catch (e) {
-        Alert.alert('JSONエラー', 'Domain Hints の JSON 形式が不正です。');
+        showAlert('JSONエラー', 'Domain Hints の JSON 形式が不正です。');
         return;
       }
     }
@@ -121,7 +115,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
           domainHints: parsedHints,
           isActive: false
         });
-        if (Platform.OS !== 'web') Alert.alert('作成完了', '新しいプロンプトを作成しました。');
+        showAlert('作成完了', '新しいプロンプトを作成しました。');
       } else if (editingTemplate && editingTemplate.id) {
         await adminApi.updatePrompt(editingTemplate.id, {
           name: formName,
@@ -129,7 +123,7 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
           systemPrompt: formSystemPrompt,
           domainHints: parsedHints,
         });
-        if (Platform.OS !== 'web') Alert.alert('更新完了', 'プロンプトを更新しました。');
+        showAlert('更新完了', 'プロンプトを更新しました。');
       } else {
         throw new Error('更新対象のプロンプトIDが見つかりません。');
       }

--- a/frontend/src/screens/TotpSettingsScreen.tsx
+++ b/frontend/src/screens/TotpSettingsScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   StyleSheet,
   Text,
   TextInput,
@@ -14,6 +13,7 @@ import { spacing } from '../theme/spacing';
 import { borderRadius } from '../theme/radii';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
+import { showAlert } from '../utils/alertMessage';
 
 type Props = {
   totpEnabled: boolean;
@@ -33,7 +33,7 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
       setSecret(setup.secret);
       setCode('');
     } catch (e: unknown) {
-      Alert.alert('エラー', e instanceof Error ? e.message : 'セットアップに失敗しました。');
+      showAlert('エラー', e instanceof Error ? e.message : 'セットアップに失敗しました。');
     } finally {
       setLoading(false);
     }
@@ -41,7 +41,7 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
 
   const handleConfirmEnable = async () => {
     if (!code.trim()) {
-      Alert.alert('入力エラー', '6桁コードを入力してください。');
+      showAlert('入力エラー', '6桁コードを入力してください。');
       return;
     }
     setLoading(true);
@@ -50,9 +50,9 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
       setSecret(null);
       setCode('');
       onChanged(true);
-      Alert.alert('完了', '二要素認証を有効にしました。');
+      showAlert('完了', '二要素認証を有効にしました。');
     } catch (e: unknown) {
-      Alert.alert('エラー', e instanceof Error ? e.message : '有効化に失敗しました。');
+      showAlert('エラー', e instanceof Error ? e.message : '有効化に失敗しました。');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,7 +1,8 @@
+import { Platform } from 'react-native';
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Platform, Alert } from 'react-native';
+import { showAlert } from './alertMessage';
 import { AUTH_STORAGE_KEYS } from '../services/authService';
 
 /**
@@ -98,7 +99,7 @@ apiClient.interceptors.response.use(
         }
       } else if (error.response.status === 403) {
         console.warn(`[API] Forbidden: ${serverMessage}`);
-        Alert.alert('アクセス権限エラー', 'この操作を行う権限がありません。');
+        showAlert('アクセス権限エラー', 'この操作を行う権限がありません。');
       }
     }
     return Promise.reject(error);


### PR DESCRIPTION
## Summary
- Screen / Hook / `apiClient` 内の `Alert.alert` を `showAlert` / `showConfirmDialog` に置換（8 ファイル）
- Web 向け `Platform.OS !== 'web'` 分岐を削除し、全プラットフォームでダイアログが表示されるように統一
- `Alert.prompt`（ProductMaster の iOS 店舗統合）は iOS 専用 API のため現状維持

## 対象ファイル
- `TotpSettingsScreen`, `PromptEditorScreen`, `CategoryManagementScreen`, `ProductMasterScreen`, `HistoryScreen`
- `useReceiptUpload`, `useAppSession`, `apiClient`

## Acceptance Criteria
- [x] Screen / Hook 内 `Alert.alert` 0 件（`alertMessage.ts`, `confirmDialog.ts` 内部除く）
- [ ] Web でダイアログが表示されることを確認（マージ前に目視）

## Test plan
- [ ] Web: 履歴取得失敗・カテゴリ更新失敗時に `window.alert` が表示される
- [ ] Web: プロンプト削除確認で `window.confirm` が動作する
- [ ] Web: 403 エラー時に権限エラーダイアログが表示される
- [ ] ネイティブ: 既存の Alert 相当の通知・確認が従来どおり動作する
- [x] `npm test` 46 tests passed

Closes #437


Made with [Cursor](https://cursor.com)