### PR TITLE
Issue #101-1: PromptEditorScreen 分解（hook + Form/List）

### DIFF
--- a/frontend/src/features/admin/components/PromptEditorForm.tsx
+++ b/frontend/src/features/admin/components/PromptEditorForm.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { AppButton, AppFormField, AppTextInput } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { cardStyles } from '../../../theme/cardStyles';
+import type { PromptEditorFormState } from '../hooks/usePromptEditor';
+import { promptEditorStyles as styles } from '../styles/promptEditorStyles';
+
+type Props = {
+  isCreatingNew: boolean;
+  form: PromptEditorFormState;
+  isSaving: boolean;
+  onFieldChange: <K extends keyof PromptEditorFormState>(
+    key: K,
+    value: PromptEditorFormState[K]
+  ) => void;
+  onCancel: () => void;
+  onSave: () => void;
+};
+
+export const PromptEditorForm: React.FC<Props> = ({
+  isCreatingNew,
+  form,
+  isSaving,
+  onFieldChange,
+  onCancel,
+  onSave,
+}) => (
+  <View style={[cardStyles.listCard, styles.formContainer]}>
+    <View style={styles.formHeader}>
+      <Text style={styles.formTitle}>
+        {isCreatingNew ? '新規プロンプトの作成' : 'プロンプトの編集'}
+      </Text>
+      <AppButton title={BUTTON_LABELS.cancel} onPress={onCancel} variant="ghost" size="sm" />
+    </View>
+
+    <AppFormField label="識別名 (管理用)">
+      <AppTextInput
+        value={form.name}
+        onChangeText={(value) => onFieldChange('name', value)}
+        placeholder="例: テスト用(外税修正版)"
+      />
+    </AppFormField>
+
+    <AppFormField label="System Prompt">
+      <AppTextInput
+        variant="textarea"
+        style={styles.promptTextArea}
+        value={form.systemPrompt}
+        onChangeText={(value) => onFieldChange('systemPrompt', value)}
+      />
+    </AppFormField>
+
+    <AppFormField label="Domain Hints (JSON形式)">
+      <AppTextInput
+        variant="textarea"
+        style={styles.jsonTextArea}
+        inputStyle={styles.jsonInputFont}
+        value={form.domainHints}
+        onChangeText={(value) => onFieldChange('domainHints', value)}
+        autoCapitalize="none"
+        autoCorrect={false}
+        placeholder={`{\n  "gas_station": "ヒント..."\n}`}
+      />
+    </AppFormField>
+
+    <AppButton
+      title={BUTTON_LABELS.save}
+      onPress={onSave}
+      loading={isSaving}
+      disabled={isSaving}
+      fullWidth
+      size="lg"
+    />
+  </View>
+);

--- a/frontend/src/features/admin/components/PromptEditorList.tsx
+++ b/frontend/src/features/admin/components/PromptEditorList.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import type { PromptTemplate } from '../../../api';
+import { AppButton } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { cardStyles } from '../../../theme/cardStyles';
+import { promptEditorStyles as styles } from '../styles/promptEditorStyles';
+
+type Props = {
+  templates: PromptTemplate[];
+  onCreate: () => void;
+  onEdit: (template: PromptTemplate) => void;
+  onActivate: (id: number) => void;
+  onDelete: (id: number) => void;
+};
+
+export const PromptEditorList: React.FC<Props> = ({
+  templates,
+  onCreate,
+  onEdit,
+  onActivate,
+  onDelete,
+}) => (
+  <View>
+    <AppButton
+      title={`＋ ${BUTTON_LABELS.create}`}
+      onPress={onCreate}
+      variant="success"
+      fullWidth
+      style={{ marginBottom: 16 }}
+    />
+
+    {templates.map((tpl) => (
+      <View
+        key={tpl.id}
+        style={[cardStyles.listCard, styles.card, tpl.isActive && styles.activeCard]}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.titleContainer}>
+            <Text style={styles.cardTitle} numberOfLines={2}>
+              {tpl.name}{' '}
+              <Text style={styles.versionText}>(v{tpl.version})</Text>
+            </Text>
+          </View>
+          {tpl.isActive ? (
+            <View style={styles.badgeContainer}>
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>使用中</Text>
+              </View>
+            </View>
+          ) : null}
+        </View>
+
+        {tpl.description ? <Text style={styles.cardDesc}>{tpl.description}</Text> : null}
+
+        <View style={styles.cardActions}>
+          {!tpl.isActive ? (
+            <AppButton
+              title={BUTTON_LABELS.setDefault}
+              onPress={() => onActivate(tpl.id)}
+              variant="outline"
+              size="sm"
+            />
+          ) : null}
+          <AppButton title={BUTTON_LABELS.edit} onPress={() => onEdit(tpl)} size="sm" />
+          {!tpl.isActive ? (
+            <AppButton
+              title={BUTTON_LABELS.delete}
+              onPress={() => onDelete(tpl.id)}
+              variant="danger"
+              size="sm"
+            />
+          ) : null}
+        </View>
+      </View>
+    ))}
+  </View>
+);

