### PR TITLE
Issue #101-4: SplitEditorItemTable 子コンポーネント分割

### DIFF
--- a/frontend/src/features/settlement/components/SplitEditorItemRow.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorItemRow.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { AppButton } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { tableStyles } from '../../../theme';
+import type { FamilyMemberSummary, ReceiptItemForSplit } from '../../../types/settlement';
+import { SplitEditorMemberSplitInputs } from './SplitEditorMemberSplitInputs';
+import { splitEditorItemTableStyles as styles } from '../styles/splitEditorItemTableStyles';
+
+type Props = {
+  item: ReceiptItemForSplit;
+  itemTotal: number;
+  activeMembers: FamilyMemberSummary[];
+  editSplits: Record<number, Record<number, number>>;
+  onAmountChange: (itemId: number, memberId: number, value: string, itemTotal: number) => void;
+  onPercentChange: (itemId: number, memberId: number, value: string, itemTotal: number) => void;
+  onSplitItemEqually: (itemId: number, itemTotal: number) => void;
+};
+
+export const SplitEditorItemRow: React.FC<Props> = ({
+  item,
+  itemTotal,
+  activeMembers,
+  editSplits,
+  onAmountChange,
+  onPercentChange,
+  onSplitItemEqually,
+}) => (
+  <View style={[tableStyles.row, styles.tableRowWide]}>
+    <Text
+      style={[tableStyles.cell, styles.cellName, tableStyles.bodyText]}
+      numberOfLines={2}
+    >
+      {item.name}
+    </Text>
+    <Text
+      style={[
+        tableStyles.cell,
+        styles.cellAmount,
+        tableStyles.bodyText,
+        tableStyles.boldText,
+      ]}
+    >
+      ¥{itemTotal.toLocaleString()}
+    </Text>
+
+    {activeMembers.map((m, idx) => {
+      const amountValue = editSplits[item.id]?.[m.id] || 0;
+      const percentValue =
+        itemTotal > 0 ? Math.round((amountValue / itemTotal) * 100) : 0;
+
+      return (
+        <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
+          <SplitEditorMemberSplitInputs
+            percentValue={percentValue}
+            amountValue={amountValue}
+            isFirst={idx === 0}
+            onPercentChange={(val) => onPercentChange(item.id, m.id, val, itemTotal)}
+            onAmountChange={(val) => onAmountChange(item.id, m.id, val, itemTotal)}
+          />
+        </View>
+      );
+    })}
+
+    <View style={[tableStyles.cell, styles.cellAction]}>
+      <AppButton
+        title={BUTTON_LABELS.splitEqual}
+        onPress={() => onSplitItemEqually(item.id, itemTotal)}
+        variant="ghost"
+        size="sm"
+      />
+    </View>
+  </View>
+);

--- a/frontend/src/features/settlement/components/SplitEditorItemTable.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorItemTable.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  ScrollView,
-  TextInput,
-} from 'react-native';
-import { AppButton } from '../../../components/ui';
-import { BUTTON_LABELS } from '../../../constants/buttonLabels';
-import { theme, tableStyles } from '../../../theme';
+import { View, ScrollView } from 'react-native';
+import { tableStyles } from '../../../theme';
 import { calcItemTotal } from '../../../utils/splitEditorSplits';
-import { webTextInputOutlineNone } from '../../../utils/webPlatformStyles';
 import type {
   FamilyMemberSummary,
   ReceiptForSplitEditor,
-  ReceiptItemForSplit,
 } from '../../../types/settlement';
