### PR TITLE
test(be): [Issue #102-1] OpenAPI ↔ 実装 drift 検知を CI に追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
           # app.integration.test.ts が createApp 経由で Prisma を import するため必須（DB 結合は skip）
           DATABASE_URL: postgresql://vitest:vitest@127.0.0.1:5432/vitest?schema=public
 
+      - name: Verify OpenAPI route drift
+        run: npm run check:openapi
+        env:
+          JWT_SECRET: ci-test-jwt-secret
+          DATABASE_URL: postgresql://vitest:vitest@127.0.0.1:5432/vitest?schema=public
+
   frontend-unit:
     name: Frontend unit tests
     runs-on: ubuntu-latest

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "prisma:seed": "prisma db seed",
     "prisma:sync-sequences": "npx tsx prisma/run-sync-sequences.ts",
     "test": "vitest run",
-    "test:integration": "RUN_API_INTEGRATION=1 vitest run --config vitest.integration.config.ts"
+    "test:integration": "RUN_API_INTEGRATION=1 vitest run --config vitest.integration.config.ts",
+    "check:openapi": "vitest run src/openapiDrift.test.ts src/utils/openapiRouteCollector.test.ts src/utils/apiRouteEndpoint.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/backend/src/openapiDrift.test.ts
+++ b/backend/src/openapiDrift.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { createApp } from './app';
+import {
+  diffRouteSets,
+  toRouteKeySet,
+} from './utils/apiRouteEndpoint';
+import { collectExpressRoutes } from './utils/expressRouteCollector';
+import {
+  collectOpenApiRoutes,
+  defaultOpenApiFilePath,
+} from './utils/openapiRouteCollector';
+
+vi.mock('./queues/receiptQueue', () => ({
+  RECEIPT_QUEUE_NAME: 'receipt-analysis',
+  receiptQueue: {
+    add: vi.fn(),
+  },
+}));
+
+describe('OpenAPI drift', () => {
+  let expressKeys: Set<string>;
+  let openApiKeys: Set<string>;
+
+  beforeAll(() => {
+    const openApiRoutes = collectOpenApiRoutes(defaultOpenApiFilePath());
+    openApiKeys = toRouteKeySet(openApiRoutes);
+
+    const app = createApp();
+    const probePaths = openApiRoutes.map((route) => route.path);
+    expressKeys = toRouteKeySet(
+      collectExpressRoutes(app, { mountProbePaths: probePaths })
+    );
+  });
+
+  it('implements every path documented in OpenAPI', () => {
+    const { missingInActual, extraInActual } = diffRouteSets(expressKeys, openApiKeys);
+
+    expect(
+      missingInActual,
+      `Express is missing OpenAPI endpoints:\n${missingInActual.join('\n')}`
+    ).toEqual([]);
+    expect(
+      extraInActual,
+      `Express has undocumented endpoints:\n${extraInActual.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/backend/src/utils/apiRouteEndpoint.test.ts
+++ b/backend/src/utils/apiRouteEndpoint.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  diffRouteSets,
+  normalizeRouteKey,
+  toRouteKeySet,
+} from './apiRouteEndpoint';
+
+describe('apiRouteEndpoint', () => {
+  it('normalizes Express and OpenAPI path params to the same key', () => {
+    expect(normalizeRouteKey('PATCH', '/api/receipts/items/:id')).toBe(
+      normalizeRouteKey('PATCH', '/api/receipts/items/{itemId}')
+    );
+  });
+
+  it('diffRouteSets reports missing and extra endpoints', () => {
+    const actual = toRouteKeySet([{ method: 'GET', path: '/api/receipts' }]);
+    const expected = toRouteKeySet([
+      { method: 'GET', path: '/api/receipts' },
+      { method: 'POST', path: '/api/receipts' },
+    ]);
+
+    expect(diffRouteSets(actual, expected)).toEqual({
+      missingInActual: ['POST /api/receipts'],
+      extraInActual: [],
+    });
+  });
+});

--- a/backend/src/utils/apiRouteEndpoint.ts
+++ b/backend/src/utils/apiRouteEndpoint.ts
@@ -1,0 +1,28 @@
+export type ApiRouteEndpoint = {
+  method: string;
+  path: string;
+};
+
+/** Express `:id` / OpenAPI `{itemId}` を同一視する正規化キー */
+export function normalizeRouteKey(method: string, path: string): string {
+  const normalizedPath = path
+    .replace(/:([A-Za-z0-9_]+)/g, '{}')
+    .replace(/\{[A-Za-z0-9_]+\}/g, '{}')
+    .replace(/\/+/g, '/')
+    .replace(/\/$/, '') || '/';
+
+  return `${method.toUpperCase()} ${normalizedPath}`;
+}
+
+export function toRouteKeySet(endpoints: ApiRouteEndpoint[]): Set<string> {
+  return new Set(endpoints.map((e) => normalizeRouteKey(e.method, e.path)));
+}
+
+export function diffRouteSets(
+  actual: Set<string>,
+  expected: Set<string>
+): { missingInActual: string[]; extraInActual: string[] } {
+  const missingInActual = [...expected].filter((key) => !actual.has(key)).sort();
+  const extraInActual = [...actual].filter((key) => !expected.has(key)).sort();
+  return { missingInActual, extraInActual };
+}

--- a/backend/src/utils/expressRouteCollector.ts
+++ b/backend/src/utils/expressRouteCollector.ts
@@ -1,0 +1,118 @@
+import type { Application, Router } from 'express';
+import type { ApiRouteEndpoint } from './apiRouteEndpoint';
+
+type RouterLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+  };
+  name?: string;
+  handle?: Router;
+  match?: (path: string) => boolean;
+  path?: string;
+};
+
+const DEFAULT_MOUNT_PROBE_PATHS = [
+  '/health',
+  '/api/auth/resolve-family',
+  '/api/auth/families/1/members',
+  '/api/admin/stats',
+  '/api/admin/prompts',
+  '/api/categories',
+  '/api/product-master',
+  '/api/stats/settlement',
+  '/api/receipts',
+  '/api/receipts/upload',
+  '/api/family-groups/members',
+  '/api/uploads/sample.webp',
+];
+
+function joinPaths(prefix: string, segment: string): string {
+  if (!segment || segment === '/') {
+    return prefix || '/';
+  }
+  const combined = `${prefix}${segment.startsWith('/') ? segment : `/${segment}`}`;
+  return combined.replace(/\/+/g, '/') || '/';
+}
+
+function resolveMountPrefix(
+  layer: RouterLayer,
+  prefix: string,
+  probePaths: string[]
+): string {
+  if (typeof layer.match !== 'function') return '';
+
+  let longest = '';
+  for (const fullProbe of probePaths) {
+    const relativeProbe =
+      prefix && fullProbe.startsWith(prefix)
+        ? fullProbe.slice(prefix.length) || '/'
+        : fullProbe;
+
+    layer.path = undefined;
+    if (layer.match(relativeProbe) && layer.path) {
+      if (layer.path.length > longest.length) {
+        longest = layer.path;
+      }
+    }
+  }
+  return longest;
+}
+
+function collectFromRouter(
+  router: Router,
+  prefix: string,
+  probePaths: string[]
+): ApiRouteEndpoint[] {
+  const stack = (router as unknown as { stack?: RouterLayer[] }).stack ?? [];
+  const endpoints: ApiRouteEndpoint[] = [];
+
+  for (const layer of stack) {
+    if (layer.route) {
+      const fullPath = joinPaths(prefix, layer.route.path);
+      for (const [method, enabled] of Object.entries(layer.route.methods)) {
+        if (!enabled || method === '_all') continue;
+        endpoints.push({ method: method.toUpperCase(), path: fullPath });
+      }
+      continue;
+    }
+
+    if (layer.name === 'router' && layer.handle) {
+      const mountSegment = resolveMountPrefix(layer, prefix, probePaths);
+      if (!mountSegment && mountSegment !== '') continue;
+      const nextPrefix = joinPaths(prefix, mountSegment);
+      endpoints.push(...collectFromRouter(layer.handle, nextPrefix, probePaths));
+    }
+  }
+
+  return endpoints;
+}
+
+export type CollectExpressRoutesOptions = {
+  mountProbePaths?: string[];
+};
+
+/** createApp() で登録された HTTP ルート一覧を収集する */
+export function collectExpressRoutes(
+  app: Application,
+  options?: CollectExpressRoutesOptions
+): ApiRouteEndpoint[] {
+  const probePaths = options?.mountProbePaths ?? DEFAULT_MOUNT_PROBE_PATHS;
+  const router = (app as unknown as { router?: Router }).router;
+  if (!router) return [];
+
+  const endpoints = collectFromRouter(router, '', probePaths);
+  const seen = new Set<string>();
+  const unique: ApiRouteEndpoint[] = [];
+
+  for (const endpoint of endpoints) {
+    const key = `${endpoint.method} ${endpoint.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(endpoint);
+  }
+
+  return unique.sort(
+    (a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method)
+  );
+}

--- a/backend/src/utils/openapiRouteCollector.test.ts
+++ b/backend/src/utils/openapiRouteCollector.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { collectOpenApiRoutes, defaultOpenApiFilePath } from './openapiRouteCollector';
+import { toRouteKeySet } from './apiRouteEndpoint';
+
+describe('openapiRouteCollector', () => {
+  it('loads public API paths from openapi.yaml', () => {
+    const routes = collectOpenApiRoutes(defaultOpenApiFilePath());
+    const keys = toRouteKeySet(routes);
+
+    expect(keys.has('GET /health')).toBe(true);
+    expect(keys.has('POST /api/auth/login')).toBe(true);
+    expect(keys.has('GET /api/receipts')).toBe(true);
+    expect(keys.has('POST /api/receipts/upload')).toBe(true);
+    expect(routes.length).toBeGreaterThan(30);
+  });
+});

--- a/backend/src/utils/openapiRouteCollector.ts
+++ b/backend/src/utils/openapiRouteCollector.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import type { ApiRouteEndpoint } from './apiRouteEndpoint';
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+function openApiPathToExpress(apiPath: string): string {
+  if (apiPath === '/health') return '/health';
+  return `/api${apiPath}`;
+}
+
+/** docs/openapi/openapi.yaml の paths から公開エンドポイントを抽出する */
+export function collectOpenApiRoutes(openApiFilePath: string): ApiRouteEndpoint[] {
+  const absolutePath = path.resolve(openApiFilePath);
+  const doc = fs.readFileSync(absolutePath, 'utf8');
+
+  const pathsStart = doc.indexOf('\npaths:\n');
+  if (pathsStart < 0) {
+    throw new Error('OpenAPI document is missing paths: section');
+  }
+
+  const componentsStart = doc.indexOf('\ncomponents:\n', pathsStart);
+  const pathsSection =
+    componentsStart > -1 ? doc.slice(pathsStart, componentsStart) : doc.slice(pathsStart);
+
+  const endpoints: ApiRouteEndpoint[] = [];
+  let currentApiPath: string | null = null;
+
+  for (const line of pathsSection.split('\n')) {
+    const pathMatch = line.match(/^  (\/[\w\-/{}]+):\s*$/);
+    if (pathMatch) {
+      currentApiPath = pathMatch[1];
+      continue;
+    }
+
+    const methodMatch = line.match(/^    (get|post|put|patch|delete):\s*$/);
+    if (methodMatch && currentApiPath) {
+      endpoints.push({
+        method: methodMatch[1].toUpperCase(),
+        path: openApiPathToExpress(currentApiPath),
+      });
+    }
+  }
+
+  return endpoints.sort(
+    (a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method)
+  );
+}
+
+export function defaultOpenApiFilePath(): string {
+  return path.resolve(__dirname, '../../../docs/openapi/openapi.yaml');
+}


### PR DESCRIPTION
## Summary
- `openapiRouteCollector` — `docs/openapi/openapi.yaml` から paths / methods を抽出
- `expressRouteCollector` — `createApp()` の Express 5 ルートを収集（マウントパスは OpenAPI paths をプローブに解決）
- `openapiDrift.test.ts` — 両者の正規化キー突合（パラメータ名の差異は `{}` に正規化）
- `npm run check:openapi` を backend に追加
- CI `test.yml` に `Verify OpenAPI route drift` ステップを追加（FE の `check:api` は既存）

## Test plan
- [x] `npm run check:openapi`（4 tests passed）
- [x] `npm test`（backend 全テストグリーン）
- [ ] OpenAPI に未記載のルート追加時に CI が fail すること
- [ ] OpenAPI のみ更新して実装未追随時に CI が fail すること

Closes #471

Made with [Cursor](https://cursor.com)