### PR TITLE
refactor(fe): [Issue #101-6] API エラー処理を showApiErrorAlert に統一

### DIFF
--- a/frontend/src/features/history/hooks/useReceiptHistory.ts
+++ b/frontend/src/features/history/hooks/useReceiptHistory.ts
@@ -3,7 +3,7 @@ import { categoryApi, receiptApi } from '../../../api';
 import { useIsWideLayout } from '../../../hooks/useIsWideLayout';
 import type { CategorySummary, ReceiptDetail } from '../../../types/receipt';
 import type { FamilyMemberSummary } from '../../../types/settlement';
-import { showAlert } from '../../../utils/alertMessage';
+import { showApiErrorAlert } from '../../../utils/apiError';
 import { getRecentYearMonths, useMonthSelectOptions } from '../../../utils/monthSelectOptions';
 
 type UseReceiptHistoryOptions = {
@@ -42,7 +42,7 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
         setCategories(res.data);
       }
     } catch (err) {
-      console.error('カテゴリー取得失敗', err);
+      showApiErrorAlert('エラー', err, 'カテゴリーの取得に失敗しました。');
     }
   }, []);
 
@@ -53,7 +53,7 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
         setMembers(res.data);
       }
     } catch (err) {
-      console.error('世帯メンバー取得失敗', err);
+      showApiErrorAlert('エラー', err, '世帯メンバーの取得に失敗しました。');
     }
   }, []);
 
@@ -76,8 +76,7 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
         }
       }
     } catch (err) {
-      console.error('履歴取得失敗', err);
-      showAlert('エラー', '履歴の取得に失敗しました');
+      showApiErrorAlert('エラー', err, '履歴の取得に失敗しました。');
     } finally {
       setLoading(false);
     }
@@ -112,8 +111,7 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
         if (selectedReceipt) setSelectedReceipt((prev) => (prev ? mapper(prev) : null));
       }
     } catch (err) {
-      console.error('カテゴリー更新失敗', err);
-      showAlert('エラー', 'カテゴリーの更新に失敗しました');
+      showApiErrorAlert('エラー', err, 'カテゴリーの更新に失敗しました。');
     }
   };
 

--- a/frontend/src/features/home/hooks/useHomeDashboard.ts
+++ b/frontend/src/features/home/hooks/useHomeDashboard.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { receiptApi, statsApi } from '../../../api';
+import { showApiErrorAlert } from '../../../utils/apiError';
 import { getCurrentYearMonth } from '../../../utils/monthSelectOptions';
 
 export function useHomeDashboard(currentMemberId: number) {
@@ -29,7 +30,7 @@ export function useHomeDashboard(currentMemberId: number) {
         setMonthlyTotal(Math.round(total));
       }
     } catch (error) {
-      console.error('Data fetch error:', error);
+      showApiErrorAlert('エラー', error, 'ダッシュボードの取得に失敗しました。');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/features/home/hooks/useReceiptUpload.ts
+++ b/frontend/src/features/home/hooks/useReceiptUpload.ts
@@ -9,6 +9,7 @@ import {
   registerWebImageFile,
   clearPendingCropUri,
 } from '../../../utils/webImageFileRegistry';
+import { showApiErrorAlert } from '../../../utils/apiError';
 import { showAlert } from '../../../utils/alertMessage';
 
 const ACCEPTANCE_MESSAGE_MS = 3000;
@@ -63,11 +64,8 @@ export function useReceiptUpload({
         registerLocalUploadFailure('サーバーが受付を拒否しました。');
         showAlert('エラー', 'レシートの受付に失敗しました。');
       } catch (err) {
-        console.error('uploadReceiptImage', err);
-        const message =
-          err instanceof Error ? err.message : '画像のアップロードに失敗しました。';
-        registerLocalUploadFailure(message);
-        showAlert('エラー', message);
+        registerLocalUploadFailure('画像のアップロードに失敗しました。');
+        showApiErrorAlert('エラー', err, '画像のアップロードに失敗しました。');
       } finally {
         setUploadingCount((count) => Math.max(0, count - 1));
       }
@@ -133,8 +131,7 @@ export function useReceiptUpload({
     try {
       await pickImageNative();
     } catch (err) {
-      console.error('handleScan Error:', err);
-      showAlert('エラー', '画像のアップロードに失敗しました。');
+      showApiErrorAlert('エラー', err, '画像のアップロードに失敗しました。');
     }
   }, [pickImageNative]);
 

--- a/frontend/src/features/settlement/hooks/useSettlementSummary.ts
+++ b/frontend/src/features/settlement/hooks/useSettlementSummary.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { statsApi } from '../../../api/statsApi';
 import { getCurrentYearMonth, getRecentYearMonths } from '../../../utils/monthSelectOptions';
+import { showApiErrorAlert } from '../../../utils/apiError';
 import { showAlert } from '../../../utils/alertMessage';
 import { showConfirmDialog } from '../../../utils/confirmDialog';
 import { BUTTON_LABELS } from '../../../constants/buttonLabels';
@@ -66,8 +67,7 @@ export function useSettlementSummary() {
         setTransferList(res.data?.transfers ?? []);
       }
     } catch (err) {
-      console.error('精算サマリーの取得失敗:', err);
-      showAlert('エラー', '精算サマリーの取得に失敗しました。');
+      showApiErrorAlert('エラー', err, '精算サマリーの取得に失敗しました。');
     } finally {
       setLoading(false);
     }
@@ -120,8 +120,7 @@ export function useSettlementSummary() {
         await loadSettlementData();
       }
     } catch (err) {
-      console.error('送金記録エラー', err);
-      showAlert('エラー', '送金記録の登録に失敗しました。');
+      showApiErrorAlert('エラー', err, '送金記録の登録に失敗しました。');
     } finally {
       setIsSubmitting(false);
     }