+import { SplitEditorTableHeader } from './SplitEditorTableHeader';
+import { SplitEditorItemRow } from './SplitEditorItemRow';
+import { SplitEditorTotalRow } from './SplitEditorTotalRow';
+import { splitEditorItemTableStyles as styles } from '../styles/splitEditorItemTableStyles';
 
 interface SplitEditorItemTableProps {
   receipt: ReceiptForSplitEditor;
@@ -53,239 +47,34 @@ export const SplitEditorItemTable: React.FC<SplitEditorItemTableProps> = ({
   onTotalPercentChange,
   onSplitWholeReceiptEqually,
   getMemberTotalAmount,
-}) => {
-  const sem = theme.colors.semantic;
+}) => (
+  <ScrollView style={styles.tableScroll} horizontal={false}>
+    <ScrollView horizontal contentContainerStyle={{ flexDirection: 'column' }}>
+      <View style={tableStyles.wrapper}>
+        <SplitEditorTableHeader activeMembers={activeMembers} />
 
-  return (
-    <ScrollView style={styles.tableScroll} horizontal={false}>
-      <ScrollView horizontal contentContainerStyle={{ flexDirection: 'column' }}>
-        <View style={tableStyles.wrapper}>
-          <View style={[tableStyles.row, tableStyles.headerRow, styles.tableRowWide]}>
-            <Text style={[tableStyles.cell, styles.cellName, tableStyles.headerText]}>
-              商品名
-            </Text>
-            <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>
-              合計
-            </Text>
-            {activeMembers.map((m) => (
-              <Text
-                key={m.id}
-                style={[
-                  tableStyles.cell,
-                  styles.cellInputCol,
-                  tableStyles.headerText,
-                  { textAlign: 'center' },
-                ]}
-              >
-                {m.name}
-              </Text>
-            ))}
-            <Text style={[tableStyles.cell, styles.cellAction, tableStyles.headerText]}>
-              操作
-            </Text>
-          </View>
+        {receipt.items.map((item) => (
+          <SplitEditorItemRow
+            key={item.id}
+            item={item}
+            itemTotal={calcItemTotal(item)}
+            activeMembers={activeMembers}
+            editSplits={editSplits}
+            onAmountChange={onAmountChange}
+            onPercentChange={onPercentChange}
+            onSplitItemEqually={onSplitItemEqually}
+          />
+        ))}
 
-          {receipt.items.map((item: ReceiptItemForSplit) => {
-            const itemTotal = calcItemTotal(item);
-
-            return (
-              <View key={item.id} style={[tableStyles.row, styles.tableRowWide]}>
-                <Text
-                  style={[tableStyles.cell, styles.cellName, tableStyles.bodyText]}
-                  numberOfLines={2}
-                >
-                  {item.name}
-                </Text>
-                <Text
-                  style={[
-                    tableStyles.cell,
-                    styles.cellAmount,
-                    tableStyles.bodyText,
-                    tableStyles.boldText,
-                  ]}
-                >
-                  ¥{itemTotal.toLocaleString()}
-                </Text>
-
-                {activeMembers.map((m, idx) => {
-                  const amountValue = editSplits[item.id]?.[m.id] || 0;
-                  const percentValue =
-                    itemTotal > 0 ? Math.round((amountValue / itemTotal) * 100) : 0;
-                  const isFirst = idx === 0;
-
-                  return (
-                    <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
-                      <View style={styles.dualInputWrapper}>
-                        <View style={styles.inputGroup}>
-                          <TextInput
-                            style={[
-                              styles.inputBox,
-                              styles.percentBox,
-                              isFirst && styles.disabledInputBox,
-                            ]}
-                            value={String(percentValue)}
-                            onChangeText={(val) =>
-                              onPercentChange(item.id, m.id, val, itemTotal)
-                            }
-                            keyboardType="number-pad"
-                            editable={!isFirst}
-                            selectTextOnFocus
-                          />
-                          <Text style={styles.unitText}>%</Text>
-                        </View>
-
-                        <View style={[styles.inputGroup, { marginLeft: 4 }]}>
-                          <TextInput
-                            style={[
-                              styles.inputBox,
-                              styles.amountBox,
-                              isFirst && styles.disabledInputBox,
-                            ]}
-                            value={String(amountValue)}
-                            onChangeText={(val) =>
-                              onAmountChange(item.id, m.id, val, itemTotal)
-                            }
-                            keyboardType="number-pad"
-                            editable={!isFirst}
-                            selectTextOnFocus
-                          />
-                          <Text style={styles.unitText}>円</Text>
-                        </View>
-                      </View>
-                    </View>
-                  );
-                })}
-
-                <View style={[tableStyles.cell, styles.cellAction]}>
-                  <AppButton
-                    title={BUTTON_LABELS.splitEqual}
-                    onPress={() => onSplitItemEqually(item.id, itemTotal)}
-                    variant="ghost"
-                    size="sm"
-                  />
-                </View>
-              </View>
-            );
-          })}
-
-          <View style={[tableStyles.row, styles.tableRowWide, styles.totalRow]}>
-            <Text style={[tableStyles.cell, styles.cellName, styles.totalText]}>
-              一括調整（全体合計）
-            </Text>
-            <Text style={[tableStyles.cell, styles.cellAmount, styles.totalText]}>
-              ¥{receiptTotalAmount.toLocaleString()}
-            </Text>
-
-            {activeMembers.map((m, idx) => {
-              const memberTotal = getMemberTotalAmount(m.id);
-              const percentValue =
-                receiptTotalAmount > 0
-                  ? Math.round((memberTotal / receiptTotalAmount) * 100)
-                  : 0;
-              const isFirst = idx === 0;
-
-              return (
-                <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
-                  <View style={styles.dualInputWrapper}>
-                    <View style={[styles.inputGroup, styles.totalInputGroup]}>
-                      <TextInput
-                        style={[
-                          styles.inputBox,
-                          styles.percentBox,
-                          isFirst && styles.disabledInputBox,
-                          styles.totalInputBox,
-                        ]}
-                        value={String(percentValue)}
-                        onChangeText={(val) => onTotalPercentChange(m.id, val)}
-                        keyboardType="number-pad"
-                        editable={!isFirst}
-                        selectTextOnFocus
-                      />
-                      <Text style={[styles.unitText, styles.totalUnitText]}>%</Text>
-                    </View>
-
-                    <View
-                      style={[styles.inputGroup, styles.totalInputGroup, { marginLeft: 4 }]}
-                    >
-                      <TextInput
-                        style={[
-                          styles.inputBox,
-                          styles.amountBox,
-                          isFirst && styles.disabledInputBox,
-                          styles.totalInputBox,
-                        ]}
-                        value={String(memberTotal)}
-                        onChangeText={(val) => onTotalAmountChange(m.id, val)}
-                        keyboardType="number-pad"
-                        editable={!isFirst}
-                        selectTextOnFocus
-                      />
-                      <Text style={[styles.unitText, styles.totalUnitText]}>円</Text>
-                    </View>
-                  </View>
-                </View>
-              );
-            })}
-
-            <View style={[tableStyles.cell, styles.cellAction]}>
-              <AppButton
-                title={BUTTON_LABELS.splitEqual}
-                onPress={onSplitWholeReceiptEqually}
-                variant="ghost"
-                size="sm"
-              />
-            </View>
-          </View>
-        </View>
-      </ScrollView>
+        <SplitEditorTotalRow
+          activeMembers={activeMembers}
+          receiptTotalAmount={receiptTotalAmount}
+          getMemberTotalAmount={getMemberTotalAmount}
+          onTotalAmountChange={onTotalAmountChange}
+          onTotalPercentChange={onTotalPercentChange}
+          onSplitWholeReceiptEqually={onSplitWholeReceiptEqually}
+        />
+      </View>
     </ScrollView>
-  );
-};
-
-const sem = theme.colors.semantic;
-
-const styles = StyleSheet.create({
-  tableScroll: { flex: 1 },
-  tableRowWide: { minWidth: 800 },
-  totalRow: {
-    backgroundColor: sem.warning.bg,
-    borderTopWidth: 2,
-    borderTopColor: sem.warning.border,
-  },
-  totalText: { fontWeight: 'bold', color: sem.warning.text },
-  totalInputGroup: { borderColor: sem.warning.border, backgroundColor: sem.warning.inputBg },
-  totalInputBox: { fontWeight: 'bold', color: sem.warning.text },
-  totalUnitText: { color: sem.warning.text, fontWeight: 'bold' },
-  cellName: { width: 160 },
-  cellAmount: { width: 90, textAlign: 'right' },
-  cellInputCol: { width: 180, alignItems: 'center' },
-  dualInputWrapper: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-  },
-  inputGroup: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: theme.colors.surface,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: 6,
-    height: 36,
-    paddingRight: 4,
-  },
-  inputBox: {
-    height: '100%',
-    textAlign: 'right',
-    fontSize: 14,
-    color: theme.colors.text.main,
-    paddingRight: 4,
-    ...webTextInputOutlineNone,
-  },
-  percentBox: { width: 35 },
-  amountBox: { width: 60 },
-  disabledInputBox: { backgroundColor: sem.neutral.bg, color: theme.colors.text.muted },
-  unitText: { fontSize: 11, color: theme.colors.text.muted },
-  cellAction: { width: 70, alignItems: 'center' },
-});
+  </ScrollView>
+);