--- a/frontend/src/features/admin/hooks/usePromptEditor.ts
+++ b/frontend/src/features/admin/hooks/usePromptEditor.ts
@@ -1,0 +1,185 @@
+import { useState, useEffect, useCallback } from 'react';
+import { adminApi, type PromptTemplate } from '../../../api';
+import { getApiErrorMessage } from '../../../utils/apiError';
+import { showAlert } from '../../../utils/alertMessage';
+import { showConfirmDialog } from '../../../utils/confirmDialog';
+
+const PROMPT_KEY = 'RECEIPT_ANALYSIS';
+
+export type PromptEditorFormState = {
+  name: string;
+  description: string;
+  systemPrompt: string;
+  domainHints: string;
+};
+
+const emptyForm = (): PromptEditorFormState => ({
+  name: '',
+  description: '',
+  systemPrompt: '',
+  domainHints: '',
+});
+
+export function usePromptEditor() {
+  const [templates, setTemplates] = useState<PromptTemplate[]>([]);
+  const [editingTemplate, setEditingTemplate] = useState<PromptTemplate | null>(null);
+  const [isCreatingNew, setIsCreatingNew] = useState(false);
+  const [form, setForm] = useState<PromptEditorFormState>(emptyForm);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isFormVisible = editingTemplate !== null || isCreatingNew;
+
+  const fetchPrompts = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await adminApi.listPrompts();
+      setTemplates((response.data ?? []).filter((p) => p.key === PROMPT_KEY));
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPrompts();
+  }, [fetchPrompts]);
+
+  const handleActivate = useCallback(
+    async (id: number) => {
+      try {
+        await adminApi.activatePrompt(id);
+        await fetchPrompts();
+      } catch (err: unknown) {
+        showAlert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
+      }
+    },
+    [fetchPrompts]
+  );
+
+  const handleDelete = useCallback(
+    (id: number) => {
+      const executeDelete = async () => {
+        try {
+          await adminApi.deletePrompt(id);
+          await fetchPrompts();
+        } catch (err: unknown) {
+          showAlert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
+        }
+      };
+
+      showConfirmDialog('削除確認', '本当にこのプロンプトを削除しますか？', [
+        { text: 'キャンセル', style: 'cancel' },
+        { text: '削除', style: 'destructive', onPress: executeDelete },
+      ]);
+    },
+    [fetchPrompts]
+  );
+
+  const openEditForm = useCallback((template: PromptTemplate) => {
+    setEditingTemplate(template);
+    setIsCreatingNew(false);
+    setForm({
+      name: template.name || '',
+      description: template.description || '',
+      systemPrompt: template.systemPrompt,
+      domainHints: template.domainHints
+        ? JSON.stringify(template.domainHints, null, 2)
+        : '',
+    });
+  }, []);
+
+  const openCreateForm = useCallback(() => {
+    setEditingTemplate(null);
+    setIsCreatingNew(true);
+    setForm({
+      ...emptyForm(),
+      name: '新規プロンプト',
+    });
+  }, []);
+
+  const cancelForm = useCallback(() => {
+    setEditingTemplate(null);
+    setIsCreatingNew(false);
+    setError(null);
+  }, []);
+
+  const updateFormField = useCallback(
+    <K extends keyof PromptEditorFormState>(key: K, value: PromptEditorFormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!form.systemPrompt.trim() || !form.name.trim()) {
+      showAlert('入力エラー', '名前とシステムプロンプトは必須です。');
+      return;
+    }
+
+    let parsedHints: unknown = null;
+    if (form.domainHints.trim()) {
+      try {
+        parsedHints = JSON.parse(form.domainHints);
+      } catch {
+        showAlert('JSONエラー', 'Domain Hints の JSON 形式が不正です。');
+        return;
+      }
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      if (isCreatingNew) {
+        await adminApi.createPrompt({
+          key: PROMPT_KEY,
+          name: form.name,
+          description: form.description,
+          systemPrompt: form.systemPrompt,
+          domainHints: parsedHints,
+          isActive: false,
+        });
+        showAlert('作成完了', '新しいプロンプトを作成しました。');
+      } else if (editingTemplate?.id) {
+        await adminApi.updatePrompt(editingTemplate.id, {
+          name: form.name,
+          description: form.description,
+          systemPrompt: form.systemPrompt,
+          domainHints: parsedHints,
+        });
+        showAlert('更新完了', 'プロンプトを更新しました。');
+      } else {
+        throw new Error('更新対象のプロンプトIDが見つかりません。');
+      }
+
+      setEditingTemplate(null);
+      setIsCreatingNew(false);
+      await fetchPrompts();
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, '保存に失敗しました。'));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editingTemplate, fetchPrompts, form, isCreatingNew]);
+
+  return {
+    templates,
+    form,
+    isLoading,
+    isSaving,
+    error,
+    isFormVisible,
+    isCreatingNew,
+    updateFormField,
+    openEditForm,
+    openCreateForm,
+    cancelForm,
+    handleSave,
+    handleActivate,
+    handleDelete,
+  };
+}

