### PR TITLE
refactor(fe): [Issue #102-2] 手動型を監査し DTO を generated に寄せる

### DIFF
--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -37,6 +37,9 @@ export type ItemSplitInput = Schemas['ItemSplitInput'];
 // --- stats ---
 export type MonthlyStatsData = Schemas['MonthlyStatsData'];
 export type AdvancedStatsData = Schemas['AdvancedStatsData'];
+export type CategoryStatRow = Schemas['CategoryStatRow'];
+export type TrendRow = Schemas['TrendRow'];
+export type ParetoRow = Schemas['ParetoRow'];
 export type SettlementStatusData = Schemas['SettlementStatusData'];
 export type SettlementMemberSummary = Schemas['SettlementMemberSummary'];
 export type SettlementTransfer = Schemas['SettlementTransfer'];

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,8 @@
 export type { ApiSuccessResponse, ApiMessageResponse } from './generated';
 export { authApi } from './authApi';
 export { receiptApi } from './receiptApi';
-export type { CommitReceiptPayload, ItemSplitSaveRequest, ListReceiptsParams } from './receiptApi';
+export type { CommitReceiptPayload, ListReceiptsParams } from './receiptApi';
+export type { ItemSplitInput } from './generated';
 export { categoryApi } from './categoryApi';
 export type { Category, CreateCategoryRequest, OptimizeCategoryResponse } from './categoryApi';
 export { productMasterApi } from './productMasterApi';

--- a/frontend/src/api/receiptApi.ts
+++ b/frontend/src/api/receiptApi.ts
@@ -1,10 +1,10 @@
 import apiClient from '../utils/apiClient';
 import type { ParsedReceiptData } from '../types/receipt';
-import type { ItemSplitSavePayload } from '../types/settlement';
 import type {
   ApiMessageResponse,
   ApiSuccessResponse,
   FamilyMemberSummary,
+  ItemSplitInput,
   ItemSplitSummary,
   ReceiptDetail,
   ReceiptItemDetail,
@@ -22,10 +22,6 @@ export type CommitReceiptPayload = {
   parsedData: ParsedReceiptData & { totalAmount: number; taxAmount: number };
   imagePath: string;
   validation: { isSuspicious: boolean; warnings: string[] };
-};
-
-export type ItemSplitSaveRequest = ItemSplitSavePayload & {
-  ratio?: number;
 };
 
 export type ReceiptJobStatusResponse = ApiSuccessResponse<ReceiptJobStatus>;
@@ -95,7 +91,7 @@ export const receiptApi = {
 
   async saveItemSplits(
     itemId: number,
-    splits: ItemSplitSaveRequest[]
+    splits: ItemSplitInput[]
   ): Promise<ApiSuccessResponse<ItemSplitSummary[] | { message: string }>> {
     const res = await apiClient.post(`/receipts/items/${itemId}/splits`, { splits });
     return res.data;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,3 +1,11 @@
+/**
+ * 認証ドメイン型
+ *
+ * - DTO: OpenAPI generated の re-export
+ * - ViewModel: ログイン結果・永続セッション（OpenAPI 非該当）
+ */
+
+/** OpenAPI DTO（auth API） */
 export type {
   ResolvedFamily,
   AuthFamilyMember,
@@ -7,11 +15,13 @@ export type {
 } from '../api/generated';
 import type { LoginMember } from '../api/generated';
 
+/** ログイン成功後のクライアント保持データ（ViewModel） */
 export type LoginResult = {
   token: string;
   member: LoginMember;
 };
 
+/** AsyncStorage 等に保存するセッション（ViewModel） */
 export type StoredSession = {
   token: string;
   memberId: number;

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -1,36 +1,27 @@
 /**
- * [Issue #67 / #71 / #63] レシート入力用インターフェース
- * - price, quantity, taxAmount は小数を許容。
- * - totalAmount は JPY の整合性のため整数を想定。
+ * レシートドメイン型
+ *
+ * - DTO: OpenAPI generated の re-export
+ * - ViewModel: 手動登録・commit 前編集（OpenAPI 非該当）
  */
+
+/** 手動登録フォーム入力（ViewModel — OpenAPI 非該当） */
 export interface ReceiptInput {
   storeName: string;
-  date: Date | string;    // API通信を考慮し string も許容
-  totalAmount: number;    // 最終支払額（四捨五入済みの整数値）
-  
-  /**
-   * [Issue #71] 外付けの消費税額
-   * 小計後に加算される税額を保持。内税のみの場合は 0 を想定。
-   */
-  taxAmount: number;      
-  
-  memberId: number;       // 既存ロジック (receiptRoutes/Controller) との名称統合
-  
-  /**
-   * [Issue #63] Gemini API トークンログID
-   * AI解析経由での保存時に、コストトレーサビリティを確保するため保持。手動登録時は undefined。
-   */
-  usageLogId?: number;    
-
+  date: Date | string;
+  totalAmount: number;
+  taxAmount: number;
+  memberId: number;
+  usageLogId?: number;
   items: {
     name: string;
-    price: number;        // 小数許容 (ガソリン単価 165.8 等)
-    quantity: number;     // 小数許容 (0.5個、1.25L 等)
+    price: number;
+    quantity: number;
     categoryId?: number | null;
   }[];
 }
 
-/** OpenAPI 生成 DTO（docs/openapi/openapi.yaml） */
+/** OpenAPI DTO（receipt API） */
 export type {
   CategorySummary,
   ItemSplitSummary,
@@ -38,7 +29,7 @@ export type {
   ReceiptDetail,
 } from '../api/generated';
 
-/** commit 前の編集用明細（UI 入力中は string 許容） */
+/** commit 前の編集用明細（ViewModel — UI 入力中は string 許容） */
 export interface ParsedReceiptItemInput {
   name: string;
   price: number | string;
@@ -46,7 +37,7 @@ export interface ParsedReceiptItemInput {
   categoryId: number | null;
 }
 
-/** commit 前の parsedData（api-spec §5.3） */
+/** commit 前の parsedData（ViewModel — api-spec §5.3 準拠、OpenAPI CommitReceiptRequest とは別） */
 export interface ParsedReceiptData {
   storeName: string;
   purchaseDate: string;

--- a/frontend/src/types/receiptJob.ts
+++ b/frontend/src/types/receiptJob.ts
@@ -1,5 +1,14 @@
+/**
+ * レシート解析ジョブ型
+ *
+ * - DTO: OpenAPI generated の re-export
+ * - ViewModel: トレイ表示・ローカル失敗行（OpenAPI 非該当）
+ */
+
+/** OpenAPI DTO（receipt jobs API） */
 export type { ReceiptJobListItem } from '../api/generated';
 
+/** BullMQ 状態の UI 表示用（ViewModel — API state 文字列のサブセット） */
 export type ReceiptJobState =
   | 'waiting'
   | 'active'
@@ -8,7 +17,7 @@ export type ReceiptJobState =
   | 'delayed'
   | 'paused';
 
-/** アップロード失敗など、サーバーにジョブが無いローカル行 */
+/** アップロード失敗など、サーバーにジョブが無いローカル行（ViewModel） */
 export type LocalFailedReceiptJob = {
   id: string;
   state: 'failed';
@@ -17,4 +26,5 @@ export type LocalFailedReceiptJob = {
   localOnly: true;
 };
 
+/** トレイ一覧の行（DTO またはローカル失敗 ViewModel） */
 export type ReceiptTrayItem = import('../api/generated').ReceiptJobListItem | LocalFailedReceiptJob;

--- a/frontend/src/types/receiptScan.ts
+++ b/frontend/src/types/receiptScan.ts
@@ -1,5 +1,24 @@
+/**
+ * レシートスキャン（解析結果確認）型
+ *
+ * - ViewModel のみ（OpenAPI 非該当）
+ * - 入力の ReceiptJobStatus（DTO）は api/generated を使用
+ */
+
+import type { ReceiptJobStatus } from '../api/generated';
 import type { ParsedReceiptData } from './receipt';
 
+/** 解析完了ジョブの result 内部 shape（ViewModel — OpenAPI result は汎用 object） */
+export type ReceiptJobCompletedResult = {
+  parsedData?: ParsedReceiptData;
+  imagePath?: string;
+  validation?: {
+    isSuspicious: boolean;
+    warnings: string[];
+  };
+};
+
+/** スキャン画面の初期データ（ViewModel） */
 export type ReceiptScanInitialData = {
   parsedData: ParsedReceiptData;
   imagePath: string;
@@ -13,29 +32,26 @@ export type ReceiptScanInitialData = {
   warnedDuplicateFromTray?: boolean;
 };
 
-type JobStatusResponse = {
-  state: string;
-  result?: {
-    parsedData?: ParsedReceiptData;
-    imagePath?: string;
-    validation?: ReceiptScanInitialData['validation'];
-  };
-  duplicateSuspected?: boolean;
-  existingReceiptId?: number | null;
-};
+function parseJobResult(
+  result: ReceiptJobStatus['result']
+): ReceiptJobCompletedResult | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  return result as ReceiptJobCompletedResult;
+}
 
 export function buildScanInitialDataFromJobStatus(
   jobId: string,
-  payload: JobStatusResponse
+  payload: ReceiptJobStatus
 ): ReceiptScanInitialData | null {
-  if (payload.state !== 'completed' || !payload.result?.parsedData || !payload.result.imagePath) {
+  const result = parseJobResult(payload.result);
+  if (payload.state !== 'completed' || !result?.parsedData || !result.imagePath) {
     return null;
   }
 
   return {
-    parsedData: payload.result.parsedData,
-    imagePath: payload.result.imagePath,
-    validation: payload.result.validation ?? { isSuspicious: false, warnings: [] },
+    parsedData: result.parsedData,
+    imagePath: result.imagePath,
+    validation: result.validation ?? { isSuspicious: false, warnings: [] },
     jobId,
     duplicateSuspected: Boolean(payload.duplicateSuspected),
     existingReceiptId: payload.existingReceiptId ?? null,

--- a/frontend/src/types/settlement.ts
+++ b/frontend/src/types/settlement.ts
@@ -1,17 +1,25 @@
-/** OpenAPI 生成 DTO（精算 API） */
+/**
+ * 精算・割勘ドメイン型
+ *
+ * - DTO: OpenAPI generated の re-export
+ * - ViewModel: 割勘エディタ用の画面固有型（OpenAPI 非該当）
+ */
+
+import type { ItemSplitSummary } from '../api/generated';
+
+/** OpenAPI DTO（settlement / receipt API） */
 export type {
   FamilyMemberSummary,
+  ItemSplitInput,
   SettlementMemberSummary,
   SettlementStatusData,
   SettlementTransfer,
 } from '../api/generated';
 
-export type ItemSplitRecord = {
-  familyMemberId: number;
-  amount: number;
-};
+/** 割勘エディタ上の按分レコード（ViewModel — ItemSplitSummary の表示用部分型） */
+export type ItemSplitRecord = Pick<ItemSplitSummary, 'familyMemberId' | 'amount'>;
 
-/** 割り勘エディタで扱うレシート明細 */
+/** 割り勘エディタで扱うレシート明細（ViewModel） */
 export type ReceiptItemForSplit = {
   id: number;
   name?: string;
@@ -20,16 +28,11 @@ export type ReceiptItemForSplit = {
   splits?: ItemSplitRecord[];
 };
 
-/** 履歴から渡される割り勘対象レシート */
+/** 履歴から渡される割り勘対象レシート（ViewModel） */
 export type ReceiptForSplitEditor = {
   id: number;
   memberId: number;
   imagePath?: string | null;
   storeName?: string;
   items: ReceiptItemForSplit[];
-};
-
-export type ItemSplitSavePayload = {
-  familyMemberId: number;
-  amount: number;
 };

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,6 +1,22 @@
+/**
+ * 統計ドメイン型
+ *
+ * - DTO: OpenAPI generated の re-export（Mapper 入力）
+ * - ViewModel: 画面表示用（Mapper 出力）
+ */
+
 import type { Category, ReceiptDetail } from '../api/generated';
 
-/** 画面表示用カテゴリ（セレクト等） */
+/** OpenAPI DTO（stats API）— Mapper 入力 */
+export type {
+  AdvancedStatsData,
+  CategoryStatRow,
+  MonthlyStatsData,
+  ParetoRow,
+  TrendRow,
+} from '../api/generated';
+
+/** 画面表示用カテゴリ（ViewModel） */
 export type StatsCategoryOption = Pick<Category, 'id' | 'name' | 'color'>;
 
 /** 月次カテゴリ別統計行（ViewModel） */
@@ -42,12 +58,3 @@ export type AdvancedStatsViewModel = {
   trend: TrendStatItem[];
   pareto: ParetoStatItem[];
 };
-
-/** OpenAPI DTO 再 export（Mapper 入力用） */
-export type {
-  AdvancedStatsData,
-  CategoryStatRow,
-  MonthlyStatsData,
-  ParetoRow,
-  TrendRow,
-} from '../api/generated';

--- a/frontend/src/utils/splitEditorSplits.ts
+++ b/frontend/src/utils/splitEditorSplits.ts
@@ -1,4 +1,4 @@
-import type { ItemSplitSavePayload } from '../types/settlement';
+import type { ItemSplitInput } from '../api/generated';
 
 /** 明細の税込小計（Backend の calcItemLineTotal と同じ丸め） */
 export function calcItemTotal(item: {
@@ -21,7 +21,7 @@ export function buildItemSplitSavePayload(
   activeMembers: SplitSaveMember[],
   amountsByMemberId: Record<number, number>,
   remainderMemberId: number
-): ItemSplitSavePayload[] {
+): ItemSplitInput[] {
   if (activeMembers.length === 0) return [];
 
   const others = activeMembers.filter((m) => m.id !== remainderMemberId);


### PR DESCRIPTION
## Summary
- `types/*.ts` 全ファイルに DTO / ViewModel の役割をファイルコメントで明記
- `ItemSplitSavePayload` を廃止し `ItemSplitInput`（OpenAPI generated）に統一
- `ItemSplitRecord` を `Pick<ItemSplitSummary, ...>` に変更（DTO 重複排除）
- `receiptScan.ts` の `JobStatusResponse` を `ReceiptJobStatus`（generated）に置換
- `generated/index.ts` に `CategoryStatRow` / `TrendRow` / `ParetoRow` エイリアスを追加

## Test plan
- [x] `npm test`（frontend 56 tests passed）
- [x] `npm run check:api` がパス
- [ ] 割勘保存・スキャン画面・統計画面が従来通り動作すること

Closes #472

Made with [Cursor](https://cursor.com)