--- a/frontend/src/features/settlement/components/SplitEditorMemberSplitInputs.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorMemberSplitInputs.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, Text, TextInput } from 'react-native';
+import { webTextInputOutlineNone } from '../../../utils/webPlatformStyles';
+import { splitEditorItemTableStyles as styles } from '../styles/splitEditorItemTableStyles';
+
+type Props = {
+  percentValue: number;
+  amountValue: number;
+  isFirst: boolean;
+  variant?: 'default' | 'total';
+  onPercentChange: (value: string) => void;
+  onAmountChange: (value: string) => void;
+};
+
+export const SplitEditorMemberSplitInputs: React.FC<Props> = ({
+  percentValue,
+  amountValue,
+  isFirst,
+  variant = 'default',
+  onPercentChange,
+  onAmountChange,
+}) => {
+  const isTotal = variant === 'total';
+  const inputGroupStyle = isTotal
+    ? [styles.inputGroup, styles.totalInputGroup]
+    : styles.inputGroup;
+  const inputBoxBase = [
+    styles.inputBox,
+    isFirst && styles.disabledInputBox,
+    isTotal && styles.totalInputBox,
+    webTextInputOutlineNone,
+  ];
+  const unitStyle = isTotal ? [styles.unitText, styles.totalUnitText] : styles.unitText;
+
+  return (
+    <View style={styles.dualInputWrapper}>
+      <View style={inputGroupStyle}>
+        <TextInput
+          style={[...inputBoxBase, styles.percentBox]}
+          value={String(percentValue)}
+          onChangeText={onPercentChange}
+          keyboardType="number-pad"
+          editable={!isFirst}
+          selectTextOnFocus
+        />
+        <Text style={unitStyle}>%</Text>
+      </View>
+
+      <View style={[inputGroupStyle, { marginLeft: 4 }]}>
+        <TextInput
+          style={[...inputBoxBase, styles.amountBox]}
+          value={String(amountValue)}
+          onChangeText={onAmountChange}
+          keyboardType="number-pad"
+          editable={!isFirst}
+          selectTextOnFocus
+        />
+        <Text style={unitStyle}>円</Text>
+      </View>
+    </View>
+  );
+};

