### PR TITLE
Issue #101-3: Backend any / as any 撲滅

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -33,8 +33,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     });
   }
 
-  // Requestオブジェクトを拡張して情報を保持 (anyキャストで型定義不足を回避)
-  (req as any).user = decoded;
+  req.user = decoded;
   
   next();
 };
@@ -46,7 +45,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
  */
 export const isAdmin = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const userId = (req as any).user?.id; 
+    const userId = req.user?.id; 
     
     if (!userId) {
       return res.status(401).json({ success: false, message: 'ユーザー情報が取得できません' });

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -52,9 +52,13 @@ export const errorHandler = (
       ? 'サーバー内部でエラーが発生しました。時間をおいて再度お試しください。'
       : message;
 
-  return res.status(statusCode).json({
+  const responseBody: { success: false; message: string; details?: unknown } = {
     success: false,
     message: safeMessage,
-    ...(details && { details }),
-  });
+  };
+  if (details !== undefined) {
+    responseBody.details = details;
+  }
+
+  return res.status(statusCode).json(responseBody);
 };

--- a/backend/src/middleware/tenantMiddleware.ts
+++ b/backend/src/middleware/tenantMiddleware.ts
@@ -12,7 +12,7 @@ import logger from '../utils/logger';
 export const tenantMiddleware = async (req: Request, res: Response, next: NextFunction) => {
   try {
     // authMiddleware (JWT) からの情報を取得
-    const user = (req as any).user;
+    const user = req.user;
     
     // JWTがない場合のフォールバック（移行期間用）
     const rawMemberId = user?.id || req.headers['x-member-id'];

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,33 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
-import { ZodError } from 'zod';
+import { ZodError, type ZodType } from 'zod';
 import { AppError } from '../utils/appError';
 
 /**
  * Zodバリデーションミドルウェア
  * エラー時は AppError を生成して共通エラーハンドラーへ渡す
  */
-export const validate = (schema: any) => 
+export const validate = (schema: ZodType) =>
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      // スキーマでパースして結果をreq.bodyに反映
       req.body = await schema.parseAsync(req.body);
       next();
-    } catch (error: any) {
-      // ZodErrorの判定と、issues/errorsプロパティの安全な取得
-      const issues = error.issues || error.errors;
-
-      if ((error instanceof ZodError || error.name === 'ZodError') && Array.isArray(issues)) {
-        // 詳細なエラー内容を整形
-        const details = issues.map((e: any) => ({
-          field: Array.isArray(e.path) ? e.path.join('.') : 'unknown',
-          message: e.message
+    } catch (error: unknown) {
+      if (error instanceof ZodError) {
+        const details = error.issues.map((issue) => ({
+          field: issue.path.join('.') || 'unknown',
+          message: issue.message,
         }));
 
-        // 共通エラーハンドラーへ渡す。レスポンス生成とログ出力はあちらで一括処理。
         return next(new AppError('入力内容に不備があります', 400, details));
       }
-      
-      // バリデーション以外のエラー、または構造が想定外の場合はそのまま次へ
+
       next(error);
     }
   };

--- a/backend/src/services/geminiService.ts
+++ b/backend/src/services/geminiService.ts
@@ -2,6 +2,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import * as fs from "fs";
 import * as path from "path";
 import logger from "../utils/logger";
+import { getHttpStatusFromError, isRetryableHttpError } from "../utils/httpError";
 import type { ParsedReceipt } from "../types/receipt";
 import { findActivePromptTemplateByKey } from "../repositories/promptRepository";
 import {
@@ -37,10 +38,9 @@ async function withRetry<T>(
 ): Promise<T> {
   try {
     return await fn();
-  } catch (error: any) {
-    const status = error?.status || error?.response?.status;
-    const isRetryable = status === 429 || status >= 500;
-    if (retries <= 0 || !isRetryable) throw error;
+  } catch (error: unknown) {
+    const status = getHttpStatusFromError(error);
+    if (retries <= 0 || !isRetryableHttpError(error)) throw error;
     
     logger.warn(`⚠️ Gemini APIリトライ中... 残り ${retries} 回 (Error: ${status})`);
     await new Promise(resolve => setTimeout(resolve, delay));

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,7 @@
+import type { JWTPayload } from '../utils/auth';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: JWTPayload;
+  }
+}

--- a/backend/src/utils/appError.ts
+++ b/backend/src/utils/appError.ts
@@ -1,9 +1,9 @@
 export class AppError extends Error {
   public readonly statusCode: number;
   public readonly isOperational: boolean;
-  public readonly details?: any;
+  public readonly details?: unknown;
 
-  constructor(message: string, statusCode: number, details?: any) {
+  constructor(message: string, statusCode: number, details?: unknown) {
     super(message);
     this.statusCode = statusCode;
     this.isOperational = true; // 予測可能な業務エラー

--- a/backend/src/utils/httpError.ts
+++ b/backend/src/utils/httpError.ts
@@ -1,0 +1,32 @@
+/** リトライ判定用に unknown エラーから HTTP ステータスを取得 */
+export function getHttpStatusFromError(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const record = error as Record<string, unknown>;
+  if (typeof record.status === 'number') return record.status;
+
+  const response = record.response;
+  if (response && typeof response === 'object') {
+    const status = (response as Record<string, unknown>).status;
+    if (typeof status === 'number') return status;
+  }
+
+  return undefined;
+}
+
+export function isRetryableHttpError(error: unknown): boolean {
+  const status = getHttpStatusFromError(error);
+  return status === 429 || (status !== undefined && status >= 500);
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Unknown error';
+}
+
+export function getNodeErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}

--- a/backend/src/utils/prismaClient.ts
+++ b/backend/src/utils/prismaClient.ts
@@ -1,12 +1,13 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import fs from 'fs/promises';
 import path from 'path';
 import logger from './logger';
-import { tenantStorage } from './context'; 
+import { tenantStorage } from './context';
+import { getErrorMessage, getNodeErrorCode } from './httpError';
 
 // [Issue #69] ログレベルを環境に応じて調整可能にする
-const prismaLogLevels: any[] = process.env.NODE_ENV === 'production' 
-  ? ['error', 'warn'] 
+const prismaLogLevels: Prisma.LogLevel[] = process.env.NODE_ENV === 'production'
+  ? ['error', 'warn']
   : ['query', 'info', 'warn', 'error'];
 
 // ベースとなるクライアント
@@ -50,7 +51,11 @@ export const prisma = basePrisma.$extends({
         // IDが取得できない（認証外など）場合はフィルタリングをスキップ
         if (!familyGroupId) return query(args);
         
-        const anyArgs = args as any;
+        const queryArgs = args as Record<string, unknown> & {
+          where?: Record<string, unknown>;
+          data?: Record<string, unknown>;
+          create?: Record<string, unknown>;
+        };
 
         // 検索・更新・削除における familyGroupId の強制注入
         const tenantOps = ['findMany', 'findFirst', 'findUnique', 'count', 'update', 'delete', 'updateMany', 'deleteMany'];
@@ -58,23 +63,23 @@ export const prisma = basePrisma.$extends({
         if (tenantOps.includes(operation)) {
           // findUnique は複合キー設定がない場合 familyGroupId を追加すると型エラーになるため
           // 実質的に findFirst 相当の挙動として familyGroupId を条件に加える
-          anyArgs.where = {
-            ...anyArgs.where,
+          queryArgs.where = {
+            ...queryArgs.where,
             familyGroupId: familyGroupId
           };
         }
 
         // 新規作成時は所属世帯を自動セット
         if (operation === 'create' || operation === 'upsert') {
-          if (anyArgs.data) {
-            anyArgs.data.familyGroupId = familyGroupId;
+          if (queryArgs.data) {
+            queryArgs.data.familyGroupId = familyGroupId;
           }
-          if (anyArgs.create) {
-            anyArgs.create.familyGroupId = familyGroupId;
+          if (queryArgs.create) {
+            queryArgs.create.familyGroupId = familyGroupId;
           }
         }
 
-        return query(anyArgs);
+        return query(queryArgs);
       },
     },
 
@@ -127,11 +132,11 @@ async function deletePhysicalFile(relativePath: string) {
     await fs.access(fullPath);
     await fs.unlink(fullPath);
     logger.info(`[CLEANUP] 物理ファイルを削除しました: ${fullPath}`);
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
+  } catch (error: unknown) {
+    if (getNodeErrorCode(error) === 'ENOENT') {
       logger.warn(`[CLEANUP] 削除対象が見つかりませんでした (既に削除済み): ${fullPath}`);
     } else {
-      logger.error(`[CLEANUP] ファイル削除失敗: ${error.message}`);
+      logger.error(`[CLEANUP] ファイル削除失敗: ${getErrorMessage(error)}`);
     }
   }
 }

--- a/backend/src/utils/retry.ts
+++ b/backend/src/utils/retry.ts
@@ -1,3 +1,5 @@
+import { getErrorMessage, isRetryableHttpError } from './httpError';
+
 /**
  * 指数バックオフを用いたリトライラッパー
  */
@@ -8,16 +10,13 @@ export async function withRetry<T>(
 ): Promise<T> {
   try {
     return await fn();
-  } catch (error: any) {
-    // 429 (Too Many Requests) や 5xx 系のエラーのみリトライ対象にするのがプロの流儀
-    const isRetryable = error.status === 429 || error.status >= 500;
-
-    if (retries <= 0 || !isRetryable) {
+  } catch (error: unknown) {
+    if (retries <= 0 || !isRetryableHttpError(error)) {
       throw error;
     }
 
-    console.warn(`⚠️ APIエラー発生。リトライします... (残り ${retries} 回) : ${error.message}`);
-    
+    console.warn(`⚠️ APIエラー発生。リトライします... (残り ${retries} 回) : ${getErrorMessage(error)}`);
+
     // 指数バックオフ: 1s -> 2s -> 4s と待ち時間を倍増させる
     await new Promise(resolve => setTimeout(resolve, delay));
     return withRetry(fn, retries - 1, delay * 2);

--- a/backend/src/workers/receiptWorker.ts
+++ b/backend/src/workers/receiptWorker.ts
@@ -4,6 +4,7 @@ import { RECEIPT_QUEUE_NAME } from '../queues/receiptQueue';
 import { analyzeOnly } from '../services/receiptService'; 
 import { runWithTenant } from '../utils/context';
 import logger from '../utils/logger';
+import { getErrorMessage } from '../utils/httpError';
 
 /**
  * [Issue #49-8 / #71]
@@ -31,9 +32,8 @@ const receiptWorker = new Worker(
         // フロントエンドのポーリングエンドポイント経由でユーザーに渡されます。
         return result;
 
-      } catch (error: any) {
-        // 画像読み込みエラーや Gemini API エラー（429/500等）を捕捉
-        logger.error(`[Worker] ジョブ失敗: ID ${job.id} - ${error.message}`);
+      } catch (error: unknown) {
+        logger.error(`[Worker] ジョブ失敗: ID ${job.id} - ${getErrorMessage(error)}`);
         
         // ジョブを失敗状態 (failed) にし、必要に応じて BullMQ のリトライ機能に委ねる
         throw error;


### PR DESCRIPTION
## Summary

ChatGPT レビュー指摘の backend `any` / `as any` を型安全に置き換え。

| ファイル | 対応 |
|----------|------|
| `types/express.d.ts` | 新設 — `req.user` に `JWTPayload` |
| `utils/httpError.ts` | 新設 — HTTP ステータス・メッセージ抽出ヘルパ |
| `middleware/authMiddleware.ts` | `as any` 除去 |
| `middleware/tenantMiddleware.ts` | 同上 |
| `middleware/validate.ts` | `ZodType` + `ZodError` 型ガード |
| `middleware/errorHandler.ts` | `AppError.details: unknown` 対応 |
| `utils/appError.ts` | `details` を `unknown` に |
| `services/geminiService.ts` | `catch (unknown)` + リトライ判定 |
| `utils/retry.ts` | 同上 |
| `workers/receiptWorker.ts` | `getErrorMessage` 利用 |
| `utils/prismaClient.ts` | `Prisma.LogLevel[]`、query args 型改善 |

## Issue

Closes #467

## Test plan

- [x] `npm test`（backend）パス（43 passed）
- [x] 変更対象ファイルに `any` / `as any` 残存なし
- [ ] レビュー後マージ（マージは担当者実施）


Made with [Cursor](https://cursor.com)