@@ -149,9 +148,9 @@ export function useSettlementSummary() {
           await loadSettlementData({ silent: true });
         }
       } catch (err) {
-        console.error('送金取消エラー', err);
-        showAlert(
+        showApiErrorAlert(
           'エラー',
+          err,
           `${fromName} → ${toName} ¥${transfer.amount.toLocaleString()} の取消に失敗しました。`
         );
       } finally {

--- a/frontend/src/features/settlement/hooks/useSplitEditor.ts
+++ b/frontend/src/features/settlement/hooks/useSplitEditor.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { receiptApi } from '../../../api/receiptApi';
+import { showApiErrorAlert } from '../../../utils/apiError';
 import { showAlert } from '../../../utils/alertMessage';
 import {
   buildItemSplitSavePayload,
@@ -53,8 +54,7 @@ export function useSplitEditor(
           setEditSplits(buildInitialSplits(receipt, initialActive));
         }
       } catch (err) {
-        console.error('メンバー取得失敗', err);
-        showAlert('エラー', 'メンバー情報の取得に失敗しました。');
+        showApiErrorAlert('エラー', err, 'メンバー情報の取得に失敗しました。');
       } finally {
         setLoading(false);
       }
@@ -204,8 +204,7 @@ export function useSplitEditor(
       await Promise.all(savePromises);
       showAlert('保存完了', '割り勘設定を保存しました。', { onOk: onBack });
     } catch (err) {
-      console.error('保存エラー', err);
-      showAlert('エラー', '保存に失敗しました。');
+      showApiErrorAlert('エラー', err, '保存に失敗しました。');
     } finally {
       setSaving(false);
     }

--- a/frontend/src/hooks/useReceiptJobs.ts
+++ b/frontend/src/hooks/useReceiptJobs.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { receiptApi } from '../api/receiptApi';
+import { showApiErrorAlert } from '../utils/apiError';
 import { countActiveReceiptJobs } from '../utils/receiptJobDisplay';
 import type { ReceiptJobListItem } from '../types/receiptJob';
 
@@ -26,7 +27,11 @@ export function useReceiptJobs(enabled: boolean) {
           setJobs(res.data as ReceiptJobListItem[]);
         }
       } catch (error) {
-        console.error('[ReceiptJobs] refresh failed:', error);
+        if (userInitiated) {
+          showApiErrorAlert('エラー', error, '解析ジョブ一覧の取得に失敗しました。');
+        } else {
+          console.error('[ReceiptJobs] refresh failed:', error);
+        }
       } finally {
         if (userInitiated) setRefreshing(false);
       }

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -41,7 +41,6 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
       const total = rows.reduce((sum, item) => sum + item.estimatedCostJpy, 0);
       setTotalCost(total);
     } catch (error: unknown) {
-      console.error('Stats Fetch Error:', error);
       setErrorMsg(getApiErrorMessage(error, 'コスト統計の取得に失敗しました。'));
     } finally {
       setLoading(false);

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
 import { productMasterApi, type ProductMaster } from '../api';
 import { showAlert } from '../utils/alertMessage';
+import { showApiErrorAlert } from '../utils/apiError';
 import { showConfirmDialog } from '../utils/confirmDialog';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
@@ -32,7 +33,7 @@ export const ProductMasterScreen = ({
       });
       setMasters(res.data ?? []);
     } catch (err) {
-      console.error('Fetch Masters Error:', err);
+      showApiErrorAlert('エラー', err, '学習マスタの取得に失敗しました。');
     } finally {
       setLoading(false);
     }
