### PR TITLE
refactor(fe): [Issue #100-14] 画面 API 直叩きの Hook 移行

### DIFF
--- a/frontend/src/features/category/hooks/useCategoryManagement.ts
+++ b/frontend/src/features/category/hooks/useCategoryManagement.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+import { categoryApi, type Category } from '../../../api';
+import { getApiErrorStatus } from '../../../utils/apiError';
+import { showAlert } from '../../../utils/alertMessage';
+import { pickNextCategoryColor } from '../../../utils/categoryColor';
+import { showConfirmDialog } from '../../../utils/confirmDialog';
+
+type UseCategoryManagementOptions = {
+  currentMemberId: number | null;
+};
+
+export function useCategoryManagement({ currentMemberId }: UseCategoryManagementOptions) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [newName, setNewName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [optimizing, setOptimizing] = useState(false);
+
+  const fetchCategories = useCallback(async () => {
+    if (!currentMemberId) return;
+    setLoading(true);
+    try {
+      const res = await categoryApi.listCategories();
+      setCategories(res.data ?? []);
+    } catch (e: unknown) {
+      if (getApiErrorStatus(e) === 401) {
+        showAlert('セッション切れ', '再度ログインしてください。');
+      } else {
+        showAlert('エラー', 'カテゴリーの取得に失敗しました。');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [currentMemberId]);
+
+  useEffect(() => {
+    if (currentMemberId) {
+      void fetchCategories();
+    }
+  }, [currentMemberId, fetchCategories]);
+
+  const addCategory = async () => {
+    if (!newName.trim() || !currentMemberId) return;
+    try {
+      const color = pickNextCategoryColor(
+        categories.map((c) => c.color).filter((c): c is string => !!c)
+      );
+      await categoryApi.createCategory({ name: newName, color });
+      setNewName('');
+      await fetchCategories();
+    } catch {
+      showAlert('エラー', '追加に失敗しました。');
+    }
+  };
+
+  const deleteCategory = (id: number) => {
+    showConfirmDialog('削除の確認', 'このカテゴリーを削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await categoryApi.deleteCategory(id);
+            await fetchCategories();
+          } catch (e: unknown) {
+            const status = getApiErrorStatus(e);
+            if (status === 400 || status === 409) {
+              showAlert('制限', 'このカテゴリーは既に使用されているため削除できません。');
+            } else {
+              showAlert('エラー', '削除に失敗しました。');
+            }
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleOptimize = () => {
+    showConfirmDialog(
+      'マスタ最適化',
+      'ProductMasterの統計に基づき、カテゴリーのキーワードを自動補強します。よろしいですか？',
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '実行',
+          onPress: async () => {
+            setOptimizing(true);
+            try {
+              const res = await categoryApi.optimizeCategories();
+              showAlert('完了', res.data?.message ?? '最適化が完了しました。');
+              await fetchCategories();
+            } catch {
+              showAlert('エラー', '最適化処理に失敗しました。');
+            } finally {
+              setOptimizing(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  return {
+    categories,
+    newName,
+    setNewName,
+    loading,
+    optimizing,
+    addCategory,
+    deleteCategory,
+    handleOptimize,
+  };
+}

--- a/frontend/src/features/category/index.ts
+++ b/frontend/src/features/category/index.ts
@@ -1,0 +1,1 @@
+export { useCategoryManagement } from './hooks/useCategoryManagement';

--- a/frontend/src/features/history/hooks/useReceiptHistory.ts
+++ b/frontend/src/features/history/hooks/useReceiptHistory.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { categoryApi, receiptApi } from '../../../api';
+import { useIsWideLayout } from '../../../hooks/useIsWideLayout';
+import type { CategorySummary, ReceiptDetail } from '../../../types/receipt';
+import type { FamilyMemberSummary } from '../../../types/settlement';
+import { showAlert } from '../../../utils/alertMessage';
+import { getRecentYearMonths, useMonthSelectOptions } from '../../../utils/monthSelectOptions';
+
+type UseReceiptHistoryOptions = {
+  currentMemberId: number;
+};
+
+export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions) {
+  const isWide = useIsWideLayout();
+
+  const [loading, setLoading] = useState(true);
+  const [receipts, setReceipts] = useState<ReceiptDetail[]>([]);
+  const [categories, setCategories] = useState<CategorySummary[]>([]);
+  const [members, setMembers] = useState<FamilyMemberSummary[]>([]);
+  const [selectedReceipt, setSelectedReceipt] = useState<ReceiptDetail | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState('');
+  const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
+
+  const months = useMemo(() => getRecentYearMonths(6), []);
+  const monthSelectOptions = useMonthSelectOptions(months, isWide);
+  const memberSelectOptions = useMemo(
+    () =>
+      members.map((m) => ({
+        label: m.id === currentMemberId ? `自分 (${m.name})` : m.name,
+        value: m.id.toString(),
+      })),
+    [members, currentMemberId]
+  );
+
+  const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
+  const baseUrl = API_URL.replace(/\/api\/?$/, '');
+
+  const fetchCategories = useCallback(async () => {
+    try {
+      const res = await categoryApi.listCategories();
+      if (res.success) {
+        setCategories(res.data);
+      }
+    } catch (err) {
+      console.error('カテゴリー取得失敗', err);
+    }
+  }, []);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      const res = await receiptApi.getFamilyMembers();
+      if (res.success) {
+        setMembers(res.data);
+      }
+    } catch (err) {
+      console.error('世帯メンバー取得失敗', err);
+    }
+  }, []);
+
+  const fetchReceipts = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await receiptApi.listReceipts({
+        ...(selectedMonth ? { month: selectedMonth } : {}),
+        memberId: selectedMember,
+      });
+      if (res.success) {
+        const data = res.data;
+        setReceipts(data);
+
+        if (selectedReceipt) {
+          const updated = data.find((r: ReceiptDetail) => r.id === selectedReceipt.id);
+          if (updated) setSelectedReceipt(updated);
+        } else if (isWide && data.length > 0) {
+          setSelectedReceipt(data[0]);
+        }
+      }
+    } catch (err) {
+      console.error('履歴取得失敗', err);
+      showAlert('エラー', '履歴の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedMonth, selectedMember, isWide, selectedReceipt?.id]);
+
+  useEffect(() => {
+    fetchCategories();
+    fetchMembers();
+  }, [fetchCategories, fetchMembers]);
+
+  useEffect(() => {
+    fetchReceipts();
+  }, [selectedMonth, selectedMember]);
+
+  const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
+    if (!categoryId) return;
+    try {
+      const response = await receiptApi.updateItemCategory(itemId, Number(categoryId));
+
+      if (response.success) {
+        const updatedItem = response.data;
+        const mapper = (r: ReceiptDetail): ReceiptDetail => ({
+          ...r,
+          items: r.items.map((item) =>
+            item.id === itemId
+              ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category }
+              : item
+          ),
+        });
+
+        setReceipts((prev) => prev.map(mapper));
+        if (selectedReceipt) setSelectedReceipt((prev) => (prev ? mapper(prev) : null));
+      }
+    } catch (err) {
+      console.error('カテゴリー更新失敗', err);
+      showAlert('エラー', 'カテゴリーの更新に失敗しました');
+    }
+  };
+
+  return {
+    isWide,
+    loading,
+    receipts,
+    categories,
+    selectedReceipt,
+    setSelectedReceipt,
+    selectedMonth,
+    setSelectedMonth,
+    selectedMember,
+    setSelectedMember,
+    monthSelectOptions,
+    memberSelectOptions,
+    baseUrl,
+    fetchReceipts,
+    handleCategoryChange,
+  };
+}

--- a/frontend/src/features/history/index.ts
+++ b/frontend/src/features/history/index.ts
@@ -1,0 +1,1 @@
+export { useReceiptHistory } from './hooks/useReceiptHistory';

--- a/frontend/src/features/receipt/hooks/useReceiptScan.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptScan.ts
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react';
+import { receiptApi } from '../../../api/receiptApi';
+import type { ParsedReceiptItemInput } from '../../../types/receipt';
+import type { ReceiptScanInitialData } from '../../../types/receiptScan';
+import { showAlert } from '../../../utils/alertMessage';
+import { getApiErrorMessage, getApiErrorResponseData } from '../../../utils/apiError';
+import { useReceiptImageSource } from '../../../utils/receiptImageSource';
+
+type ReceiptFormData = ReceiptScanInitialData['parsedData'] & {
+  taxAmount: string | number;
+};
+
+type UseReceiptScanOptions = {
+  initialData: ReceiptScanInitialData;
+  categories: Array<{ id: number; name: string }>;
+  onSuccess: () => void;
+  onCancel: () => void;
+};
+
+export function useReceiptScan({
+  initialData,
+  categories,
+  onSuccess,
+  onCancel,
+}: UseReceiptScanOptions) {
+  const [loading, setLoading] = useState(false);
+  const [receiptData, setReceiptData] = useState<ReceiptFormData>({
+    ...initialData.parsedData,
+    taxAmount: initialData.parsedData.taxAmount ?? '0',
+  });
+
+  const categorySelectOptions = useMemo(
+    () => categories.map((c) => ({ label: c.name, value: c.id })),
+    [categories]
+  );
+
+  const imageSource = useReceiptImageSource(initialData.imagePath);
+
+  const calculatedTotal = useMemo(() => {
+    const itemsTotal = receiptData.items.reduce((sum, item) => {
+      const p = parseFloat(String(item.price)) || 0;
+      const q = parseFloat(String(item.quantity)) || 0;
+      return sum + p * q;
+    }, 0);
+
+    const tax = parseFloat(String(receiptData.taxAmount)) || 0;
+    return Math.round(itemsTotal + tax);
+  }, [receiptData.items, receiptData.taxAmount]);
+
+  const updateItem = (
+    index: number,
+    key: keyof ParsedReceiptItemInput,
+    value: ParsedReceiptItemInput[keyof ParsedReceiptItemInput]
+  ) => {
+    const newItems = [...receiptData.items];
+    newItems[index] = { ...newItems[index], [key]: value };
+    setReceiptData({ ...receiptData, items: newItems });
+  };
+
+  const removeItem = (index: number) => {
+    const newItems = receiptData.items.filter((_, i) => i !== index);
+    setReceiptData({ ...receiptData, items: newItems });
+  };
+
+  const addItem = () => {
+    const newItems = [...receiptData.items, { name: '', price: 0, quantity: 1, categoryId: null }];
+    setReceiptData({ ...receiptData, items: newItems });
+  };
+
+  const handleCommit = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const payload = {
+        jobId: initialData.jobId,
+        parsedData: {
+          ...receiptData,
+          totalAmount: calculatedTotal,
+          taxAmount: parseFloat(String(receiptData.taxAmount)) || 0,
+          items: receiptData.items.map((item) => ({
+            ...item,
+            price: parseFloat(String(item.price)) || 0,
+            quantity: parseFloat(String(item.quantity)) || 0,
+            categoryId: item.categoryId ? Number(item.categoryId) : null,
+          })),
+        },
+        imagePath: initialData.imagePath,
+        validation: initialData.validation,
+      };
+
+      const res = await receiptApi.commitReceipt(payload);
+      if (res.success) {
+        showAlert('成功', 'レシートを保存しました。', { onOk: onSuccess });
+        return;
+      }
+    } catch (err: unknown) {
+      const apiError = getApiErrorResponseData(err);
+      const message = getApiErrorMessage(err, '保存に失敗しました。');
+
+      if (message === 'DUPLICATE') {
+        const duplicateMessage = initialData.warnedDuplicateFromTray
+          ? '確認トレイで重複の疑いが表示されていました。同じ内容のレシートは保存できません。トレイから破棄するか、履歴で既存レシートを確認してください。'
+          : '同じ店名・日付・金額のレシートが世帯内に存在します。履歴画面で確認してください。';
+        showAlert('既に登録済みです', duplicateMessage, { onOk: onCancel });
+        return;
+      }
+
+      console.error('Commit error:', apiError || message);
+      showAlert('エラー', message || '保存に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    loading,
+    receiptData,
+    setReceiptData,
+    categorySelectOptions,
+    imageSource,
+    calculatedTotal,
+    updateItem,
+    removeItem,
+    addItem,
+    handleCommit,
+  };
+}

--- a/frontend/src/features/receipt/index.ts
+++ b/frontend/src/features/receipt/index.ts
@@ -1,5 +1,6 @@
 export { useReceiptDetail } from './hooks/useReceiptDetail';
 export type { ReceiptDetailFlow } from './hooks/useReceiptDetail';
+export { useReceiptScan } from './hooks/useReceiptScan';
 export { ReceiptDetailComponent } from './components/ReceiptDetailComponent';
 export type { ReceiptDetailComponentProps } from './components/ReceiptDetailComponent';
 export { ReceiptDetailActions } from './components/ReceiptDetailActions';

--- a/frontend/src/screens/CategoryManagementScreen.tsx
+++ b/frontend/src/screens/CategoryManagementScreen.tsx
@@ -1,17 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { StyleSheet, View, Text, FlatList, ActivityIndicator, Platform } from 'react-native';
-import { categoryApi, type Category } from '../api';
-import { getApiErrorStatus } from '../utils/apiError';
-import { showAlert } from '../utils/alertMessage';
 import { AppBackButton, AppButton, AppListColorDot, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
+import { useCategoryManagement } from '../features/category';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
 import { typography } from '../theme/typography';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
-import { pickNextCategoryColor } from '../utils/categoryColor';
-import { showConfirmDialog } from '../utils/confirmDialog';
 
 export const CategoryManagementScreen = ({
   onBack,
@@ -20,93 +16,7 @@ export const CategoryManagementScreen = ({
   onBack: () => void;
   currentMemberId: number | null;
 }) => {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [newName, setNewName] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [optimizing, setOptimizing] = useState(false);
-
-  useEffect(() => {
-    if (currentMemberId) fetchCategories();
-  }, [currentMemberId]);
-
-  const fetchCategories = async () => {
-    if (!currentMemberId) return;
-    setLoading(true);
-    try {
-      const res = await categoryApi.listCategories();
-      setCategories(res.data ?? []);
-    } catch (e: unknown) {
-      if (getApiErrorStatus(e) === 401) {
-        showAlert('セッション切れ', '再度ログインしてください。');
-      } else {
-        showAlert('エラー', 'カテゴリーの取得に失敗しました。');
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const addCategory = async () => {
-    if (!newName.trim() || !currentMemberId) return;
-    try {
-      const color = pickNextCategoryColor(
-        categories.map((c) => c.color).filter((c): c is string => !!c)
-      );
-      await categoryApi.createCategory({ name: newName, color });
-      setNewName('');
-      fetchCategories();
-    } catch {
-      showAlert('エラー', '追加に失敗しました。');
-    }
-  };
-
-  const deleteCategory = (id: number) => {
-    showConfirmDialog('削除の確認', 'このカテゴリーを削除しますか？', [
-      { text: 'キャンセル', style: 'cancel' },
-      {
-        text: '削除',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            await categoryApi.deleteCategory(id);
-            fetchCategories();
-          } catch (e: unknown) {
-            const status = getApiErrorStatus(e);
-            if (status === 400 || status === 409) {
-              showAlert('制限', 'このカテゴリーは既に使用されているため削除できません。');
-            } else {
-              showAlert('エラー', '削除に失敗しました。');
-            }
-          }
-        },
-      },
-    ]);
-  };
-
-  const handleOptimize = () => {
-    showConfirmDialog(
-      'マスタ最適化',
-      'ProductMasterの統計に基づき、カテゴリーのキーワードを自動補強します。よろしいですか？',
-      [
-        { text: 'キャンセル', style: 'cancel' },
-        {
-          text: '実行',
-          onPress: async () => {
-            setOptimizing(true);
-            try {
-              const res = await categoryApi.optimizeCategories();
-              showAlert('完了', res.data?.message ?? '最適化が完了しました。');
-              fetchCategories();
-            } catch {
-              showAlert('エラー', '最適化処理に失敗しました。');
-            } finally {
-              setOptimizing(false);
-            }
-          },
-        },
-      ]
-    );
-  };
+  const category = useCategoryManagement({ currentMemberId });
 
   return (
     <View style={[screenLayout.container, styles.containerCategory]}>
@@ -118,18 +28,18 @@ export const CategoryManagementScreen = ({
       <View style={[cardStyles.section, styles.inputSection]}>
         <AppTextInput
           style={styles.nameInput}
-          value={newName}
-          onChangeText={setNewName}
+          value={category.newName}
+          onChangeText={category.setNewName}
           placeholder="新しいカテゴリー"
         />
-        <AppButton title={BUTTON_LABELS.add} onPress={addCategory} size="md" />
+        <AppButton title={BUTTON_LABELS.add} onPress={category.addCategory} size="md" />
       </View>
 
       <AppButton
         title="🪄 キーワード自動最適化"
-        onPress={handleOptimize}
-        loading={optimizing}
-        disabled={optimizing}
+        onPress={category.handleOptimize}
+        loading={category.optimizing}
+        disabled={category.optimizing}
         fullWidth
         size="md"
         style={{ backgroundColor: colors.semantic.category.optimize, marginBottom: spacing.lg }}
@@ -137,11 +47,11 @@ export const CategoryManagementScreen = ({
 
       {!currentMemberId ? (
         <Text style={styles.emptyText}>メンバーを選択してください</Text>
-      ) : loading ? (
+      ) : category.loading ? (
         <ActivityIndicator size="large" color={colors.primary} style={{ marginTop: 50 }} />
       ) : (
         <FlatList
-          data={categories}
+          data={category.categories}
           keyExtractor={(item) => item.id.toString()}
           contentContainerStyle={styles.list}
           renderItem={({ item }) => (
@@ -151,7 +61,7 @@ export const CategoryManagementScreen = ({
               right={
                 <AppButton
                   title={BUTTON_LABELS.delete}
-                  onPress={() => deleteCategory(item.id)}
+                  onPress={() => category.deleteCategory(item.id)}
                   variant="dangerFilled"
                   size="sm"
                 />

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -1,165 +1,50 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { 
-  StyleSheet, 
-  Text, 
-  View, 
-  FlatList, 
-  TouchableOpacity, 
-  ActivityIndicator, 
-  Platform, 
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  Platform,
 } from 'react-native';
-import { categoryApi, receiptApi } from '../api';
-import { getRecentYearMonths, useMonthSelectOptions } from '../utils/monthSelectOptions';
-import { showAlert } from '../utils/alertMessage';
-// Issue #66: BREAKPOINTS 参照
 import { AppBackButton, AppModal, AppSelect } from '../components/ui';
+import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
+import { useReceiptHistory } from '../features/history';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
-import { useIsWideLayout } from '../hooks/useIsWideLayout';
-import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
-import type { CategorySummary, ReceiptDetail } from '../types/receipt';
-import type { FamilyMemberSummary, ReceiptForSplitEditor } from '../types/settlement';
+import type { ReceiptDetail } from '../types/receipt';
+import type { ReceiptForSplitEditor } from '../types/settlement';
 
 interface HistoryScreenProps {
   onBack: () => void;
-  currentMemberId: number; 
+  currentMemberId: number;
   onGoToSplitEditor?: (receipt: ReceiptForSplitEditor) => void;
 }
 
 /**
- * [Issue #67 / #64 / Web・ネイティブ完全互換] 履歴一覧画面
+ * [Issue #67 / #64 / #100-14] 履歴一覧画面 — Hook + UI の薄型 Screen
  */
 export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEditor }: HistoryScreenProps) {
-  const isWide = useIsWideLayout();
-
-  const [loading, setLoading] = useState(true);
-  const [receipts, setReceipts] = useState<ReceiptDetail[]>([]);
-  const [categories, setCategories] = useState<CategorySummary[]>([]);
-  const [members, setMembers] = useState<FamilyMemberSummary[]>([]);
-  const [selectedReceipt, setSelectedReceipt] = useState<ReceiptDetail | null>(null);
-  
-  const [selectedMonth, setSelectedMonth] = useState('');
-  const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
-
-  const months = useMemo(() => getRecentYearMonths(6), []);
-
-  const monthSelectOptions = useMonthSelectOptions(months, isWide);
-
-  const memberSelectOptions = useMemo(
-    () =>
-      members.map((m) => ({
-        label: m.id === currentMemberId ? `自分 (${m.name})` : m.name,
-        value: m.id.toString(),
-      })),
-    [members, currentMemberId]
-  );
-
-  const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
-  const BASE_URL = API_URL.replace(/\/api\/?$/, '');
-
-  // カテゴリマスタの取得
-  const fetchCategories = useCallback(async () => {
-    try {
-      const res = await categoryApi.listCategories();
-      if (res.success) {
-        setCategories(res.data);
-      }
-    } catch (err) {
-      console.error('カテゴリー取得失敗', err);
-    }
-  }, []);
-
-  // ★ Issue #64: 所属世帯のメンバー一覧を取得
-  const fetchMembers = useCallback(async () => {
-    try {
-      const res = await receiptApi.getFamilyMembers();
-      if (res.success) {
-        setMembers(res.data);
-      }
-    } catch (err) {
-      console.error('世帯メンバー取得失敗', err);
-    }
-  }, []);
-
-  // 履歴データの取得
-  const fetchReceipts = useCallback(async () => {
-    try {
-      setLoading(true);
-      const res = await receiptApi.listReceipts({
-        ...(selectedMonth ? { month: selectedMonth } : {}),
-        memberId: selectedMember,
-      });
-      if (res.success) {
-        const data = res.data;
-        setReceipts(data);
-        
-        // 編集・保存後に選択中データの参照を最新に更新
-        if (selectedReceipt) {
-          const updated = data.find((r: ReceiptDetail) => r.id === selectedReceipt.id);
-          if (updated) setSelectedReceipt(updated);
-        } else if (isWide && data.length > 0) {
-          // 初回ロード時は1件目を選択
-          setSelectedReceipt(data[0]);
-        }
-      }
-    } catch (err) {
-      console.error('履歴取得失敗', err);
-      showAlert('エラー', '履歴の取得に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedMonth, selectedMember, isWide, selectedReceipt?.id]);
-
-  useEffect(() => {
-    fetchCategories();
-    fetchMembers(); // ★ 初期化時にメンバーマスタをロード
-  }, [fetchCategories, fetchMembers]);
-
-  useEffect(() => {
-    fetchReceipts();
-  }, [selectedMonth, selectedMember]); // フィルタ変更時のみ自動発火
-
-  // カテゴリのみの簡易変更処理（既存互換）
-  const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
-    if (!categoryId) return;
-    try {
-      const response = await receiptApi.updateItemCategory(itemId, Number(categoryId));
-
-      if (response.success) {
-        const updatedItem = response.data;
-        const mapper = (r: ReceiptDetail): ReceiptDetail => ({
-          ...r,
-          items: r.items.map((item) =>
-            item.id === itemId ? { ...item, categoryId: updatedItem.categoryId, category: updatedItem.category } : item
-          ),
-        });
-
-        setReceipts(prev => prev.map(mapper));
-        if (selectedReceipt) setSelectedReceipt((prev) => (prev ? mapper(prev) : null));
-      }
-    } catch (err) {
-      console.error('カテゴリー更新失敗', err);
-      showAlert('エラー', 'カテゴリーの更新に失敗しました');
-    }
-  };
+  const history = useReceiptHistory({ currentMemberId });
 
   const renderItem = ({ item }: { item: ReceiptDetail }) => {
-    const isSelected = selectedReceipt?.id === item.id;
+    const isSelected = history.selectedReceipt?.id === item.id;
     const displayAmount = Math.round(item.totalAmount || 0);
 
     return (
-      <TouchableOpacity 
-        style={[cardStyles.listCard, styles.listCardExtra, isSelected && isWide && styles.activeCard]} 
-        onPress={() => setSelectedReceipt(item)}
+      <TouchableOpacity
+        style={[cardStyles.listCard, styles.listCardExtra, isSelected && history.isWide && styles.activeCard]}
+        onPress={() => history.setSelectedReceipt(item)}
         activeOpacity={0.7}
       >
         <View style={styles.cardHeader}>
           <Text style={styles.date}>
             {item.date ? new Date(item.date).toLocaleDateString('ja-JP') : '日付不明'}
           </Text>
-          <Text style={[styles.store, isSelected && isWide && { color: colors.primary }]} numberOfLines={1}>
+          <Text style={[styles.store, isSelected && history.isWide && { color: colors.primary }]} numberOfLines={1}>
             {item.storeName || '店名不明'}
           </Text>
         </View>
@@ -184,36 +69,36 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
           <View style={{ width: 40 }} />
         </View>
 
-        <View style={[styles.filterContainer, isWide ? styles.filterContainerWide : styles.filterContainerMobile]}>
-          <View style={[styles.filterSelectWrap, isWide && styles.filterSelectWrapWide]}>
+        <View style={[styles.filterContainer, history.isWide ? styles.filterContainerWide : styles.filterContainerMobile]}>
+          <View style={[styles.filterSelectWrap, history.isWide && styles.filterSelectWrapWide]}>
             <AppSelect<string>
-              selectedValue={selectedMonth}
-              onValueChange={setSelectedMonth}
-              options={monthSelectOptions}
+              selectedValue={history.selectedMonth}
+              onValueChange={history.setSelectedMonth}
+              options={history.monthSelectOptions}
               placeholder="全期間"
               placeholderValue=""
             />
           </View>
-          <View style={[styles.filterSelectWrap, isWide && styles.filterSelectWrapWide]}>
+          <View style={[styles.filterSelectWrap, history.isWide && styles.filterSelectWrapWide]}>
             <AppSelect<string>
-              selectedValue={selectedMember}
-              onValueChange={setSelectedMember}
-              options={memberSelectOptions}
+              selectedValue={history.selectedMember}
+              onValueChange={history.setSelectedMember}
+              options={history.memberSelectOptions}
               placeholder="世帯全体"
               placeholderValue=""
             />
           </View>
         </View>
 
-        <View style={isWide ? styles.mainContentWide : styles.mainContentMobile}>
-          <View style={isWide ? styles.masterPane : styles.fullPane}>
-            {loading ? (
+        <View style={history.isWide ? styles.mainContentWide : styles.mainContentMobile}>
+          <View style={history.isWide ? styles.masterPane : styles.fullPane}>
+            {history.loading ? (
               <View style={styles.centerLoading}>
                 <ActivityIndicator size="large" color={colors.primary} />
               </View>
             ) : (
               <FlatList
-                data={receipts}
+                data={history.receipts}
                 keyExtractor={(item) => item.id.toString()}
                 renderItem={renderItem}
                 contentContainerStyle={styles.list}
@@ -223,17 +108,17 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
             )}
           </View>
 
-          {isWide && (
+          {history.isWide && (
             <View style={styles.detailPane}>
-              {selectedReceipt ? (
-                <ReceiptDetailComponent 
-                  receipt={selectedReceipt}
-                  categories={categories}
-                  onCategoryChange={handleCategoryChange}
-                  baseUrl={BASE_URL}
+              {history.selectedReceipt ? (
+                <ReceiptDetailComponent
+                  receipt={history.selectedReceipt}
+                  categories={history.categories}
+                  onCategoryChange={history.handleCategoryChange}
+                  baseUrl={history.baseUrl}
                   fullWidth={false}
-                  onSaveSuccess={fetchReceipts}
-                  onGoToSplitEditor={onGoToSplitEditor} // ★ 追加: Componentへハンドラを渡す
+                  onSaveSuccess={history.fetchReceipts}
+                  onGoToSplitEditor={onGoToSplitEditor}
                 />
               ) : (
                 <View style={styles.emptyDetailWrapper}>
@@ -245,21 +130,21 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
         </View>
       </View>
 
-      {!isWide && (
+      {!history.isWide && (
         <AppModal
-          visible={!!selectedReceipt}
-          onRequestClose={() => setSelectedReceipt(null)}
+          visible={!!history.selectedReceipt}
+          onRequestClose={() => history.setSelectedReceipt(null)}
           variant="sheet"
-          title={selectedReceipt?.storeName || '店名不明'}
+          title={history.selectedReceipt?.storeName || '店名不明'}
         >
-          {selectedReceipt ? (
+          {history.selectedReceipt ? (
             <ReceiptDetailComponent
-              receipt={selectedReceipt}
-              categories={categories}
-              onCategoryChange={handleCategoryChange}
-              baseUrl={BASE_URL}
+              receipt={history.selectedReceipt}
+              categories={history.categories}
+              onCategoryChange={history.handleCategoryChange}
+              baseUrl={history.baseUrl}
               fullWidth={true}
-              onSaveSuccess={fetchReceipts}
+              onSaveSuccess={history.fetchReceipts}
               onGoToSplitEditor={onGoToSplitEditor}
             />
           ) : null}

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import {
   View,
   Text,
@@ -11,8 +11,8 @@ import {
   Image,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { receiptApi } from '../api/receiptApi';
 import { AppBackButton, AppButton, AppFormField, AppSelect, AppTextInput } from '../components/ui';
+import { useReceiptScan } from '../features/receipt';
 import { modalStyles } from '../theme/modalStyles';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
@@ -20,11 +20,7 @@ import { borderRadius } from '../theme/radii';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
-import { useReceiptImageSource } from '../utils/receiptImageSource';
-import { showAlert } from '../utils/alertMessage';
-import { getApiErrorMessage, getApiErrorResponseData } from '../utils/apiError';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
-import type { ParsedReceiptItemInput } from '../types/receipt';
 
 const c = colors;
 const s = colors.semantic.scan;
@@ -37,10 +33,7 @@ interface ReceiptScanScreenProps {
 }
 
 /**
- * [Issue #67 / #71 / #63] レシート解析結果の確認・編集画面
- * - 外税(taxAmount)の編集・合算に対応
- * - 単価・数量の小数点入力対応
- * - 解析コスト紐付け用 usageLogId のポストに対応
+ * [Issue #67 / #71 / #100-14] レシート解析結果の確認・編集画面 — Hook + UI
  */
 export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
   initialData,
@@ -48,93 +41,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
   onSuccess,
   onCancel,
 }) => {
-  const [loading, setLoading] = useState(false);
-  // 初期値に taxAmount がない場合へのフォールバック
-  const [receiptData, setReceiptData] = useState({
-    ...initialData.parsedData,
-    taxAmount: initialData.parsedData.taxAmount ?? '0',
-  });
-
-  const categorySelectOptions = useMemo(
-    () => categories.map((c) => ({ label: c.name, value: c.id })),
-    [categories]
-  );
-
-  const imageSource = useReceiptImageSource(initialData.imagePath);
-
-  // 合計金額の計算（明細合計 + 外税）
-  const calculatedTotal = useMemo(() => {
-    const itemsTotal = receiptData.items.reduce((sum, item) => {
-      const p = parseFloat(String(item.price)) || 0;
-      const q = parseFloat(String(item.quantity)) || 0;
-      return sum + (p * q);
-    }, 0);
-    
-    const tax = parseFloat(String(receiptData.taxAmount)) || 0;
-    // 日本円のため最終的な支払額は四捨五入して整数化
-    return Math.round(itemsTotal + tax);
-  }, [receiptData.items, receiptData.taxAmount]);
-
-  const updateItem = (index: number, key: keyof ParsedReceiptItemInput, value: ParsedReceiptItemInput[keyof ParsedReceiptItemInput]) => {
-    const newItems = [...receiptData.items];
-    newItems[index] = { ...newItems[index], [key]: value };
-    setReceiptData({ ...receiptData, items: newItems });
-  };
-
-  const removeItem = (index: number) => {
-    const newItems = receiptData.items.filter((_, i) => i !== index);
-    setReceiptData({ ...receiptData, items: newItems });
-  };
-
-  const addItem = () => {
-    const newItems = [...receiptData.items, { name: '', price: 0, quantity: 1, categoryId: null }];
-    setReceiptData({ ...receiptData, items: newItems });
-  };
-
-  const handleCommit = async () => {
-    if (loading) return;
-    setLoading(true);
-    try {
-      const payload = {
-        jobId: initialData.jobId,
-        parsedData: { 
-          ...receiptData, 
-          totalAmount: calculatedTotal,
-          taxAmount: parseFloat(String(receiptData.taxAmount)) || 0,
-          items: receiptData.items.map(item => ({
-            ...item,
-            price: parseFloat(String(item.price)) || 0,
-            quantity: parseFloat(String(item.quantity)) || 0,
-            categoryId: item.categoryId ? Number(item.categoryId) : null
-          }))
-        },
-        imagePath: initialData.imagePath,
-        validation: initialData.validation
-      };
-      
-      const res = await receiptApi.commitReceipt(payload);
-      if (res.success) {
-        showAlert('成功', 'レシートを保存しました。', { onOk: onSuccess });
-        return;
-      }
-    } catch (err: unknown) {
-      const apiError = getApiErrorResponseData(err);
-      const message = getApiErrorMessage(err, '保存に失敗しました。');
-
-      if (message === 'DUPLICATE') {
-        const duplicateMessage = initialData.warnedDuplicateFromTray
-          ? '確認トレイで重複の疑いが表示されていました。同じ内容のレシートは保存できません。トレイから破棄するか、履歴で既存レシートを確認してください。'
-          : '同じ店名・日付・金額のレシートが世帯内に存在します。履歴画面で確認してください。';
-        showAlert('既に登録済みです', duplicateMessage, { onOk: onCancel });
-        return;
-      }
-
-      console.error('Commit error:', apiError || message);
-      showAlert('エラー', message || '保存に失敗しました。');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const scan = useReceiptScan({ initialData, categories, onSuccess, onCancel });
 
   return (
     <SafeAreaView style={[screenLayout.container, styles.containerScan]}>
@@ -144,9 +51,9 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
           <Text style={[screenLayout.headerTitle, styles.headerTitleScan]}>解析結果の確認</Text>
           <AppButton
             title={BUTTON_LABELS.save}
-            onPress={handleCommit}
-            loading={loading}
-            disabled={loading}
+            onPress={scan.handleCommit}
+            loading={scan.loading}
+            disabled={scan.loading}
             size="sm"
           />
         </View>
@@ -165,9 +72,9 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
             </View>
           ) : null}
 
-          {imageSource && (
+          {scan.imageSource && (
             <View style={styles.imageContainer}>
-              <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
+              <Image source={scan.imageSource} style={styles.receiptImage} resizeMode="contain" />
               <View style={styles.imageLabel}><Text style={styles.imageLabelText}>加工済みプレビュー</Text></View>
             </View>
           )}
@@ -176,15 +83,15 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
             <Text style={styles.sectionLabel}>基本情報</Text>
             <AppFormField label="店舗名">
               <AppTextInput
-                value={receiptData.storeName}
-                onChangeText={(val) => setReceiptData({ ...receiptData, storeName: val })}
+                value={scan.receiptData.storeName}
+                onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, storeName: val })}
                 placeholder="店舗名"
               />
             </AppFormField>
             <AppFormField label="購入日時">
               <AppTextInput
-                value={receiptData.purchaseDate}
-                onChangeText={(val) => setReceiptData({ ...receiptData, purchaseDate: val })}
+                value={scan.receiptData.purchaseDate}
+                onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, purchaseDate: val })}
                 placeholder="YYYY-MM-DD HH:mm"
               />
             </AppFormField>
@@ -193,9 +100,9 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
               <View style={modalStyles.inputWithUnit}>
                 <AppTextInput
                   variant="inline"
-                  value={String(receiptData.taxAmount)}
+                  value={String(scan.receiptData.taxAmount)}
                   keyboardType="decimal-pad"
-                  onChangeText={(val) => setReceiptData({ ...receiptData, taxAmount: val })}
+                  onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, taxAmount: val })}
                 />
                 <Text style={modalStyles.unitSuffix}>円</Text>
               </View>
@@ -203,41 +110,41 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
 
             <View style={styles.totalDisplay}>
               <Text style={styles.totalLabel}>支払合計 (税込)</Text>
-              <Text style={styles.totalValue}>¥ {calculatedTotal.toLocaleString()}</Text>
+              <Text style={styles.totalValue}>¥ {scan.calculatedTotal.toLocaleString()}</Text>
             </View>
           </View>
 
           <View style={styles.itemsHeader}>
-            <Text style={styles.sectionLabel}>商品明細 ({receiptData.items.length})</Text>
+            <Text style={styles.sectionLabel}>商品明細 ({scan.receiptData.items.length})</Text>
             <AppButton
               title={`+ ${BUTTON_LABELS.add}`}
-              onPress={addItem}
+              onPress={scan.addItem}
               variant="outline"
               size="sm"
             />
           </View>
 
-          {receiptData.items.map((item, idx) => (
+          {scan.receiptData.items.map((item, idx) => (
             <View key={idx} style={[cardStyles.chartCard, styles.itemCard]}>
               <View style={styles.itemHeaderRow}>
                 <AppTextInput
                   style={styles.itemNameInput}
                   value={item.name}
-                  onChangeText={(val) => updateItem(idx, 'name', val)}
+                  onChangeText={(val) => scan.updateItem(idx, 'name', val)}
                   placeholder="商品名"
                 />
-                <TouchableOpacity onPress={() => removeItem(idx)}>
+                <TouchableOpacity onPress={() => scan.removeItem(idx)}>
                   <Text style={styles.deleteIcon}>🗑️</Text>
                 </TouchableOpacity>
               </View>
-              
+
               <View style={styles.itemDetailRow}>
                 <View style={styles.itemSubGroup}>
                   <Text style={styles.subLabel}>単価 (¥)</Text>
                   <AppTextInput
                     value={String(item.price)}
                     keyboardType="decimal-pad"
-                    onChangeText={(val) => updateItem(idx, 'price', val)}
+                    onChangeText={(val) => scan.updateItem(idx, 'price', val)}
                   />
                 </View>
                 <View style={[styles.itemSubGroup, { flex: 0.6 }]}>
@@ -245,7 +152,7 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
                   <AppTextInput
                     value={String(item.quantity)}
                     keyboardType="decimal-pad"
-                    onChangeText={(val) => updateItem(idx, 'quantity', val)}
+                    onChangeText={(val) => scan.updateItem(idx, 'quantity', val)}
                   />
                 </View>
                 <View style={[styles.itemSubGroup, { alignItems: 'flex-end' }]}>
@@ -259,8 +166,8 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
               <AppFormField label="カテゴリ">
                 <AppSelect<number | null>
                   selectedValue={item.categoryId}
-                  onValueChange={(val) => updateItem(idx, 'categoryId', val)}
-                  options={categorySelectOptions}
+                  onValueChange={(val) => scan.updateItem(idx, 'categoryId', val)}
+                  options={scan.categorySelectOptions}
                   placeholder="未選択"
                 />
               </AppFormField>


### PR DESCRIPTION
## Summary
- `features/history/hooks/useReceiptHistory.ts` 新設 — HistoryScreen の `categoryApi` / `receiptApi` 呼び出しを集約
- `features/category/hooks/useCategoryManagement.ts` 新設 — CategoryManagementScreen の `categoryApi` 呼び出しを集約
- `features/receipt/hooks/useReceiptScan.ts` 新設 — ReceiptScanScreen の `receiptApi.commitReceipt` を集約
- 対象 3 Screen を Hook 戻り値 + UI の薄型ラッパーに変更（StatisticsScreen は #100-8 済み）

## Acceptance Criteria
- [x] 対象 Screen 内に `categoryApi` / `receiptApi` / `statsApi` 直 import 0 件
- [x] Screen は Hook 戻り値 + UI のみ

## Test plan
- [ ] 履歴: 月・メンバーフィルタ、明細表示・カテゴリ変更・保存後リフレッシュ
- [ ] カテゴリ設定: 追加・削除・キーワード最適化
- [ ] 解析結果確認: 編集・保存・重複エラー表示
- [x] `npm test` 46 tests passed

Closes #438


Made with [Cursor](https://cursor.com)