### PR TITLE
refactor(be): [Issue #102-3] BE API DTO を OpenAPI 契約型に整合

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "prisma:sync-sequences": "npx tsx prisma/run-sync-sequences.ts",
     "test": "vitest run",
     "test:integration": "RUN_API_INTEGRATION=1 vitest run --config vitest.integration.config.ts",
-    "check:openapi": "vitest run src/openapiDrift.test.ts src/utils/openapiRouteCollector.test.ts src/utils/apiRouteEndpoint.test.ts"
+    "check:openapi": "vitest run src/openapiDrift.test.ts src/utils/openapiRouteCollector.test.ts src/utils/apiRouteEndpoint.test.ts src/types/apiSchemas.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -10,6 +10,7 @@ import {
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
+import type { ReceiptJobStatus } from '../types/apiSchemas';
 import { commitReceipt as commitReceiptService } from '../services/receipt/receiptCommitService';
 import { createManualReceipt } from '../services/receipt/receiptUpdateService';
 import {
@@ -38,11 +39,14 @@ export const getJobStatus = async (req: Request<{ jobId: string }>, res: Respons
     }
 
     const state = await job.getState();
-    let data: Record<string, unknown> = {
-      id: job.id,
+    let data: ReceiptJobStatus = {
+      id: String(job.id),
       state,
-      result: job.returnvalue,
-      error: job.failedReason,
+      result:
+        job.returnvalue && typeof job.returnvalue === 'object'
+          ? (job.returnvalue as Record<string, unknown>)
+          : undefined,
+      error: job.failedReason ?? undefined,
     };
     data = await enrichCompletedJobPayload(job, familyGroupId, data);
 

--- a/backend/src/services/receiptJobService.ts
+++ b/backend/src/services/receiptJobService.ts
@@ -2,32 +2,12 @@ import type { Job } from 'bullmq';
 import fs from 'fs/promises';
 import path from 'path';
 import { receiptQueue } from '../queues/receiptQueue';
+import type { ReceiptJobListItem, ReceiptJobStatus } from '../types/apiSchemas';
 import { checkDuplicateReceipt } from './duplicateReceiptService';
 import { findReceiptIdByImagePath } from '../repositories/receiptRepository';
 import { AppError } from '../utils/appError';
 
 const LIST_JOB_STATES = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused'] as const;
-
-export type ReceiptJobListItem = {
-  id: string;
-  state: string;
-  imagePath: string | null;
-  createdAt: number;
-  failedReason?: string | null;
-  parsedData?: {
-    storeName: string;
-    purchaseDate: string;
-    totalAmount: number;
-    taxAmount?: number;
-    itemCount: number;
-  };
-  validation?: {
-    isSuspicious: boolean;
-    warnings: string[];
-  };
-  duplicateSuspected?: boolean;
-  existingReceiptId?: number;
-};
 
 type AnalyzeJobReturn = {
   parsedData?: {
@@ -121,9 +101,9 @@ export async function listReceiptJobsForMember(
 export async function enrichCompletedJobPayload(
   job: Job,
   familyGroupId: number,
-  payload: Record<string, unknown>
-): Promise<Record<string, unknown>> {
-  const state = payload.state as string;
+  payload: ReceiptJobStatus
+): Promise<ReceiptJobStatus> {
+  const state = payload.state;
   if (state !== 'completed' || !job.returnvalue) {
     return payload;
   }
@@ -142,7 +122,7 @@ export async function enrichCompletedJobPayload(
   return {
     ...payload,
     duplicateSuspected: duplicate.duplicateSuspected,
-    existingReceiptId: duplicate.existingReceiptId,
+    existingReceiptId: duplicate.existingReceiptId ?? null,
   };
 }
 

--- a/backend/src/types/apiResponse.ts
+++ b/backend/src/types/apiResponse.ts
@@ -1,0 +1,12 @@
+/**
+ * 標準 API レスポンス envelope（OpenAPI ApiSuccessEnvelope / ApiMessageEnvelope）
+ */
+export type ApiSuccessResponse<T> = {
+  success: true;
+  data: T;
+};
+
+export type ApiMessageResponse = {
+  success: true;
+  message: string;
+};

--- a/backend/src/types/apiSchemas.test.ts
+++ b/backend/src/types/apiSchemas.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { API_SCHEMA_EXPORTS } from './apiSchemas';
+import {
+  collectOpenApiSchemaNames,
+  defaultOpenApiFilePath,
+} from '../utils/openapiSchemaCollector';
+
+describe('apiSchemas', () => {
+  it('exports only schema names that exist in openapi.yaml', () => {
+    const openApiNames = new Set(collectOpenApiSchemaNames(defaultOpenApiFilePath()));
+    const missing = API_SCHEMA_EXPORTS.filter((name) => !openApiNames.has(name));
+
+    expect(
+      missing,
+      `apiSchemas.ts references schemas missing from OpenAPI:\n${missing.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/backend/src/types/apiSchemas.ts
+++ b/backend/src/types/apiSchemas.ts
@@ -1,0 +1,269 @@
+/**
+ * OpenAPI 契約 DTO（docs/openapi/openapi.yaml が正本）
+ *
+ * FE の frontend/src/api/generated と同型を維持する。
+ * 変更時は openapi.yaml → FE generate:api → 本ファイルの突合（apiSchemas.test.ts）の順。
+ *
+ * ドメイン内部型（Gemini 解析等）は types/receipt.ts を使用すること。
+ */
+
+// --- auth ---
+export type ResolvedFamily = {
+  id: number;
+  name: string;
+  inviteCode: string;
+};
+
+export type AuthFamilyMember = {
+  id: number;
+  name: string;
+};
+
+export type LoginMember = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: string;
+  totpEnabled?: boolean;
+};
+
+export type LoginResponse = {
+  token: string | null;
+  pendingToken: string | null;
+  member: LoginMember;
+  requiresTotpVerification: boolean;
+  requiresTotpSetup: boolean;
+};
+
+export type TotpSetupInfo = {
+  secret: string;
+  otpauthUrl: string;
+};
+
+// --- receipt ---
+export type CategorySummary = {
+  id: number;
+  name: string;
+  color?: string | null;
+};
+
+export type ItemSplitSummary = {
+  id: number;
+  itemId: number;
+  familyMemberId: number;
+  amount: number;
+};
+
+export type ReceiptItemDetail = {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+  categoryId: number | null;
+  category?: CategorySummary | null;
+  splits?: ItemSplitSummary[];
+};
+
+export type ReceiptDetail = {
+  id: number;
+  storeName: string;
+  date?: string;
+  totalAmount: number;
+  taxAmount?: number;
+  imagePath?: string | null;
+  memberId?: number;
+  familyGroupId?: number;
+  items: ReceiptItemDetail[];
+};
+
+export type ReceiptValidation = {
+  isSuspicious: boolean;
+  warnings: string[];
+};
+
+export type ReceiptJobListItem = {
+  id: string;
+  state: string;
+  imagePath: string | null;
+  createdAt: number;
+  failedReason?: string | null;
+  parsedData?: {
+    storeName: string;
+    purchaseDate: string;
+    totalAmount: number;
+    taxAmount?: number;
+    itemCount: number;
+  };
+  validation?: ReceiptValidation;
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number;
+};
+
+export type ReceiptJobStatus = {
+  id: string;
+  state: string;
+  result?: Record<string, unknown>;
+  error?: string;
+  duplicateSuspected?: boolean;
+  existingReceiptId?: number | null;
+};
+
+export type UploadJobResponse = {
+  jobId: string;
+  status?: string;
+};
+
+export type ItemSplitInput = {
+  familyMemberId: number;
+  ratio?: number;
+  amount?: number;
+};
+
+export type FamilyMemberSummary = {
+  id: number;
+  name: string;
+};
+
+// --- stats ---
+export type CategoryStatRow = {
+  categoryId?: number | null;
+  categoryName?: string;
+  totalAmount?: number | string;
+  color?: string | null;
+};
+
+export type MonthlyStatsData = {
+  month: string;
+  totalAmount: number;
+  stats: CategoryStatRow[];
+  latestReceipt: ReceiptDetail | null;
+};
+
+export type TrendRow = {
+  period: string;
+  total: number;
+  prev_total?: number | null;
+};
+
+export type ParetoRow = {
+  name: string;
+  amount: number | string;
+  ratio: number | string;
+  cumulative_ratio: number | string;
+};
+
+export type AdvancedStatsData = {
+  trend: TrendRow[];
+  pareto: ParetoRow[];
+};
+
+export type SettlementMemberSummary = {
+  memberId: number;
+  name: string;
+  paidAmount: number;
+  owedAmount: number;
+  balance: number;
+};
+
+export type SettlementTransfer = {
+  id: number;
+  month: string;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  settledAt: string;
+};
+
+export type SettlementStatusData = {
+  members: SettlementMemberSummary[];
+  transfers: SettlementTransfer[];
+};
+
+// --- category ---
+export type Category = {
+  id: number;
+  name: string;
+  color: string | null;
+  keywords: string[];
+};
+
+export type OptimizeCategoryResponse = {
+  message: string;
+  updatedCount?: number;
+};
+
+// --- productMaster ---
+export type ProductMaster = {
+  id: number;
+  name: string;
+  storeName: string | null;
+  categoryId: number | null;
+  category?: CategorySummary | null;
+};
+
+export type MergeStoreNamesResponse = {
+  updatedCount: number;
+};
+
+// --- admin ---
+export type PromptTemplate = {
+  id: number;
+  name: string;
+  description: string | null;
+  systemPrompt: string;
+  domainHints: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminCostStatRow = {
+  month: string;
+  modelId: string;
+  totalPromptTokens: number;
+  totalCandidatesTokens: number;
+  estimatedCostJpy: number;
+};
+
+// --- health ---
+export type HealthResponse = {
+  status: string;
+  env?: string;
+  timestamp?: string;
+};
+
+/** OpenAPI components/schemas に存在すべき公開 DTO 名（ドリフト検知用） */
+export const API_SCHEMA_EXPORTS = [
+  'ResolvedFamily',
+  'AuthFamilyMember',
+  'LoginMember',
+  'LoginResponse',
+  'TotpSetupInfo',
+  'CategorySummary',
+  'ItemSplitSummary',
+  'ReceiptItemDetail',
+  'ReceiptDetail',
+  'ReceiptValidation',
+  'ReceiptJobListItem',
+  'ReceiptJobStatus',
+  'UploadJobResponse',
+  'ItemSplitInput',
+  'FamilyMemberSummary',
+  'CategoryStatRow',
+  'MonthlyStatsData',
+  'TrendRow',
+  'ParetoRow',
+  'AdvancedStatsData',
+  'SettlementMemberSummary',
+  'SettlementTransfer',
+  'SettlementStatusData',
+  'Category',
+  'OptimizeCategoryResponse',
+  'ProductMaster',
+  'MergeStoreNamesResponse',
+  'PromptTemplate',
+  'AdminCostStatRow',
+  'HealthResponse',
+] as const;
+
+export type ApiSchemaExportName = (typeof API_SCHEMA_EXPORTS)[number];

--- a/backend/src/types/receipt.ts
+++ b/backend/src/types/receipt.ts
@@ -1,6 +1,8 @@
 /**
- * レシートドメイン型（Issue #98-2）
- * Gemini 解析出力・commit/save 経路の共通型。api-spec §5.3 と整合。
+ * レシートドメイン内部型（Issue #98-2 / #102-3）
+ *
+ * Gemini 解析・commit 入力・重複チェック等の **アプリケーション内部** 型。
+ * HTTP レスポンス DTO は types/apiSchemas.ts（OpenAPI 契約）を正とする。
  */
 
 /** Gemini 解析出力の明細 */

--- a/backend/src/utils/openapiSchemaCollector.ts
+++ b/backend/src/utils/openapiSchemaCollector.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+/** docs/openapi/openapi.yaml の components/schemas 名一覧を抽出する */
+export function collectOpenApiSchemaNames(openApiFilePath: string): string[] {
+  const absolutePath = path.resolve(openApiFilePath);
+  const doc = fs.readFileSync(absolutePath, 'utf8');
+
+  const schemasStart = doc.indexOf('\n  schemas:\n');
+  if (schemasStart < 0) {
+    throw new Error('OpenAPI document is missing components/schemas section');
+  }
+
+  const names: string[] = [];
+  const section = doc.slice(schemasStart);
+  for (const line of section.split('\n')) {
+    const match = line.match(/^    ([A-Za-z0-9]+):\s*$/);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+
+  return names;
+}
+
+export function defaultOpenApiFilePath(): string {
+  return path.resolve(__dirname, '../../../docs/openapi/openapi.yaml');
+}

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,7 +1,7 @@
 # アーキテクチャ概要（As-built）
 
 Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276) / [#423 Issue #100](https://github.com/yama180sx/receipt-ai-app/issues/423) / [#459 Issue #101](https://github.com/yama180sx/receipt-ai-app/issues/459) / [#468 Issue #102](https://github.com/yama180sx/receipt-ai-app/issues/468)  
-子 Issue: [#292 Issue #90-1](https://github.com/yama180sx/receipt-ai-app/issues/292) / [#439 Issue #100-15](https://github.com/yama180sx/receipt-ai-app/issues/439) / [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461) / [#474 Issue #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474)  
+子 Issue: [#292 Issue #90-1](https://github.com/yama180sx/receipt-ai-app/issues/292) / [#439 Issue #100-15](https://github.com/yama180sx/receipt-ai-app/issues/439) / [#461 Issue #101-7](https://github.com/yama180sx/receipt-ai-app/issues/461) / [#474 Issue #102-4](https://github.com/yama180sx/receipt-ai-app/issues/474) / [#473 Issue #102-3](https://github.com/yama180sx/receipt-ai-app/issues/473)  
 計画: [plan.md](../refactor/plan.md)
 
 本ドキュメントは **実装準拠（as-built）** で記述する。コード・テスト済み挙動を正とし、詳細なドメイン・API・画面仕様は後続の設計資料を参照する。
@@ -206,22 +206,26 @@ flowchart LR
   GEN[frontend/api/generated]
   FET[frontend/types ViewModel]
   MAP[frontend/mappers]
+  APISCH[backend/types/apiSchemas]
   CTRL[backend/controllers]
-  DOM[backend/types Domain]
+  DOM[backend/types/receipt]
 
   OAS -->|openapi-typescript| GEN
   GEN --> FET
   GEN --> MAP
-  OAS -.->|整合| CTRL
+  OAS -.->|手動同期| APISCH
+  APISCH --> CTRL
   DOM --> CTRL
 ```
 
 | 層 | 正本 | 配置 | 備考 |
 |----|------|------|------|
-| API 契約（DTO） | OpenAPI | `docs/openapi/openapi.yaml` | FE 型は `npm run generate:api` で生成 |
+| API 契約（DTO） | OpenAPI | `docs/openapi/openapi.yaml` | FE: `generate:api` / BE: `types/apiSchemas.ts` |
 | FE ViewModel | 画面固有 | `frontend/src/types/` | generated の re-export + 拡張のみ |
 | FE Mapper | DTO → 表示用 | `frontend/src/mappers/` | — |
-| BE ドメイン型 | 内部モデル | `backend/src/types/` | `ParsedReceipt` 等。HTTP 形は OpenAPI に合わせる |
+| BE API DTO | OpenAPI 契約ミラー | `backend/src/types/apiSchemas.ts` | `apiSchemas.test.ts` で schema 名を検証（#102-3） |
+| BE ドメイン型 | 内部モデル | `backend/src/types/receipt.ts` 等 | `ParsedReceipt` 等。HTTP レスポンスは apiSchemas を使用 |
+| BE Express 拡張 | リクエストコンテキスト | `backend/src/types/express.d.ts` | `req.user` 等 |
 | DB | Prisma | `backend/prisma/schema.prisma` | API DTO とは別層 |
 
 **新 API 追加**: [api-spec.md](./api-spec.md) **§9**（チェックリスト・CI コマンド・AI プロンプト）を正本とする。PR では `check:api`（FE generated diff）と `check:openapi`（BE ルート突合）が必須。


### PR DESCRIPTION
## Summary
- `backend/src/types/apiSchemas.ts` を新設（OpenAPI components/schemas の BE ミラー）
- `apiSchemas.test.ts` — エクスポート名が openapi.yaml に存在することを検証
- `receiptJobService` の手動 `ReceiptJobListItem` を apiSchemas へ移行
- `getJobStatus` / `enrichCompletedJobPayload` を `ReceiptJobStatus` 型で統一
- `types/receipt.ts` をドメイン内部型と明記（API DTO は apiSchemas）
- `architecture.md` §4.5 を更新（apiSchemas / receipt の層責務）

## 判断記録（spec vs 実装）
- OpenAPI `ReceiptJobStatus.result` は `additionalProperties: true` のため、BE では `Record<string, unknown>` を維持（実装の柔軟性優先）
- `authService` の `AuthMemberDto` は内部整形用として残置（`LoginMember` と同形。全面置換は #103 Mapper 層で検討）

## Test plan
- [x] `npm test`（backend 48 tests passed）
- [x] `npm run check:openapi` に apiSchemas テストを含む
- [ ] ジョブステータス取得・トレイ一覧が従来通り動作すること

Closes #473

Made with [Cursor](https://cursor.com)