--- a/frontend/src/features/admin/index.ts
+++ b/frontend/src/features/admin/index.ts
@@ -1,0 +1,3 @@
+export { usePromptEditor } from './hooks/usePromptEditor';
+export { PromptEditorForm } from './components/PromptEditorForm';
+export { PromptEditorList } from './components/PromptEditorList';

--- a/frontend/src/features/admin/styles/promptEditorStyles.ts
+++ b/frontend/src/features/admin/styles/promptEditorStyles.ts
@@ -1,0 +1,61 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '../../../theme/colors';
+import { spacing } from '../../../theme/spacing';
+import { borderRadius } from '../../../theme/radii';
+
+const adm = colors.semantic.admin;
+
+export const promptEditorStyles = StyleSheet.create({
+  containerAdmin: { backgroundColor: adm.background },
+  headerAdmin: { backgroundColor: adm.surface, borderBottomColor: adm.border },
+  contentContainer: { paddingBottom: 40 },
+  center: { justifyContent: 'center', alignItems: 'center' },
+  loadingText: { marginTop: spacing.md - 4, color: adm.textMuted },
+  errorContainer: {
+    backgroundColor: adm.errorBg,
+    padding: spacing.md - 4,
+    borderRadius: borderRadius.sm,
+    marginBottom: spacing.md,
+  },
+  errorText: { color: adm.errorText },
+  card: {
+    backgroundColor: adm.surface,
+    marginBottom: spacing.md - 4,
+    borderWidth: 2,
+    borderColor: adm.border,
+  },
+  activeCard: { borderColor: colors.primary },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: spacing.sm,
+  },
+  titleContainer: { flex: 1, paddingRight: spacing.sm },
+  cardTitle: { fontSize: 16, fontWeight: 'bold', color: adm.textDark, lineHeight: 22 },
+  versionText: { fontSize: 12, color: adm.textMuted, fontWeight: 'normal' },
+  badgeContainer: { justifyContent: 'flex-start', paddingTop: 2 },
+  badge: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.md,
+  },
+  badgeText: { color: colors.text.inverse, fontSize: 10, fontWeight: 'bold' },
+  cardDesc: { fontSize: 13, color: adm.textMuted, marginBottom: spacing.md - 4 },
+  cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm, flexWrap: 'wrap' },
+  formContainer: {
+    backgroundColor: adm.surface,
+    borderColor: adm.border,
+  },
+  formHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  formTitle: { fontSize: 18, fontWeight: 'bold', flex: 1 },
+  promptTextArea: { minHeight: 200 },
+  jsonTextArea: { minHeight: 150 },
+  jsonInputFont: { fontFamily: 'Courier' },
+});

--- a/frontend/src/screens/PromptEditorScreen.tsx
+++ b/frontend/src/screens/PromptEditorScreen.tsx
@@ -1,172 +1,24 @@
-import React, { useState, useEffect } from 'react';
-import {
-  StyleSheet,
-  View,
-  Text,
-  ScrollView,
-  ActivityIndicator,
-} from 'react-native';
+import React from 'react';
+import { View, Text, ScrollView, ActivityIndicator } from 'react-native';
 