--- a/frontend/src/features/settlement/components/SplitEditorTableHeader.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorTableHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { tableStyles } from '../../../theme';
+import type { FamilyMemberSummary } from '../../../types/settlement';
+import { splitEditorItemTableStyles as styles } from '../styles/splitEditorItemTableStyles';
+
+type Props = {
+  activeMembers: FamilyMemberSummary[];
+};
+
+export const SplitEditorTableHeader: React.FC<Props> = ({ activeMembers }) => (
+  <View style={[tableStyles.row, tableStyles.headerRow, styles.tableRowWide]}>
+    <Text style={[tableStyles.cell, styles.cellName, tableStyles.headerText]}>商品名</Text>
+    <Text style={[tableStyles.cell, styles.cellAmount, tableStyles.headerText]}>合計</Text>
+    {activeMembers.map((m) => (
+      <Text
+        key={m.id}
+        style={[
+          tableStyles.cell,
+          styles.cellInputCol,
+          tableStyles.headerText,
+          { textAlign: 'center' },
+        ]}
+      >
+        {m.name}
+      </Text>
+    ))}
+    <Text style={[tableStyles.cell, styles.cellAction, tableStyles.headerText]}>操作</Text>
+  </View>
+);

--- a/frontend/src/features/settlement/components/SplitEditorTotalRow.tsx
+++ b/frontend/src/features/settlement/components/SplitEditorTotalRow.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { AppButton } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { tableStyles } from '../../../theme';
+import type { FamilyMemberSummary } from '../../../types/settlement';
+import { SplitEditorMemberSplitInputs } from './SplitEditorMemberSplitInputs';
+import { splitEditorItemTableStyles as styles } from '../styles/splitEditorItemTableStyles';
+
+type Props = {
+  activeMembers: FamilyMemberSummary[];
+  receiptTotalAmount: number;
+  getMemberTotalAmount: (memberId: number) => number;
+  onTotalAmountChange: (memberId: number, value: string) => void;
+  onTotalPercentChange: (memberId: number, value: string) => void;
+  onSplitWholeReceiptEqually: () => void;
+};
+
+export const SplitEditorTotalRow: React.FC<Props> = ({
+  activeMembers,
+  receiptTotalAmount,
+  getMemberTotalAmount,
+  onTotalAmountChange,
+  onTotalPercentChange,
+  onSplitWholeReceiptEqually,
+}) => (
+  <View style={[tableStyles.row, styles.tableRowWide, styles.totalRow]}>
+    <Text style={[tableStyles.cell, styles.cellName, styles.totalText]}>
+      一括調整（全体合計）
+    </Text>
+    <Text style={[tableStyles.cell, styles.cellAmount, styles.totalText]}>
+      ¥{receiptTotalAmount.toLocaleString()}
+    </Text>
+
+    {activeMembers.map((m, idx) => {
+      const memberTotal = getMemberTotalAmount(m.id);
+      const percentValue =
+        receiptTotalAmount > 0
+          ? Math.round((memberTotal / receiptTotalAmount) * 100)
+          : 0;
+
+      return (
+        <View key={m.id} style={[tableStyles.cell, styles.cellInputCol]}>
+          <SplitEditorMemberSplitInputs
+            percentValue={percentValue}
+            amountValue={memberTotal}
+            isFirst={idx === 0}
+            variant="total"
+            onPercentChange={(val) => onTotalPercentChange(m.id, val)}
+            onAmountChange={(val) => onTotalAmountChange(m.id, val)}
+          />
+        </View>
+      );
+    })}
+
+    <View style={[tableStyles.cell, styles.cellAction]}>
+      <AppButton
+        title={BUTTON_LABELS.splitEqual}
+        onPress={onSplitWholeReceiptEqually}
+        variant="ghost"
+        size="sm"
+      />
+    </View>
+  </View>
+);

