### PR TITLE
Issue #101-2: ReceiptImageCropModal 画像操作 hook 分離

### DIFF
--- a/frontend/src/components/ReceiptImageCropModal.tsx
+++ b/frontend/src/components/ReceiptImageCropModal.tsx
@@ -1,29 +1,15 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 import {
   View,
   Text,
   StyleSheet,
   Image,
   Modal,
-  PanResponder,
   Platform,
-  type LayoutChangeEvent,
-  type GestureResponderEvent,
-  type PanResponderGestureState,
 } from 'react-native';
-import * as ImageManipulator from 'expo-image-manipulator';
 import { AppButton } from './ui';
 import { theme } from '../theme';
-import { registerWebImageFile, uriToWebImageFile } from '../utils/webImageFileRegistry';
-import {
-  computeContainedLayout,
-  cropImageUriWeb,
-  loadImageDimensions,
-  mapSelectionToCrop,
-} from '../utils/cropImageWeb';
-
-type Point = { x: number; y: number };
-type Rect = { x: number; y: number; width: number; height: number };
+import { useImageCropSelection } from '../hooks/useImageCropSelection';
 
 type Props = {
   visible: boolean;
@@ -32,16 +18,8 @@ type Props = {
   onCancel: () => void;
 };
 
-function normalizeRect(start: Point, end: Point): Rect {
-  const x = Math.min(start.x, end.x);
-  const y = Math.min(start.y, end.y);
-  const width = Math.abs(end.x - start.x);
-  const height = Math.abs(end.y - start.y);
-  return { x, y, width, height };
-}
-
 /**
- * Web 向けレシート切り取りモーダル（Issue #94-4）
+ * レシート切り取りモーダル（Issue #94-4 / #101-2）
  */
 export function ReceiptImageCropModal({
   visible,
@@ -49,137 +27,7 @@ export function ReceiptImageCropModal({
   onConfirm,
   onCancel,
 }: Props) {
-  const [displaySize, setDisplaySize] = useState({ width: 0, height: 0 });
-  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
-  const [selection, setSelection] = useState<Rect | null>(null);
-  const [processing, setProcessing] = useState(false);
-  const dragStart = useRef<Point | null>(null);
-
-  useEffect(() => {
-    setSelection(null);
-    dragStart.current = null;
-    setDisplaySize({ width: 0, height: 0 });
-    setNaturalSize({ width: 0, height: 0 });
-  }, [imageUri, visible]);
-
-  const resetState = useCallback(() => {
-    setSelection(null);
-    dragStart.current = null;
-    setProcessing(false);
-  }, []);
-
-  const handleLayout = (e: LayoutChangeEvent) => {
-    const { width, height } = e.nativeEvent.layout;
-    setDisplaySize({ width, height });
-  };
-
-  const handleImageLoad = (e: { nativeEvent: { source: { width: number; height: number } } }) => {
-    const { width, height } = e.nativeEvent.source;
-    setNaturalSize({ width, height });
-  };
-
-  const updateSelection = (start: Point, current: Point) => {
-    setSelection(normalizeRect(start, current));
-  };
-
-  const panResponder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onPanResponderGrant: (evt: GestureResponderEvent) => {
-        const { locationX, locationY } = evt.nativeEvent;
-        dragStart.current = { x: locationX, y: locationY };
-        setSelection({ x: locationX, y: locationY, width: 0, height: 0 });
-      },
-      onPanResponderMove: (evt: GestureResponderEvent, _gs: PanResponderGestureState) => {
-        if (!dragStart.current) return;
-        const { locationX, locationY } = evt.nativeEvent;
-        updateSelection(dragStart.current, { x: locationX, y: locationY });
-      },
-      onPanResponderRelease: (evt: GestureResponderEvent) => {
-        if (!dragStart.current) return;
-        const { locationX, locationY } = evt.nativeEvent;
-        updateSelection(dragStart.current, { x: locationX, y: locationY });
-        dragStart.current = null;
-      },
-    })
-  ).current;
-
-  const getNaturalSize = async (): Promise<{ width: number; height: number }> => {
-    if (naturalSize.width > 0 && naturalSize.height > 0) {
-      return naturalSize;
-    }
-    if (Platform.OS === 'web') {
-      return loadImageDimensions(imageUri);
-    }
-    return new Promise((resolve, reject) => {
-      Image.getSize(
-        imageUri,
-        (width, height) => resolve({ width, height }),
-        reject
-      );
-    });
-  };
-
-  const cropSelectedRegion = async (): Promise<string | null> => {
-    if (!selection || selection.width < 8 || selection.height < 8) return null;
-    if (!displaySize.width || !displaySize.height) return null;
-
-    const natural = await getNaturalSize();
-    const layout = computeContainedLayout(
-      displaySize.width,
-      displaySize.height,
-      natural.width,
-      natural.height
-    );
-    const crop = mapSelectionToCrop(selection, layout, natural.width, natural.height);
-    if (!crop) return null;
-
-    if (Platform.OS === 'web') {
-      return cropImageUriWeb(imageUri, crop);
-    }
-
-    const result = await ImageManipulator.manipulateAsync(
-      imageUri,
-      [{ crop }],
-      { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
-    );
-    return result.uri;
-  };
-
-  const finishConfirm = async (uri: string) => {
-    if (Platform.OS === 'web') {
-      try {
-        const file = await uriToWebImageFile(uri, 'receipt_cropped.jpg');
-        registerWebImageFile(uri, file);
-      } catch (e) {
-        console.error('[Crop] web file register failed', e);
-      }
-    }
-    onConfirm(uri);
-  };
-
-  const handleConfirm = async () => {
-    setProcessing(true);
-    try {
-      const croppedUri = await cropSelectedRegion();
-      await finishConfirm(croppedUri ?? imageUri);
-    } catch (e) {
-      console.error('[Crop] failed', e);
-      await finishConfirm(imageUri);
-    } finally {
-      setProcessing(false);
-    }
-  };
-
-  const handleSkipCrop = () => {
-    resetState();
-    void finishConfirm(imageUri);
-  };
-
-  const handleCancel = () => {
-    resetState();
-    onCancel();
-  };
+  const crop = useImageCropSelection({ visible, imageUri, onConfirm, onCancel });
 
   if (!visible) return null;
 
@@ -188,22 +36,22 @@ export function ReceiptImageCropModal({
       <Text style={styles.title}>レシートの範囲を選択</Text>
       <Text style={styles.hint}>ドラッグして切り取る範囲を指定してください</Text>
 
-      <View style={styles.imageArea} onLayout={handleLayout} {...panResponder.panHandlers}>
+      <View style={styles.imageArea} onLayout={crop.handleLayout} {...crop.panHandlers}>
         <Image
           source={{ uri: imageUri }}
           style={styles.image}
           resizeMode="contain"
-          onLoad={handleImageLoad}
+          onLoad={crop.handleImageLoad}
         />
-        {selection && selection.width > 0 && selection.height > 0 ? (
+        {crop.selection && crop.selection.width > 0 && crop.selection.height > 0 ? (
           <View
             style={[
               styles.selection,
               {
-                left: selection.x,
-                top: selection.y,
-                width: selection.width,
-                height: selection.height,
+                left: crop.selection.x,
+                top: crop.selection.y,
+                width: crop.selection.width,
+                height: crop.selection.height,
               },
             ]}
             pointerEvents="none"
@@ -212,12 +60,12 @@ export function ReceiptImageCropModal({
       </View>
 
       <View style={styles.actions}>
-        <AppButton title="キャンセル" variant="outline" onPress={handleCancel} />
-        <AppButton title="切り取らずに使う" variant="secondary" onPress={handleSkipCrop} />
+        <AppButton title="キャンセル" variant="outline" onPress={crop.handleCancel} />
+        <AppButton title="切り取らずに使う" variant="secondary" onPress={crop.handleSkipCrop} />
         <AppButton
-          title={processing ? '処理中...' : '切り取って解析'}
-          onPress={() => void handleConfirm()}
-          disabled={processing}
+          title={crop.processing ? '処理中...' : '切り取って解析'}
+          onPress={() => void crop.handleConfirm()}
+          disabled={crop.processing}
         />
       </View>
     </View>
@@ -228,7 +76,7 @@ export function ReceiptImageCropModal({
   }
 
   return (
-    <Modal visible={visible} animationType="slide" onRequestClose={handleCancel}>
+    <Modal visible={visible} animationType="slide" onRequestClose={crop.handleCancel}>
       {content}
     </Modal>
   );

--- a/frontend/src/hooks/useImageCropSelection.ts
+++ b/frontend/src/hooks/useImageCropSelection.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Image,
+  PanResponder,
+  Platform,
+  type LayoutChangeEvent,
+  type GestureResponderEvent,
+  type PanResponderGestureState,
+} from 'react-native';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { registerWebImageFile, uriToWebImageFile } from '../utils/webImageFileRegistry';
+import {
+  computeContainedLayout,
+  cropImageUriWeb,
+  loadImageDimensions,
+  mapSelectionToCrop,
+} from '../utils/cropImageWeb';
+
+type Point = { x: number; y: number };
+export type CropRect = { x: number; y: number; width: number; height: number };
+
+function normalizeRect(start: Point, end: Point): CropRect {
+  const x = Math.min(start.x, end.x);
+  const y = Math.min(start.y, end.y);
+  const width = Math.abs(end.x - start.x);
+  const height = Math.abs(end.y - start.y);
+  return { x, y, width, height };
+}
+
+type UseImageCropSelectionOptions = {
+  visible: boolean;
+  imageUri: string;
+  onConfirm: (uri: string) => void;
+  onCancel: () => void;
+};
+
+export function useImageCropSelection({
+  visible,
+  imageUri,
+  onConfirm,
+  onCancel,
+}: UseImageCropSelectionOptions) {
+  const [displaySize, setDisplaySize] = useState({ width: 0, height: 0 });
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const [selection, setSelection] = useState<CropRect | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const dragStart = useRef<Point | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    dragStart.current = null;
+    setDisplaySize({ width: 0, height: 0 });
+    setNaturalSize({ width: 0, height: 0 });
+  }, [imageUri, visible]);
+
+  const resetState = useCallback(() => {
+    setSelection(null);
+    dragStart.current = null;
+    setProcessing(false);
+  }, []);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setDisplaySize({ width, height });
+  }, []);
+
+  const handleImageLoad = useCallback(
+    (e: { nativeEvent: { source: { width: number; height: number } } }) => {
+      const { width, height } = e.nativeEvent.source;
+      setNaturalSize({ width, height });
+    },
+    []
+  );
+
+  const updateSelection = useCallback((start: Point, current: Point) => {
+    setSelection(normalizeRect(start, current));
+  }, []);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt: GestureResponderEvent) => {
+        const { locationX, locationY } = evt.nativeEvent;
+        dragStart.current = { x: locationX, y: locationY };
+        setSelection({ x: locationX, y: locationY, width: 0, height: 0 });
+      },
+      onPanResponderMove: (evt: GestureResponderEvent, _gs: PanResponderGestureState) => {
+        if (!dragStart.current) return;
+        const { locationX, locationY } = evt.nativeEvent;
+        updateSelection(dragStart.current, { x: locationX, y: locationY });
+      },
+      onPanResponderRelease: (evt: GestureResponderEvent) => {
+        if (!dragStart.current) return;
+        const { locationX, locationY } = evt.nativeEvent;
+        updateSelection(dragStart.current, { x: locationX, y: locationY });
+        dragStart.current = null;
+      },
+    })
+  ).current;
+
+  const getNaturalSize = useCallback(async (): Promise<{ width: number; height: number }> => {
+    if (naturalSize.width > 0 && naturalSize.height > 0) {
+      return naturalSize;
+    }
+    if (Platform.OS === 'web') {
+      return loadImageDimensions(imageUri);
+    }
+    return new Promise((resolve, reject) => {
+      Image.getSize(
+        imageUri,
+        (width, height) => resolve({ width, height }),
+        reject
+      );
+    });
+  }, [imageUri, naturalSize.height, naturalSize.width]);
+
+  const cropSelectedRegion = useCallback(async (): Promise<string | null> => {
+    if (!selection || selection.width < 8 || selection.height < 8) return null;
+    if (!displaySize.width || !displaySize.height) return null;
+
+    const natural = await getNaturalSize();
+    const layout = computeContainedLayout(
+      displaySize.width,
+      displaySize.height,
+      natural.width,
+      natural.height
+    );
+    const crop = mapSelectionToCrop(selection, layout, natural.width, natural.height);
+    if (!crop) return null;
+
+    if (Platform.OS === 'web') {
+      return cropImageUriWeb(imageUri, crop);
+    }
+
+    const result = await ImageManipulator.manipulateAsync(
+      imageUri,
+      [{ crop }],
+      { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
+    );
+    return result.uri;
+  }, [displaySize.height, displaySize.width, getNaturalSize, imageUri, selection]);
+
+  const finishConfirm = useCallback(
+    async (uri: string) => {
+      if (Platform.OS === 'web') {
+        try {
+          const file = await uriToWebImageFile(uri, 'receipt_cropped.jpg');
+          registerWebImageFile(uri, file);
+        } catch (e) {
+          console.error('[Crop] web file register failed', e);
+        }
+      }
+      onConfirm(uri);
+    },
+    [onConfirm]
+  );
+
+  const handleConfirm = useCallback(async () => {
+    setProcessing(true);
+    try {
+      const croppedUri = await cropSelectedRegion();
+      await finishConfirm(croppedUri ?? imageUri);
+    } catch (e) {
+      console.error('[Crop] failed', e);
+      await finishConfirm(imageUri);
+    } finally {
+      setProcessing(false);
+    }
+  }, [cropSelectedRegion, finishConfirm, imageUri]);
+
+  const handleSkipCrop = useCallback(() => {
+    resetState();
+    void finishConfirm(imageUri);
+  }, [finishConfirm, imageUri, resetState]);
+
+  const handleCancel = useCallback(() => {
+    resetState();
+    onCancel();
+  }, [onCancel, resetState]);
+
+  return {
+    selection,
+    processing,
+    panHandlers: panResponder.panHandlers,
+    handleLayout,
+    handleImageLoad,
+    handleConfirm,
+    handleSkipCrop,
+    handleCancel,
+  };
+}


### PR DESCRIPTION
## Summary

- `hooks/useImageCropSelection.ts` を新設
  - 選択範囲 state / PanResponder
  - Web / Native の crop 処理
  - 確認・スキップ・キャンセルハンドラ
- `ReceiptImageCropModal.tsx` を UI のみに整理（**287→134 行**）

Platform 固有の画像操作は hook + 既存 `utils/cropImageWeb.ts` に閉じる。

## Issue

Closes #466

## Test plan

- [x] `npm test`（frontend）パス
- [ ] Web で切り取り・スキップ・キャンセルが従来通り
- [ ] Native で同様（可能なら）
- [ ] レビュー後マージ（マージは担当者実施）


Made with [Cursor](https://cursor.com)