-import { adminApi, type PromptTemplate } from '../api';
-import { getApiErrorMessage } from '../utils/apiError';
-import { showAlert } from '../utils/alertMessage';
-import { showConfirmDialog } from '../utils/confirmDialog';
-import { AppBackButton, AppButton, AppFormField, AppTextInput } from '../components/ui';
-import { BUTTON_LABELS } from '../constants/buttonLabels';
+import { AppBackButton } from '../components/ui';
 import { colors } from '../theme/colors';
-import { spacing } from '../theme/spacing';
-import { borderRadius } from '../theme/radii';
-import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
-
-const adm = colors.semantic.admin;
+import {
+  usePromptEditor,
+  PromptEditorForm,
+  PromptEditorList,
+} from '../features/admin';
+import { promptEditorStyles as styles } from '../features/admin/styles/promptEditorStyles';
 
 interface PromptEditorScreenProps {
   onBack: () => void;
 }
 
 export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }) => {
-  const [templates, setTemplates] = useState<PromptTemplate[]>([]);
-  const [editingTemplate, setEditingTemplate] = useState<PromptTemplate | null>(null);
-  const [isCreatingNew, setIsCreatingNew] = useState(false);
-  
-  // フォーム用ステート
-  const [formName, setFormName] = useState('');
-  const [formDesc, setFormDesc] = useState('');
-  const [formSystemPrompt, setFormSystemPrompt] = useState('');
-  const [formDomainHints, setFormDomainHints] = useState('');
+  const editor = usePromptEditor();
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const PROMPT_KEY = 'RECEIPT_ANALYSIS';
-
-  // --- API連携関数 ---
-
-  const fetchPrompts = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await adminApi.listPrompts();
-      setTemplates((response.data ?? []).filter((p) => p.key === PROMPT_KEY));
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err));
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchPrompts();
-  }, []);
-
-  const handleActivate = async (id: number) => {
-    try {
-      await adminApi.activatePrompt(id);
-      fetchPrompts();
-    } catch (err: unknown) {
-      showAlert('エラー', getApiErrorMessage(err, 'デフォルトの切り替えに失敗しました。'));
-    }
-  };
-
-  const handleDelete = async (id: number) => {
-    const executeDelete = async () => {
-      try {
-        await adminApi.deletePrompt(id);
-        fetchPrompts();
-      } catch (err: unknown) {
-        showAlert('エラー', getApiErrorMessage(err, '削除に失敗しました。'));
-      }
-    };
-
-    showConfirmDialog('削除確認', '本当にこのプロンプトを削除しますか？', [
-      { text: 'キャンセル', style: 'cancel' },
-      { text: '削除', style: 'destructive', onPress: executeDelete },
-    ]);
-  };
-
-  const handleSave = async () => {
-    if (!formSystemPrompt.trim() || !formName.trim()) {
-      showAlert('入力エラー', '名前とシステムプロンプトは必須です。');
-      return;
-    }
-
-    let parsedHints = null;
-    if (formDomainHints.trim()) {
-      try {
-        parsedHints = JSON.parse(formDomainHints);
-      } catch (e) {
-        showAlert('JSONエラー', 'Domain Hints の JSON 形式が不正です。');
-        return;
-      }
-    }
-
-    setIsSaving(true);
-    setError(null);
-
-    try {
-      if (isCreatingNew) {
-        await adminApi.createPrompt({
-          key: PROMPT_KEY,
-          name: formName,
-          description: formDesc,
-          systemPrompt: formSystemPrompt,
-          domainHints: parsedHints,
-          isActive: false
-        });
-        showAlert('作成完了', '新しいプロンプトを作成しました。');
-      } else if (editingTemplate && editingTemplate.id) {
-        await adminApi.updatePrompt(editingTemplate.id, {
-          name: formName,
-          description: formDesc,
-          systemPrompt: formSystemPrompt,
-          domainHints: parsedHints,
-        });
-        showAlert('更新完了', 'プロンプトを更新しました。');
-      } else {
-        throw new Error('更新対象のプロンプトIDが見つかりません。');
-      }
-      
-      setEditingTemplate(null);
-      setIsCreatingNew(false);
-      fetchPrompts();
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, '保存に失敗しました。'));
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  // --- UI制御関数 ---
-
-  const openEditForm = (template: PromptTemplate) => {
-    setEditingTemplate(template);
-    setIsCreatingNew(false);
-    setFormName(template.name || '');
-    setFormDesc(template.description || '');
-    setFormSystemPrompt(template.systemPrompt);
-    setFormDomainHints(template.domainHints ? JSON.stringify(template.domainHints, null, 2) : '');
-  };
-
-  const openCreateForm = () => {
-    setEditingTemplate(null);
-    setIsCreatingNew(true);
-    setFormName('新規プロンプト');
-    setFormDesc('');
-    setFormSystemPrompt('');
-    setFormDomainHints('');
-  };
-
-  const cancelForm = () => {
-    setEditingTemplate(null);
-    setIsCreatingNew(false);
-    setError(null);
-  };
-
-  // --- レンダリング ---
-
-  if (isLoading && templates.length === 0) {
+  if (editor.isLoading && editor.templates.length === 0) {
     return (
       <View style={[screenLayout.container, styles.center]}>
         <ActivityIndicator size="large" color={colors.primary} />
@@ -184,172 +36,31 @@ export const PromptEditorScreen: React.FC<PromptEditorScreenProps> = ({ onBack }
       </View>
 
       <ScrollView contentContainerStyle={[screenLayout.scrollContent, styles.contentContainer]}>
-        {error && (
+        {editor.error ? (
           <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>{error}</Text>
+            <Text style={styles.errorText}>{editor.error}</Text>
           </View>
-        )}
+        ) : null}
 
-        {/* フォーム画面（編集 または 新規作成） */}
-        {(editingTemplate || isCreatingNew) ? (
-          <View style={[cardStyles.listCard, styles.formContainer]}>
-            <View style={styles.formHeader}>
-              <Text style={styles.formTitle}>
-                {isCreatingNew ? '新規プロンプトの作成' : 'プロンプトの編集'}
-              </Text>
-              <AppButton
-                title={BUTTON_LABELS.cancel}
-                onPress={cancelForm}
-                variant="ghost"
-                size="sm"
-              />
-            </View>
-
-            <AppFormField label="識別名 (管理用)">
-              <AppTextInput
-                value={formName}
-                onChangeText={setFormName}
-                placeholder="例: テスト用(外税修正版)"
-              />
-            </AppFormField>
-
-            <AppFormField label="System Prompt">
-              <AppTextInput
-                variant="textarea"
-                style={styles.promptTextArea}
-                value={formSystemPrompt}
-                onChangeText={setFormSystemPrompt}
-              />
-            </AppFormField>
-
-            <AppFormField label="Domain Hints (JSON形式)">
-              <AppTextInput
-                variant="textarea"
-                style={styles.jsonTextArea}
-                inputStyle={styles.jsonInputFont}
-                value={formDomainHints}
-                onChangeText={setFormDomainHints}
-                autoCapitalize="none"
-                autoCorrect={false}
-                placeholder={`{\n  "gas_station": "ヒント..."\n}`}
-              />
-            </AppFormField>
-
-            <AppButton
-              title={BUTTON_LABELS.save}
-              onPress={handleSave}
-              loading={isSaving}
-              disabled={isSaving}
-              fullWidth
-              size="lg"
-            />
-          </View>
+        {editor.isFormVisible ? (
+          <PromptEditorForm
+            isCreatingNew={editor.isCreatingNew}
+            form={editor.form}
+            isSaving={editor.isSaving}
+            onFieldChange={editor.updateFormField}
+            onCancel={editor.cancelForm}
+            onSave={() => void editor.handleSave()}
+          />
         ) : (
-          /* 一覧表示画面 */
-          <View>
-            <AppButton
-              title={`＋ ${BUTTON_LABELS.create}`}
-              onPress={openCreateForm}
-              variant="success"
-              fullWidth
-              style={{ marginBottom: 16 }}
-            />
-
-            {templates.map((tpl) => (
-              <View key={tpl.id} style={[cardStyles.listCard, styles.card, tpl.isActive && styles.activeCard]}>
-                <View style={styles.cardHeader}>
-                  {/* ★修正: タイトル部分に flex: 1 を当てて右側の要素を押し出さないようにする */}
-                  <View style={styles.titleContainer}>
-                    <Text style={styles.cardTitle} numberOfLines={2}>
-                      {tpl.name} <Text style={styles.versionText}>(v{tpl.version})</Text>
-                    </Text>
-                  </View>
-                  {tpl.isActive && (
-                    <View style={styles.badgeContainer}>
-                      <View style={styles.badge}>
-                        <Text style={styles.badgeText}>使用中</Text>
-                      </View>
-                    </View>
-                  )}
-                </View>
-                {tpl.description && <Text style={styles.cardDesc}>{tpl.description}</Text>}
-                
-                <View style={styles.cardActions}>
-                  {!tpl.isActive && (
-                    <AppButton
-                      title={BUTTON_LABELS.setDefault}
-                      onPress={() => handleActivate(tpl.id)}
-                      variant="outline"
-                      size="sm"
-                    />
-                  )}
-                  <AppButton
-                    title={BUTTON_LABELS.edit}
-                    onPress={() => openEditForm(tpl)}
-                    size="sm"
-                  />
-                  {!tpl.isActive && (
-                    <AppButton
-                      title={BUTTON_LABELS.delete}
-                      onPress={() => handleDelete(tpl.id)}
-                      variant="danger"
-                      size="sm"
-                    />
-                  )}
-                </View>
-              </View>
-            ))}
-          </View>
+          <PromptEditorList
+            templates={editor.templates}
+            onCreate={editor.openCreateForm}
+            onEdit={editor.openEditForm}
+            onActivate={(id) => void editor.handleActivate(id)}
+            onDelete={editor.handleDelete}
+          />
         )}
       </ScrollView>
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  containerAdmin: { backgroundColor: adm.background },
-  headerAdmin: { backgroundColor: adm.surface, borderBottomColor: adm.border },
-  contentContainer: { paddingBottom: 40 },
-  center: { justifyContent: 'center', alignItems: 'center' },
-  loadingText: { marginTop: spacing.md - 4, color: adm.textMuted },
-  errorContainer: {
-    backgroundColor: adm.errorBg,
-    padding: spacing.md - 4,
-    borderRadius: borderRadius.sm,
-    marginBottom: spacing.md,
-  },
-  errorText: { color: adm.errorText },
-
-  card: {
-    backgroundColor: adm.surface,
-    marginBottom: spacing.md - 4,
-    borderWidth: 2,
-    borderColor: adm.border,
-  },
-  activeCard: { borderColor: colors.primary },
-  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: spacing.sm },
-  titleContainer: { flex: 1, paddingRight: spacing.sm },
-  cardTitle: { fontSize: 16, fontWeight: 'bold', color: adm.textDark, lineHeight: 22 },
-  versionText: { fontSize: 12, color: adm.textMuted, fontWeight: 'normal' },
-  badgeContainer: { justifyContent: 'flex-start', paddingTop: 2 },
-  badge: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: borderRadius.md,
-  },
-  badgeText: { color: colors.text.inverse, fontSize: 10, fontWeight: 'bold' },
-
-  cardDesc: { fontSize: 13, color: adm.textMuted, marginBottom: spacing.md - 4 },
-  cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing.sm, flexWrap: 'wrap' },
-
-  formContainer: {
-    backgroundColor: adm.surface,
-    borderColor: adm.border,
-  },
-  formHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: spacing.md },
-  formTitle: { fontSize: 18, fontWeight: 'bold', flex: 1 },
-  promptTextArea: { minHeight: 200 },
-  jsonTextArea: { minHeight: 150 },
-  jsonInputFont: { fontFamily: 'Courier' },
-});


### PR DESCRIPTION
## Summary

- `features/admin/` を新設
  - `hooks/usePromptEditor.ts` — 一覧取得・作成・更新・削除・フォーム state
  - `components/PromptEditorForm.tsx` — 編集フォーム UI
  - `components/PromptEditorList.tsx` — 一覧 UI
  - `styles/promptEditorStyles.ts` — 管理画面スタイル
- `PromptEditorScreen.tsx` を hook + 子コンポーネントの薄型ラッパーに変更（**355→66 行**）

[frontend-conventions.md](docs/design/frontend-conventions.md) 準拠（Screen < 150、hook < 250）。

## Issue

Closes #465

## Test plan

- [x] `npm test`（frontend）パス
- [x] PromptEditorScreen.tsx が 150 行以下
- [ ] プロンプト一覧・作成・編集・デフォルト切替・削除が従来通り（管理者で目視）
- [ ] レビュー後マージ（マージは担当者実施）


Made with [Cursor](https://cursor.com)