--- a/frontend/src/features/settlement/styles/splitEditorItemTableStyles.ts
+++ b/frontend/src/features/settlement/styles/splitEditorItemTableStyles.ts
@@ -1,0 +1,49 @@
+import { StyleSheet } from 'react-native';
+import { theme } from '../../../theme';
+
+const sem = theme.colors.semantic;
+
+export const splitEditorItemTableStyles = StyleSheet.create({
+  tableScroll: { flex: 1 },
+  tableRowWide: { minWidth: 800 },
+  totalRow: {
+    backgroundColor: sem.warning.bg,
+    borderTopWidth: 2,
+    borderTopColor: sem.warning.border,
+  },
+  totalText: { fontWeight: 'bold', color: sem.warning.text },
+  totalInputGroup: { borderColor: sem.warning.border, backgroundColor: sem.warning.inputBg },
+  totalInputBox: { fontWeight: 'bold', color: sem.warning.text },
+  totalUnitText: { color: sem.warning.text, fontWeight: 'bold' },
+  cellName: { width: 160 },
+  cellAmount: { width: 90, textAlign: 'right' },
+  cellInputCol: { width: 180, alignItems: 'center' },
+  dualInputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  inputGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: 6,
+    height: 36,
+    paddingRight: 4,
+  },
+  inputBox: {
+    height: '100%',
+    textAlign: 'right',
+    fontSize: 14,
+    color: theme.colors.text.main,
+    paddingRight: 4,
+  },
+  percentBox: { width: 35 },
+  amountBox: { width: 60 },
+  disabledInputBox: { backgroundColor: sem.neutral.bg, color: theme.colors.text.muted },
+  unitText: { fontSize: 11, color: theme.colors.text.muted },
+  cellAction: { width: 70, alignItems: 'center' },
+});


### PR DESCRIPTION
## Summary

- `SplitEditorItemTable.tsx` を子コンポーネントに分割（**291→80 行**）
  - `SplitEditorTableHeader` — ヘッダー行
  - `SplitEditorItemRow` — 商品行
  - `SplitEditorTotalRow` — 一括調整行
  - `SplitEditorMemberSplitInputs` — % / 円デュアル入力（行・合計行で共用）
  - `styles/splitEditorItemTableStyles.ts` — スタイル共通化

## Issue

Closes #462

## Test plan

- [x] `npm test`（frontend）パス
- [x] SplitEditorItemTable.tsx が 120 行以下
- [ ] 割勘エディタの按分入力・均等割り・一括調整が従来通り（目視）
- [ ] レビュー後マージ（マージは担当者実施）


Made with [Cursor](https://cursor.com)