@@ -54,8 +55,8 @@ export const ProductMasterScreen = ({
           try {
             await productMasterApi.deleteProductMaster(id);
             fetchMasters();
-          } catch {
-            showAlert('エラー', '削除に失敗しました');
+          } catch (err) {
+            showApiErrorAlert('エラー', err, '削除に失敗しました。');
           }
         },
       },
@@ -88,8 +89,8 @@ export const ProductMasterScreen = ({
                         });
                         showAlert('完了', '統合完了しました');
                         fetchMasters();
-                      } catch {
-                        showAlert('エラー', '統合失敗');
+                      } catch (err) {
+                        showApiErrorAlert('エラー', err, '統合に失敗しました。');
                       }
                     },
                   },

--- a/frontend/src/utils/apiError.test.ts
+++ b/frontend/src/utils/apiError.test.ts
@@ -1,12 +1,23 @@
 import axios from 'axios';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getApiErrorMessage,
   getApiErrorResponseData,
   getApiErrorStatus,
+  showApiErrorAlert,
 } from './apiError';
+import { showAlert } from './alertMessage';
+
+vi.mock('./alertMessage', () => ({
+  showAlert: vi.fn(),
+}));
 
 describe('apiError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   it('extracts error field from axios response', () => {
     const error = new axios.AxiosError(
       'Request failed',
@@ -45,5 +56,32 @@ describe('apiError', () => {
     expect(getApiErrorMessage(axiosError)).toBe('DUPLICATE');
     expect(getApiErrorMessage(new Error('保存に失敗'))).toBe('保存に失敗');
     expect(getApiErrorMessage('unknown')).toBe('通信エラーが発生しました。');
+  });
+
+  it('showApiErrorAlert notifies user with extracted message', () => {
+    const error = new axios.AxiosError(
+      'Request failed',
+      'ERR_BAD_REQUEST',
+      undefined,
+      undefined,
+      {
+        status: 500,
+        data: { error: 'サーバーエラー' },
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {} as never,
+      }
+    );
+
+    showApiErrorAlert('エラー', error, '操作に失敗しました。');
+
+    expect(showAlert).toHaveBeenCalledWith('エラー', 'サーバーエラー');
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('showApiErrorAlert uses fallback when message is unavailable', () => {
+    showApiErrorAlert('エラー', 'unknown', '一覧の取得に失敗しました。');
+
+    expect(showAlert).toHaveBeenCalledWith('エラー', '一覧の取得に失敗しました。');
   });
 });

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { showAlert } from './alertMessage';
 
 function readStringField(data: unknown, key: 'error' | 'message'): string | undefined {
   if (!data || typeof data !== 'object') return undefined;
@@ -39,4 +40,14 @@ export function getApiErrorMessage(
   }
 
   return fallback;
+}
+
+/** API エラーをログ出力し、抽出メッセージでユーザーに通知する */
+export function showApiErrorAlert(
+  title: string,
+  error: unknown,
+  fallback = '通信エラーが発生しました。'
+): void {
+  console.error(`[API Error] ${title}:`, error);
+  showAlert(title, getApiErrorMessage(error, fallback));
 }


### PR DESCRIPTION
## Summary
- `utils/apiError.ts` に `showApiErrorAlert(title, error, fallback?)` を追加（ログ + メッセージ抽出 + `showAlert`）
- 以下の API エラー catch を移行:
  - `ProductMasterScreen`
  - `useSplitEditor` / `useSettlementSummary`
  - `useReceiptHistory` / `useReceiptUpload` / `useHomeDashboard`
  - `useReceiptJobs`（ユーザー操作による refresh 時のみアラート）
- `AdminStatsScreen` はインラインエラー表示のため `getApiErrorMessage` を継続（`console.error` のみ除去）

## Test plan
- [x] `npm test -- --run apiError`（4 tests passed）
- [ ] 各画面で API 失敗時にサーバーメッセージまたは fallback が表示されること
- [ ] 割勘・精算・履歴・アップロードの正常系が従来通り動作すること

Closes #464

Made with [Cursor](https://cursor.com)