### PR TITLE
Issue #101-0: Phase 4 実装計画ドキュメント作成

### DIFF
--- a/docs/refactor/plan.md
+++ b/docs/refactor/plan.md
@@ -223,3 +223,83 @@ Epic: [#423 Epic #100](https://github.com/yama180sx/receipt-ai-app/issues/423)
 
 （#98-8 と並行: #393, #394, #397, #399, #400, #401）
 ```
+
+## 8. Epic #101 — ChatGPT レビュー 20260622 フォローアップ（Phase 4）
+
+Epic: [#459 Epic #101](https://github.com/yama180sx/receipt-ai-app/issues/459)
+
+[ChatGPT レビュー 20260622](../specs/chatgpt/ChatGPT_レビュー_20260622.txt)（**79/100点**）のフォローアップ。Epic #100 完了後も残る **画面肥大・画像処理/UI 混在・backend any 残存・API エラー処理散在** を解消し、AI 駆動開発向けの **フロント実装規約** も整備する。
+
+### 8.1 方針サマリー
+
+| 項目 | 決定内容 |
+|------|----------|
+| 入力ソース | ChatGPT レビュー 20260622 + コード突合 + Epic #99 / #100 成功パターン |
+| FE 方針 | Screen = hook + 子コンポーネント（**150行以内**）。#387 / #431 と同型 |
+| BE 方針 | 残存 `any` / `as any` を Express 型拡張・`unknown` で撲滅（局所修正） |
+| エラー方針 | FE: `getApiErrorMessage` / `showApiErrorAlert` に統一。BE: #101-3 は middleware 層中心 |
+| AI 駆動 | #101-7 で規約 + プロンプトテンプレートを正本化し、以降の実装 Issue で参照 |
+| スコープ外 | React Hook Form、Context 新規追加、big-bang 一括 PR |
+
+### 8.2 レビュー減点と対応マッピング
+
+| 観点 | 点数 | 主な対応 Issue |
+|------|------|----------------|
+| DRY / 共通化 | 18/25 | #101-6 |
+| 責務分割 | 20/25 | #101-1, #101-2, #101-4, #101-5 |
+| 型定義 | 22/25 | #101-3 |
+| 保守性 | 19/25 | #101-7 + 上記 |
+
+### 8.3 子 Issue 対応表
+
+| 命名 | GitHub | 優先度 | 見積（AI 補助） |
+|------|--------|--------|----------------|
+| #101 Epic | [#459](https://github.com/yama180sx/receipt-ai-app/issues/459) | — | — |
+| #101-0 | [#460](https://github.com/yama180sx/receipt-ai-app/issues/460) | Must | 0.5 人日 |
+| #101-1 | [#465](https://github.com/yama180sx/receipt-ai-app/issues/465) | Must | 1 人日 |
+| #101-2 | [#466](https://github.com/yama180sx/receipt-ai-app/issues/466) | Must | 1 人日 |
+| #101-3 | [#467](https://github.com/yama180sx/receipt-ai-app/issues/467) | Must | 0.5〜1 人日 |
+| #101-4 | [#462](https://github.com/yama180sx/receipt-ai-app/issues/462) | Should | 1 人日 |
+| #101-5 | [#463](https://github.com/yama180sx/receipt-ai-app/issues/463) | Should | 1 人日 |
+| #101-6 | [#464](https://github.com/yama180sx/receipt-ai-app/issues/464) | Should | 0.5〜1 人日 |
+| #101-7 | [#461](https://github.com/yama180sx/receipt-ai-app/issues/461) | Must | 0.5 人日 |
+
+### 8.4 #100 との関係（重複しないスコープ）
+
+| #100 で実施済み | #101 で追加する理由 |
+|----------------|---------------------|
+| Login / Home / Statistics 等の Screen 分解 | **PromptEditorScreen**（355行）・**ReceiptImageCropModal**（287行）・**SplitEditorItemTable**（292行）が未対応 |
+| BE Repository / authService 本実装 | middleware 層の残存 `any`（`authMiddleware` / `validate` 等）が未対応 |
+| `getApiErrorMessage` 導入・Alert 統一 | Hook 層での `console.error` + 固定メッセージが残存（ProductMaster 等） |
+| architecture.md as-built（#100-15） | AI 駆動向け **実装規約・プロンプトテンプレート** は未整備 |
+
+**重複しないことの確認**: #101 は #100 で触っていないファイル・運用ルールに限定する。層境界の全面整理（Mapper / OpenAPI drift CI）は **Epic #102 / #103**（Phase 5）へ委譲。
+
+### 8.5 Won't fix / Later（記録）
+
+| 項目 | 判定 | 対応 |
+|------|------|------|
+| React Hook Form 導入 | **Won't fix** | hook 分割で十分（#101-1） |
+| Context 新規追加 | **Won't fix** | #101-7 で既存 Context のみと明文化 |
+| frontend/backend 型の完全共有（C-2） | **Later → Epic #102** | [#468](https://github.com/yama180sx/receipt-ai-app/issues/468) |
+| API 層 DTO / 変換 / エラー完全分離（C-4） | **Later → Epic #103** | [#469](https://github.com/yama180sx/receipt-ai-app/issues/469) |
+
+### 8.6 推奨着手順
+
+```
+#460（#101-0 plan）→ #461（#101-7 規約）→ #465 → #466 → #467
+  → #462 / #463（並行可）→ #464
+  → Epic #102 / #103（#101 完了後）
+```
+
+**Screen 分解の参考パターン**: Epic #99 [#387](https://github.com/yama180sx/receipt-ai-app/issues/387)（SplitEditorScreen 588→146行）、Epic #100 [#431](https://github.com/yama180sx/receipt-ai-app/issues/431)（LoginScreen + useLoginFlow）。
+
+### 8.7 後続 Epic（Phase 5、本 Epic スコープ外）
+
+| Epic | GitHub | テーマ |
+|------|--------|--------|
+| #102 | [#468](https://github.com/yama180sx/receipt-ai-app/issues/468) | API 契約型 SSOT（OpenAPI drift CI、FE/BE 型整合） |
+| #103 | [#469](https://github.com/yama180sx/receipt-ai-app/issues/469) | Backend 層境界（Response Mapper、errorHandler 一本化） |
+
+詳細は各 Epic の #102-0 / #103-0（plan 追記 Issue）で正本化する。
+

--- a/docs/specs/chatgpt/ChatGPT_レビュー_20260622.txt
+++ b/docs/specs/chatgpt/ChatGPT_レビュー_20260622.txt
@@ -1,0 +1,347 @@
+現在React Native (Expo), TypeScript, PostgreSQLで構築中のアプリ「RecAIpt」のソースコード一式です。
+
+人間による細部レビューを一切排除した『真の品質ガバナンス』の検証として、以下の4観点から【100点満点からの厳格な減点方式】でシビアに採点してください。
+冗長な褒め言葉や配慮は一切不要です。将来の保守者（非AIネイティブな人間）への引き継ぎに耐えうるかという視点で、具体的な減点理由と改善ポイントをストレートに提示してください。
+
+【評価観点】
+1. コードの共通化とDRY原則（25点）: 微調整の連発によって、似たロジックやインラインコードが重複・コピペされていないか。
+2. コンポーネントの責務分割（25点）: 1つのファイルにロジック、UI、データ処理が詰め込まれすぎ、ファイルが肥大化していないか。
+3. 型定義の堅牢性と一元管理（25点）: Anyの乱用や不適切なアサーションがなく、型が適切に共通化されているか。
+4. 保守性とクリーン度（25点）: 結合度が強すぎて、将来の修正で別画面に予期せぬバグを誘発しやすくないか。
+思考を停止しました
+
+ZIPを実際に展開・走査したうえで評価します。
+（対象：約512ファイル、TypeScript/TSX 約298ファイル）
+
+総合評価
+観点	点数
+1. 共通化・DRY	18 / 25
+2. 責務分割	20 / 25
+3. 型定義	22 / 25
+4. 保守性	19 / 25
+総合	79 / 100
+1. コードの共通化とDRY原則
+18 / 25
+減点 -3
+
+画面レベルでフォーム管理が散在
+
+例：
+
+PromptEditorScreen.tsx
+ReceiptScanScreen.tsx
+ProductMasterScreen.tsx
+
+などで
+
+const [formName, setFormName]
+const [formDesc, setFormDesc]
+const [isLoading, setIsLoading]
+const [error, setError]
+
+のような管理が繰り返されている。
+
+React Hook Formや共通Form Hookへ寄せられる部分が残っている。
+
+減点 -2
+
+APIエラー処理が各所に分散
+
+try {
+ ...
+} catch (err) {
+ setError(...)
+}
+
+が大量に存在。
+
+APIラッパ層に寄せれば画面側コード量を削減可能。
+
+減点 -2
+
+状態管理パターンが統一されていない。
+
+一部
+
+useState
+
+一部
+
+useMemo
+useCallback
+
+一部
+
+Context
+
+で実装されている。
+
+アーキテクチャとしては許容範囲だが、
+将来参加者が「どれを採用するのが正解か」を迷う。
+
+良い点
+
+以下はかなり整理されている。
+
+theme/
+components/ui/
+features/
+hooks/
+utils/
+
+構造が明確。
+
+2020年代のReact Native案件としては平均以上。
+
+2. コンポーネント責務分割
+20 / 25
+減点 -3
+
+まだ肥大化した画面が存在
+
+確認できたもの
+
+PromptEditorScreen.tsx (355行)
+ReceiptScanScreen.tsx (237行)
+ReceiptImageCropModal.tsx (287行)
+SplitEditorItemTable.tsx (292行)
+
+特に
+
+PromptEditorScreen
+
+UI
+
+API通信
+
+フォーム管理
+
+状態管理
+
+編集モード切替
+
+保存処理
+
+削除処理
+
+を1ファイルに持っている。
+
+実質
+
+PromptEditorForm
+PromptEditorList
+PromptEditorActions
+
+へ分離できる。
+
+減点 -2
+
+ReceiptImageCropModal
+
+画像操作ロジックとUIが密結合。
+
+将来
+
+Androidのみ対応修正
+iOSのみ修正
+
+が発生した時に変更範囲が大きい。
+
+良い点
+
+逆に
+
+features/
+hooks/
+utils/
+
+への分離はかなり進んでいる。
+
+特に
+
+useSplitEditor
+useSettlementSummary
+useLoginFlow
+
+は責務分離できている。
+
+ここは高評価。
+
+3. 型定義の堅牢性
+22 / 25
+減点 -1
+
+any使用が残存
+
+確認できたファイル
+
+geminiService.ts
+authMiddleware.ts
+tenantMiddleware.ts
+validate.ts
+receiptWorker.ts
+appError.ts
+
+など。
+
+件数としては少ない。
+
+全体規模から見ると良好。
+
+減点 -1
+
+一部
+
+as any
+
+キャストが存在
+
+約6箇所確認。
+
+本来は型ガードで解決したい。
+
+減点 -1
+
+型定義が
+
+backend/src/types
+frontend/src/types
+
+に分散。
+
+API契約型を完全共有できていない。
+
+良い点
+
+これはかなり優秀。
+
+確認できた限り
+
+unknown
+
+を適切に利用している箇所が多い。
+
+また
+
+PromptTemplate
+ReceiptForSplitEditor
+FamilyMemberSummary
+
+などドメイン型が整理されている。
+
+「TypeScriptを書いているだけ」の案件より明らかに上。
+
+4. 保守性とクリーン度
+19 / 25
+減点 -2
+
+Context依存がやや増え始めている。
+
+例
+
+ReceiptTrayContext
+
+今後増殖すると
+
+変更影響範囲が読みにくくなる。
+
+減点 -2
+
+API層の責務がやや曖昧
+
+receiptApi
+adminApi
+service
+controller
+
+の境界はあるが
+
+変換責務
+
+エラーハンドリング責務
+
+DTO責務
+
+が完全には分離されていない。
+
+減点 -2
+
+生成コード以外でも200〜300行超のファイルが複数ある。
+
+確認対象
+
+PromptEditorScreen.tsx
+SplitEditorItemTable.tsx
+useSplitEditor.ts
+ReceiptImageCropModal.tsx
+ReceiptScanScreen.tsx
+
+この規模になると保守者は全体把握に時間を要する。
+
+良い点
+
+循環参照臭はほぼ見当たらない。
+
+ディレクトリ構造も比較的整理されている。
+
+「どこに何があるかわからない」
+
+状態にはなっていない。
+
+保守者目線で最も危険な箇所
+
+優先順位順。
+
+優先度A
+
+PromptEditorScreen.tsx
+
+355行
+
+最初に分割すべき。
+
+優先度A
+
+ReceiptImageCropModal.tsx
+
+画像処理＋UI混在
+
+将来の不具合温床。
+
+優先度B
+
+SplitEditorItemTable.tsx
+
+292行
+
+テーブル描画責務過多。
+
+優先度B
+
+useSplitEditor.ts
+
+303行
+
+Hookとしては大きすぎる。
+
+最終判定
+
+このコードベースは
+
+「個人開発レベルは卒業しているが、企業案件として長期運用するにはもう一段階の整理が必要」
+
+という状態です。
+
+厳格採点すると
+
+79/100
+
+です。
+
+70点台後半なので品質は決して低くありませんが、
+
+「AIで高速実装した結果、画面単位で責務が肥大化し始めている兆候」
+
+が見えています。
+
+今の段階で画面分割・フォーム共通化・API責務整理を実施すれば、85〜90点台までは十分狙える状態です。


### PR DESCRIPTION
## Summary

- `docs/refactor/plan.md` に **§8 Epic #101**（ChatGPT レビュー 20260622 フォローアップ / Phase 4）を追記
- 子 Issue #101-0〜#101-7 の GitHub 番号・優先度・見積を一覧化
- Epic #100 とのスコープ差分を明記（重複しない範囲の確認）
- Won't fix / Later（Epic #102 / #103 への委譲）と推奨着手順を記録

## Issue

Closes #460

## Test plan

- [x] plan.md §8 が Epic #459 の子 Issue 表と整合している
- [x] #100 との重複スコープがないことが §8.4 に記載されている
- [ ] レビュー後マージ（マージは担当者実施）


Made with [Cursor](https://cursor.com)