### PR TITLE
docs: [Issue #102-4] 新 API 追加時の運用ルールを文書化

### DIFF
--- a/docs/design/api-spec.md
+++ b/docs/design/api-spec.md
@@ -1,8 +1,8 @@
 # API 仕様書（As-built）
 
 Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)  
-子 Issue: [#294 Issue #90-3](https://github.com/yama180sx/receipt-ai-app/issues/294)  
-計画: [plan.md](./plan.md)
+子 Issue: [#294 Issue #90-3](https://github.com/yama180sx/receipt-ai-app/issues/294) / [#474 Issue #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474)  
+計画: [plan.md](../refactor/plan.md) §9
 
 本ドキュメントは **実装準拠（as-built）** で記述する。Express ルート・ミドルウェア・コントローラの挙動を正とし、ドメインルールは [domain-model.md](./domain-model.md)（#90-2）を参照する。
 
@@ -12,7 +12,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 |------|------|
 | [architecture.md](./architecture.md) | システム構成・ミドルウェア概要（#90-1） |
 | [domain-model.md](./domain-model.md) | 按分・精算の業務ルール（#90-2） |
-| [plan.md](./plan.md) §8 | API ドキュメント化スコープ（本書で詳細化） |
+| [plan.md](../refactor/plan.md) §9 | Epic #102 API 契約型 SSOT |
 
 ---
 
@@ -661,7 +661,81 @@ npm run test:integration
 
 ---
 
-## 9. 関連資料
+## 9. 新 API 追加手順（Epic #102 / #102-4）
+
+新規エンドポイント追加時は **OpenAPI を先に更新** し、FE/BE の型分散を防ぐ。契約の正本は [../openapi/openapi.yaml](../openapi/openapi.yaml)（[plan.md](../refactor/plan.md) §9）。
+
+### 9.1 原則
+
+| ルール | 内容 |
+|--------|------|
+| OpenAPI first | `docs/openapi/openapi.yaml` に path・request/response schema を先に書く |
+| DTO は generated | FE は `frontend/src/api/generated` を正とする（手動 interface で API レスポンスを再定義しない） |
+| BE は契約に追随 | Controller の JSON 形は OpenAPI schema と一致させる（ドメイン内部型は `backend/src/types/` に残してよい） |
+| drift 検知 | PR で `check:api` と `check:openapi` がグリーンであること |
+
+### 9.2 実装チェックリスト（人間・AI 共通）
+
+```
+1. [ ] docs/openapi/openapi.yaml に paths / components/schemas を追加・更新
+2. [ ] frontend で npm run generate:api を実行し schema.ts を更新
+3. [ ] 必要なら frontend/src/api/generated/index.ts にドメイン別エイリアスを追加
+4. [ ] backend: routes → controller → service を実装（レスポンス envelope は §2.2 準拠）
+5. [ ] frontend: src/api/* ラッパー → features/*/hooks から呼び出し
+6. [ ] ViewModel が必要なら frontend/src/types/ に追加（DTO 重複禁止）
+7. [ ] Mapper が必要なら frontend/src/mappers/ に追加
+8. [ ] 本書（api-spec.md）にエンドポイント説明を as-built 追記
+9. [ ] npm run check:api（frontend）がパス
+10. [ ] npm run check:openapi（backend）がパス
+11. [ ] npm test（frontend / backend）がパス
+```
+
+### 9.3 CI コマンド
+
+| コマンド | 実行場所 | 検証内容 |
+|----------|----------|----------|
+| `npm run generate:api` | `frontend/` | OpenAPI → `api/generated/schema.ts` 再生成 |
+| `npm run check:api` | `frontend/` | 生成物がコミット済みか（OpenAPI 変更の未反映を検知） |
+| `npm run check:openapi` | `backend/` | Express ルートと OpenAPI paths の突合（#102-1） |
+
+いずれも `.github/workflows/test.yml` の PR チェックに含まれる。
+
+### 9.4 型の置き場所（FE / BE）
+
+| 種別 | 正本 | 配置 |
+|------|------|------|
+| API 契約（DTO） | OpenAPI | `docs/openapi/openapi.yaml` → FE `api/generated/` |
+| FE ViewModel | 画面・フロー固有 | `frontend/src/types/`（generated の re-export + 拡張のみ） |
+| BE ドメイン型 | Gemini / commit 内部 | `backend/src/types/`（HTTP レスポンス型の二重定義は禁止） |
+
+詳細は [frontend-conventions.md](./frontend-conventions.md) §4.3、[architecture.md](./architecture.md) §4.5 を参照。
+
+### 9.5 AI プロンプト用チェックリスト
+
+```markdown
+## タスク
+{新 API / 既存 API 拡張の概要}
+
+## 契約（必須・OpenAPI first）
+- [ ] docs/openapi/openapi.yaml を先に更新した
+- [ ] npm run generate:api で FE 型を再生成した
+- [ ] FE DTO は api/generated のみ（types/ に API レスポンスの手動 interface を書いていない）
+- [ ] BE レスポンス JSON が OpenAPI schema と一致する
+
+## 実装
+- [ ] backend: routes → controller → service（envelope: success + data）
+- [ ] frontend: api/* ラッパー → features/*/hooks（Screen から api 直 import 禁止）
+- [ ] エラーは showApiErrorAlert / getApiErrorMessage（[frontend-conventions.md](docs/design/frontend-conventions.md)）
+
+## 完了条件
+- [ ] npm run check:api && npm run check:openapi がパス
+- [ ] npm test（frontend / backend）がパス
+- [ ] docs/design/api-spec.md に as-built 追記
+```
+
+---
+
+## 10. 関連資料
 
 - [domain-model.md](./domain-model.md) — 按分・精算ドメイン（#90-2）
 - [architecture.md](./architecture.md) — ミドルウェア・リクエストフロー（#90-1）

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,7 +1,7 @@
 # アーキテクチャ概要（As-built）
 
-Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276) / [#423 Issue #100](https://github.com/yama180sx/receipt-ai-app/issues/423) / [#459 Issue #101](https://github.com/yama180sx/receipt-ai-app/issues/459)  
-子 Issue: [#292 Issue #90-1](https://github.com/yama180sx/receipt-ai-app/issues/292) / [#439 Issue #100-15](https://github.com/yama180sx/receipt-ai-app/issues/439) / [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461)  
+Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276) / [#423 Issue #100](https://github.com/yama180sx/receipt-ai-app/issues/423) / [#459 Issue #101](https://github.com/yama180sx/receipt-ai-app/issues/459) / [#468 Issue #102](https://github.com/yama180sx/receipt-ai-app/issues/468)  
+子 Issue: [#292 Issue #90-1](https://github.com/yama180sx/receipt-ai-app/issues/292) / [#439 Issue #100-15](https://github.com/yama180sx/receipt-ai-app/issues/439) / [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461) / [#474 Issue #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474)  
 計画: [plan.md](../refactor/plan.md)
 
 本ドキュメントは **実装準拠（as-built）** で記述する。コード・テスト済み挙動を正とし、詳細なドメイン・API・画面仕様は後続の設計資料を参照する。
@@ -10,7 +10,8 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276) /
 |------|------|
 | [database-schema.md](./database-schema.md) | DB 列定義・制約 |
 | [domain-model.md](./domain-model.md) | ドメインモデル・業務ルール（#90-2） |
-| [api-spec.md](./api-spec.md) | API 仕様（#90-3） |
+| [api-spec.md](./api-spec.md) | API 仕様・**新 API 追加手順**（#90-3 / #102-4） |
+| [openapi.yaml](../openapi/openapi.yaml) | API 契約 SSOT（機械可読、#102） |
 | [ai-pipeline.md](./ai-pipeline.md) | 3層正規化・AI パイプライン（#90-4） |
 | [frontend-screens.md](./frontend-screens.md) | 画面遷移・フロント（#90-5） |
 | [frontend-conventions.md](./frontend-conventions.md) | FE 実装規約・AI プロンプト（#101-7） |
@@ -195,6 +196,36 @@ Prisma への直接アクセスは **Repository に集約** する。Service は
 
 テナントスコープは Prisma Client Extension（`$extends`）で Repository 内部から適用する。UseCase 物理層（`usecases/` フォルダ）は設けず、**Service メソッド = Application 操作** とする（[plan.md](../refactor/plan.md) §7）。
 
+### 4.5 API 契約型（OpenAPI SSOT / #102）
+
+Epic [#468 #102](https://github.com/yama180sx/receipt-ai-app/issues/468) に基づき、**公開 API の契約は OpenAPI YAML のみを正本** とする。FE/BE で手動に DTO を二重定義しない。
+
+```mermaid
+flowchart LR
+  OAS[docs/openapi/openapi.yaml]
+  GEN[frontend/api/generated]
+  FET[frontend/types ViewModel]
+  MAP[frontend/mappers]
+  CTRL[backend/controllers]
+  DOM[backend/types Domain]
+
+  OAS -->|openapi-typescript| GEN
+  GEN --> FET
+  GEN --> MAP
+  OAS -.->|整合| CTRL
+  DOM --> CTRL
+```
+
+| 層 | 正本 | 配置 | 備考 |
+|----|------|------|------|
+| API 契約（DTO） | OpenAPI | `docs/openapi/openapi.yaml` | FE 型は `npm run generate:api` で生成 |
+| FE ViewModel | 画面固有 | `frontend/src/types/` | generated の re-export + 拡張のみ |
+| FE Mapper | DTO → 表示用 | `frontend/src/mappers/` | — |
+| BE ドメイン型 | 内部モデル | `backend/src/types/` | `ParsedReceipt` 等。HTTP 形は OpenAPI に合わせる |
+| DB | Prisma | `backend/prisma/schema.prisma` | API DTO とは別層 |
+
+**新 API 追加**: [api-spec.md](./api-spec.md) **§9**（チェックリスト・CI コマンド・AI プロンプト）を正本とする。PR では `check:api`（FE generated diff）と `check:openapi`（BE ルート突合）が必須。
+
 ---
 
 ## 5. リクエストフロー
@@ -288,7 +319,7 @@ Expo Router（`frontend/app/`）によるファイルベースルーティング
 
 **状態管理**: `AppSessionProvider`（`features/app`）+ `ReceiptTrayProvider` + 各 Hook のローカル state。Redux / Zustand は未使用。
 
-**API 接続**: `frontend/src/api/*`（型付きラッパー）→ `apiClient.ts`（認証ヘッダ注入・403 通知）。Screen / Hook から `categoryApi` / `receiptApi` / `statsApi` を直接 import しない（#100-14）。
+**API 接続**: `frontend/src/api/*`（型付きラッパー）→ `apiClient.ts`（認証ヘッダ注入・403 通知）。DTO は [openapi.yaml](../openapi/openapi.yaml) 由来の `api/generated`（[api-spec.md](./api-spec.md) §9）。Screen / Hook から `categoryApi` / `receiptApi` / `statsApi` を直接 import しない（#100-14）。
 
 **Mapper**: API 生レスポンスの画面向け整形は `frontend/src/mappers/`（例: `statsMapper.ts`）。
 

--- a/docs/design/frontend-conventions.md
+++ b/docs/design/frontend-conventions.md
@@ -1,7 +1,7 @@
 # フロントエンド実装規約 & AI プロンプトテンプレート
 
-Epic: [#459 Issue #101](https://github.com/yama180sx/receipt-ai-app/issues/459)  
-子 Issue: [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461)  
+Epic: [#459 Issue #101](https://github.com/yama180sx/receipt-ai-app/issues/459) / [#468 Issue #102](https://github.com/yama180sx/receipt-ai-app/issues/468)  
+子 Issue: [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461) / [#474 Issue #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474)  
 計画: [plan.md](../refactor/plan.md) §8
 
 本ドキュメントは **新規実装・AI 駆動開発・コードレビュー** の正本とする。層の全体像は [architecture.md](./architecture.md) §6、画面一覧は [frontend-screens.md](./frontend-screens.md) を参照。
@@ -141,6 +141,17 @@ try {
 | ViewModel | 手動定義 | `frontend/src/types/`（generated の再 export + 画面拡張） |
 | 変換 | Mapper | `frontend/src/mappers/` |
 
+**新 API 追加時（#102-4）**
+
+1. `docs/openapi/openapi.yaml` を **先に** 更新する（契約 SSOT）
+2. `npm run generate:api` で `api/generated/schema.ts` を再生成する
+3. 必要なら `api/generated/index.ts` にエイリアスを追加する
+4. Hook は generated 型または `types/` の re-export を使う。**API レスポンスと同形の interface を `types/` に新規定義しない**
+5. 画面固有の入力中 state・表示用型のみ `types/` に置く（例: `ParsedReceiptData`, `ReceiptForSplitEditor`）
+6. PR 前に `npm run check:api`（generated diff）をパスする
+
+手順の正本: [api-spec.md](./api-spec.md) §9。
+
 - `any` / `as any` **禁止**。`unknown` + 型ガードまたは Zod 等で絞る
 - React Hook Form は **導入しない**（hook + `useState` で十分。Epic #101 Won't fix）
 
@@ -223,6 +234,30 @@ try {
 分割が必要な場合は具体的なファイル名案を提示してください。
 ```
 
+### 6.4 新 API 追加の実装依頼
+
+```markdown
+## タスク
+{新エンドポイント / 既存 API 拡張の概要}
+
+## 契約（OpenAPI first — [api-spec.md](docs/design/api-spec.md) §9 準拠）
+- [ ] docs/openapi/openapi.yaml を先に更新
+- [ ] npm run generate:api で FE 型を再生成
+- [ ] DTO は api/generated のみ。ViewModel は types/（API レスポンスの手動二重定義禁止）
+- [ ] BE レスポンス envelope（success + data）は OpenAPI schema と一致
+
+## 実装規約
+- backend: routes → controller → service
+- frontend: api/* ラッパー → features/*/hooks（Screen から api 直 import 禁止）
+- エラー: showApiErrorAlert / getApiErrorMessage
+- any / as any 禁止
+
+## 完了条件
+- [ ] npm run check:api && npm run check:openapi がパス
+- [ ] npm test（frontend / backend）がパス
+- [ ] api-spec.md に as-built 追記
+```
+
 ---
 
 ## 7. Epic #101 との対応
@@ -234,4 +269,4 @@ try {
 | `showApiErrorAlert` 横断適用 | #101-6 [#464](https://github.com/yama180sx/receipt-ai-app/issues/464) |
 | 本ドキュメント | #101-7 [#461](https://github.com/yama180sx/receipt-ai-app/issues/461) |
 
-Phase 5（API 契約 SSOT / BE Mapper）は Epic [#102](https://github.com/yama180sx/receipt-ai-app/issues/468) / [#103](https://github.com/yama180sx/receipt-ai-app/issues/469) で対応する。
+Phase 5（API 契約 SSOT / BE Mapper）は Epic [#102](https://github.com/yama180sx/receipt-ai-app/issues/468) / [#103](https://github.com/yama180sx/receipt-ai-app/issues/469) で対応する。新 API 手順は [#474 #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474) → [api-spec.md](./api-spec.md) §9。


### PR DESCRIPTION
## Summary
- `api-spec.md` §9 — OpenAPI first 手順、実装チェックリスト、CI コマンド、AI プロンプト
- `frontend-conventions.md` §4.3 拡充 + §6.4 新 API 追加用プロンプトテンプレート
- `architecture.md` §4.5 — API 契約型境界図・層責務表、api-spec §9 へのリンク

## Test plan
- [x] 各ドキュメントのリンク・Markdown 構造が正しいこと
- [ ] architecture.md → api-spec.md §9 から手順を辿れること
- [ ] AI プロンプトに check:api / check:openapi が含まれること

Closes #474

Made with [Cursor](https://cursor.com)