### PR TITLE
Issue #103-4: エラーハンドリング責務の一本化

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -1,8 +1,8 @@
-import { Request, Response, NextFunction } from 'express';
-import logger from '../utils/logger';
 import { AppError } from '../utils/appError';
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendMessage, sendSuccess } from '../utils/sendApiResponse';
 import {
   listPromptTemplates,
   createPromptTemplate,
@@ -12,77 +12,44 @@ import {
   getAdminCostStats,
 } from '../services/admin/adminService';
 
-export const getPrompts = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const prompts = await listPromptTemplates(requireTenantContext());
-    res.json({ success: true, data: prompts });
-  } catch (error) {
-    logger.error(`[AdminAPI] getPrompts Error: ${error}`);
-    next(new AppError('プロンプトの取得に失敗しました', 500));
-  }
-};
-
-export const createPrompt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const newPrompt = await createPromptTemplate(requireTenantContext(), req.body);
-    res.json({ success: true, data: newPrompt });
-  } catch (error) {
-    logger.error(`[AdminAPI] createPrompt Error: ${error}`);
-    next(error instanceof AppError ? error : new AppError('プロンプトの作成に失敗しました', 500));
-  }
-};
-
-export const updatePrompt = async (req: Request, res: Response, next: NextFunction) => {
+function parsePromptId(req: Parameters<typeof getRouteParam>[0]): number {
   const id = getRouteParam(req, 'id');
   if (!id || isNaN(Number(id))) {
-    return next(new AppError('無効なIDが指定されました', 400));
+    throw new AppError('無効なIDが指定されました', 400);
   }
+  return Number(id);
+}
 
-  try {
-    const updated = await updatePromptTemplate(requireTenantContext(), Number(id), req.body);
-    res.json({ success: true, data: updated });
-  } catch (error) {
-    logger.error(`[AdminAPI] updatePrompt Error: ${error}`);
-    next(error instanceof AppError ? error : new AppError('プロンプトの更新に失敗しました', 500));
-  }
-};
+export const getPrompts = asyncHandler(async (_req, res) => {
+  const prompts = await listPromptTemplates(requireTenantContext());
+  sendSuccess(res, prompts);
+});
 
-export const activatePrompt = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
-  if (!id || isNaN(Number(id))) {
-    return next(new AppError('無効なIDが指定されました', 400));
-  }
+export const createPrompt = asyncHandler(async (req, res) => {
+  const newPrompt = await createPromptTemplate(requireTenantContext(), req.body);
+  sendSuccess(res, newPrompt);
+});
 
-  try {
-    await activatePromptTemplate(requireTenantContext(), Number(id));
-    res.json({ success: true, message: 'デフォルトを切り替えました' });
-  } catch (error) {
-    logger.error(`[AdminAPI] activatePrompt Error: ${error}`);
-    next(error instanceof AppError ? error : new AppError('切り替えに失敗しました', 500));
-  }
-};
+export const updatePrompt = asyncHandler(async (req, res) => {
+  const updated = await updatePromptTemplate(
+    requireTenantContext(),
+    parsePromptId(req),
+    req.body
+  );
+  sendSuccess(res, updated);
+});
 
-export const deletePrompt = async (req: Request, res: Response, next: NextFunction) => {
-  const id = getRouteParam(req, 'id');
-  if (!id || isNaN(Number(id))) {
-    return next(new AppError('無効なIDが指定されました', 400));
-  }
+export const activatePrompt = asyncHandler(async (req, res) => {
+  await activatePromptTemplate(requireTenantContext(), parsePromptId(req));
+  sendMessage(res, 'デフォルトを切り替えました');
+});
 
-  try {
-    await deletePromptTemplate(requireTenantContext(), Number(id));
-    res.json({ success: true, message: '削除しました' });
-  } catch (error) {
-    logger.error(`[AdminAPI] deletePrompt Error: ${error}`);
-    next(error instanceof AppError ? error : new AppError('削除に失敗しました', 500));
-  }
-};
+export const deletePrompt = asyncHandler(async (req, res) => {
+  await deletePromptTemplate(requireTenantContext(), parsePromptId(req));
+  sendMessage(res, '削除しました');
+});
 
-export const getCostStats = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const result = await getAdminCostStats(requireTenantContext());
-    res.json({ success: true, data: result });
-  } catch (error) {
-    logger.error(`[AdminAPI] getCostStats Error: ${error}`);
-    next(new AppError('統計データの取得に失敗しました', 500));
-  }
-};
+export const getCostStats = asyncHandler(async (_req, res) => {
+  const result = await getAdminCostStats(requireTenantContext());
+  sendSuccess(res, result);
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request } from 'express';
 import { JWTPayload } from '../utils/auth';
 import {
   confirmTotpSetupForMember,
@@ -10,22 +10,18 @@ import {
   verifyTotpForMember,
 } from '../services/authService';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendSuccess } from '../utils/sendApiResponse';
 
 type AuthUser = JWTPayload;
-
-const ok = <T>(res: Response, data: T) => res.status(200).json({ success: true, data });
 
 const getAuthUser = (req: Request): AuthUser => (req as Request & { user: AuthUser }).user;
 
 const handle =
-  (fn: (req: Request, res: Response) => Promise<unknown>) =>
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      ok(res, await fn(req, res));
-    } catch (error) {
-      next(error);
-    }
-  };
+  <T>(fn: (req: Request) => Promise<T>) =>
+  asyncHandler(async (req, res) => {
+    sendSuccess(res, await fn(req));
+  });
 
 export const resolveFamily = handle(async (req) => {
   const { inviteCode } = req.body;

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -1,6 +1,7 @@
-import { Request, Response, NextFunction } from 'express';
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendMessage, sendOk, sendSuccess } from '../utils/sendApiResponse';
 import {
   listCategories,
   createCategory as createCategoryService,
@@ -8,38 +9,22 @@ import {
   optimizeCategoryKeywords,
 } from '../services/category/categoryService';
 
-export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const categories = await listCategories(requireTenantContext());
-    res.json({ success: true, data: categories });
-  } catch (error) {
-    next(error);
-  }
-};
+export const getCategories = asyncHandler(async (_req, res) => {
+  const categories = await listCategories(requireTenantContext());
+  sendSuccess(res, categories);
+});
 
-export const createCategory = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const category = await createCategoryService(requireTenantContext(), req.body);
-    res.status(201).json({ success: true, data: category });
-  } catch (error) {
-    next(error);
-  }
-};
+export const createCategory = asyncHandler(async (req, res) => {
+  const category = await createCategoryService(requireTenantContext(), req.body);
+  sendSuccess(res, category, 201);
+});
 
-export const deleteCategory = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    await deleteCategoryService(requireTenantContext(), Number(getRouteParam(req, 'id')));
-    res.json({ success: true });
-  } catch (error) {
-    next(error);
-  }
-};
+export const deleteCategory = asyncHandler(async (req, res) => {
+  await deleteCategoryService(requireTenantContext(), Number(getRouteParam(req, 'id')));
+  sendOk(res);
+});
 
-export const optimizeKeywords = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const data = await optimizeCategoryKeywords(requireTenantContext());
-    res.json({ success: true, data });
-  } catch (error) {
-    next(error);
-  }
-};
+export const optimizeKeywords = asyncHandler(async (_req, res) => {
+  const data = await optimizeCategoryKeywords(requireTenantContext());
+  sendSuccess(res, data);
+});

--- a/backend/src/controllers/productMasterController.ts
+++ b/backend/src/controllers/productMasterController.ts
@@ -1,6 +1,8 @@
-import { Request, Response, NextFunction } from 'express';
+import { AppError } from '../utils/appError';
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendMessage, sendSuccess } from '../utils/sendApiResponse';
 import {
   listProductMasters,
   updateProductMaster,
@@ -8,68 +10,40 @@ import {
   deleteProductMaster,
 } from '../services/productMaster/productMasterService';
 
-export const getProductMasters = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const masters = await listProductMasters(requireTenantContext(), {
-      q: typeof req.query.q === 'string' ? req.query.q : undefined,
-      store: typeof req.query.store === 'string' ? req.query.store : undefined,
-    });
-    res.json({ success: true, data: masters });
-  } catch (error) {
-    next(error);
-  }
-};
+export const getProductMasters = asyncHandler(async (req, res) => {
+  const masters = await listProductMasters(requireTenantContext(), {
+    q: typeof req.query.q === 'string' ? req.query.q : undefined,
+    store: typeof req.query.store === 'string' ? req.query.store : undefined,
+  });
+  sendSuccess(res, masters);
+});
 
-export const updateProductMasterHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const updated = await updateProductMaster(
-      requireTenantContext(),
-      Number(getRouteParam(req, 'id')),
-      req.body
-    );
-    res.json({ success: true, data: updated });
-  } catch (error) {
-    next(error);
-  }
-};
+export const updateProductMasterHandler = asyncHandler(async (req, res) => {
+  const updated = await updateProductMaster(
+    requireTenantContext(),
+    Number(getRouteParam(req, 'id')),
+    req.body
+  );
+  sendSuccess(res, updated);
+});
 
 export { updateProductMasterHandler as updateProductMaster };
 
-export const mergeStoreNamesHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const { sourceStoreName, targetStoreName } = req.body;
-    const data = await mergeStoreNames(
-      requireTenantContext(),
-      sourceStoreName,
-      targetStoreName
-    );
-    res.json({ success: true, data });
-  } catch (error) {
-    next(error);
-  }
-};
+export const mergeStoreNamesHandler = asyncHandler(async (req, res) => {
+  const { sourceStoreName, targetStoreName } = req.body;
+  const data = await mergeStoreNames(
+    requireTenantContext(),
+    sourceStoreName,
+    targetStoreName
+  );
+  sendSuccess(res, data);
+});
 
 export { mergeStoreNamesHandler as mergeStoreNames };
 
-export const deleteProductMasterHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    await deleteProductMaster(requireTenantContext(), Number(getRouteParam(req, 'id')));
-    res.json({ success: true, message: '削除しました' });
-  } catch (error) {
-    next(error);
-  }
-};
+export const deleteProductMasterHandler = asyncHandler(async (req, res) => {
+  await deleteProductMaster(requireTenantContext(), Number(getRouteParam(req, 'id')));
+  sendMessage(res, '削除しました');
+});
 
 export { deleteProductMasterHandler as deleteProductMaster };

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -1,4 +1,5 @@
-import { Request, Response, NextFunction } from 'express';
+import path from 'path';
+import sharp from 'sharp';
 import { AppError } from '../utils/appError';
 import { receiptQueue } from '../queues/receiptQueue';
 import { findCategoriesByFamilyGroup } from '../repositories/categoryRepository';
@@ -10,6 +11,8 @@ import {
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
 import { sendMessage, sendSuccess } from '../utils/sendApiResponse';
+import { asyncHandler } from '../utils/asyncHandler';
+import logger from '../utils/logger';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
 import {
   mapAdvancedStatsToApi,
@@ -39,230 +42,180 @@ import {
 } from '../services/receipt/receiptStatsService';
 import { SplitInput } from '../utils/itemSplitAllocation';
 
-export const getJobStatus = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const job = await receiptQueue.getJob(getRouteParam(req, 'jobId'));
-    if (!job) throw new AppError('ジョブが見つかりません。', 404);
+export const getJobStatus = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const job = await receiptQueue.getJob(getRouteParam(req, 'jobId'));
+  if (!job) throw new AppError('ジョブが見つかりません。', 404);
 
-    const jobFamilyGroupId = Number(job.data?.familyGroupId);
-    if (!jobFamilyGroupId || jobFamilyGroupId !== familyGroupId) {
-      throw new AppError('ジョブが見つかりません。', 404);
-    }
-
-    const state = await job.getState();
-    const data = await enrichCompletedJobPayload(
-      job,
-      familyGroupId,
-      mapJobToStatus(job, state)
-    );
-
-    sendSuccess(res, data);
-  } catch (error) {
-    next(error);
+  const jobFamilyGroupId = Number(job.data?.familyGroupId);
+  if (!jobFamilyGroupId || jobFamilyGroupId !== familyGroupId) {
+    throw new AppError('ジョブが見つかりません。', 404);
   }
-};
 
-export const getReceiptJobs = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const jobs = await listReceiptJobsForMember(ctx.familyGroupId, ctx.memberId);
-    sendSuccess(res, jobs);
-  } catch (error) {
-    next(error);
-  }
-};
+  const state = await job.getState();
+  const data = await enrichCompletedJobPayload(
+    job,
+    familyGroupId,
+    mapJobToStatus(job, state)
+  );
 
-export const discardReceiptJob = async (req: Request<{ jobId: string }>, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    await discardReceiptJobForMember(getRouteParam(req, 'jobId'), ctx.familyGroupId, ctx.memberId);
-    sendMessage(res, 'Discarded');
-  } catch (error) {
-    next(error);
-  }
-};
+  sendSuccess(res, data);
+});
 
-export const getCategories = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const categories = await findCategoriesByFamilyGroup(familyGroupId);
-    sendSuccess(res, mapCategoriesToSummary(categories));
-  } catch (error) {
-    next(error);
-  }
-};
+export const getReceiptJobs = asyncHandler(async (_req, res) => {
+  const ctx = requireTenantContext();
+  const jobs = await listReceiptJobsForMember(ctx.familyGroupId, ctx.memberId);
+  sendSuccess(res, jobs);
+});
 
-export const uploadReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const imagePath = req.file?.path;
+export const discardReceiptJob = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  await discardReceiptJobForMember(getRouteParam(req, 'jobId'), ctx.familyGroupId, ctx.memberId);
+  sendMessage(res, 'Discarded');
+});
 
-    if (!imagePath) throw new AppError('画像がアップロードされていません。', 400);
+export const getCategories = asyncHandler(async (_req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const categories = await findCategoriesByFamilyGroup(familyGroupId);
+  sendSuccess(res, mapCategoriesToSummary(categories));
+});
 
-    const job = await receiptQueue.add('analyze-receipt', {
-      memberId: ctx.memberId,
-      familyGroupId: ctx.familyGroupId,
-      imagePath,
-    });
+export const uploadReceipt = asyncHandler(async (req, res) => {
+  const file = req.file as Express.Multer.File | undefined;
+  if (!file) throw new AppError('画像がアップロードされていません。', 400);
 
-    sendSuccess(res, mapUploadJobResponse(job.id), 202);
-  } catch (error) {
-    next(error);
-  }
-};
+  const ctx = requireTenantContext();
+  const { familyGroupId, memberId } = ctx;
 
-export const commitReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const { parsedData, imagePath, validation, jobId } = req.body;
+  const timestamp = Date.now();
+  const baseFileName = `receipt-${timestamp}-${Math.round(Math.random() * 1e9)}`;
+  const uploadDir = 'uploads';
+  const imagePath = path.join(uploadDir, `${baseFileName}.webp`);
 
-    if (!parsedData || !imagePath) throw new AppError('必要なデータが不足しています。', 400);
+  await sharp(file.buffer)
+    .rotate()
+    .resize(1000, 1000, { fit: 'inside', withoutEnlargement: true })
+    .webp({ quality: 75, effort: 6 })
+    .toFile(imagePath);
 
-    const result = await commitReceiptService({
-      ctx,
-      parsedData: parsedData as ReceiptCommitPayload,
-      imagePath,
-      isSuspicious: validation?.isSuspicious || false,
-      warnings: validation?.warnings || [],
-      jobId,
-    });
+  const job = await receiptQueue.add('analyze-receipt', {
+    memberId,
+    familyGroupId,
+    imagePath,
+  });
 
-    sendSuccess(res, mapReceiptToDetail(result), 201);
-  } catch (error) {
-    next(error);
-  }
-};
+  logger.info(`[Queue] 解析ジョブ登録: ID ${job.id} (世帯: ${familyGroupId}, 会員: ${memberId})`);
 
-export const createReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const { date, storeName, items, imagePath } = req.body;
+  sendSuccess(res, { ...mapUploadJobResponse(job.id), status: 'queued' }, 202);
+});
 
-    const newReceipt = await createManualReceipt(ctx, {
-      date,
-      storeName,
-      items: items as ReceiptCreateItemInput[],
-      imagePath,
-    });
+export const commitReceipt = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  const { parsedData, imagePath, validation, jobId } = req.body;
 
-    sendSuccess(res, mapReceiptToDetail(newReceipt)!, 201);
-  } catch (error) {
-    next(error);
-  }
-};
+  if (!parsedData || !imagePath) throw new AppError('必要なデータが不足しています。', 400);
 
-export const updateReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const id = getRouteParam(req, 'id');
-    const { date, storeName, items } = req.body;
+  const result = await commitReceiptService({
+    ctx,
+    parsedData: parsedData as ReceiptCommitPayload,
+    imagePath,
+    isSuspicious: validation?.isSuspicious || false,
+    warnings: validation?.warnings || [],
+    jobId,
+  });
 
-    const result = await updateReceiptById(Number(id), familyGroupId, {
-      date,
-      storeName,
-      items: items as ReceiptCreateItemInput[],
-    });
+  sendSuccess(res, mapReceiptToDetail(result), 201);
+});
 
-    sendSuccess(res, mapReceiptToDetail(result)!);
-  } catch (error) {
-    next(error);
-  }
-};
+export const createReceipt = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  const { date, storeName, items, imagePath } = req.body;
 
-export const updateItemCategory = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const id = getRouteParam(req, 'id');
-    const { categoryId } = req.body;
+  const newReceipt = await createManualReceipt(ctx, {
+    date,
+    storeName,
+    items: items as ReceiptCreateItemInput[],
+    imagePath,
+  });
 
-    const result = await updateItemCategoryById(Number(id), familyGroupId, categoryId);
-    sendSuccess(res, mapReceiptItemToDetail(result));
-  } catch (error) {
-    next(error);
-  }
-};
+  sendSuccess(res, mapReceiptToDetail(newReceipt)!, 201);
+});
 
-export const getReceipts = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const { month, memberId } = req.query;
-    const receipts = await listReceipts({
-      familyGroupId,
-      memberId: typeof memberId === 'string' ? memberId : undefined,
-      month: typeof month === 'string' ? month : undefined,
-    });
-    sendSuccess(res, mapReceiptList(receipts));
-  } catch (error) {
-    next(error);
-  }
-};
+export const updateReceipt = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const id = getRouteParam(req, 'id');
+  const { date, storeName, items } = req.body;
 
-export const getLatestReceipt = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const receipt = await fetchLatestReceipt(familyGroupId);
-    sendSuccess(res, mapReceiptToDetail(receipt));
-  } catch (error) {
-    next(error);
-  }
-};
+  const result = await updateReceiptById(Number(id), familyGroupId, {
+    date,
+    storeName,
+    items: items as ReceiptCreateItemInput[],
+  });
 
-export const deleteReceipt = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    await deleteReceiptById(Number(getRouteParam(req, 'id')), familyGroupId);
-    sendMessage(res, 'Deleted');
-  } catch (error) {
-    next(error);
-  }
-};
+  sendSuccess(res, mapReceiptToDetail(result)!);
+});
 
-export const getMonthlyStats = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
-    const data = await fetchMonthlyStats(familyGroupId, month);
-    sendSuccess(res, mapMonthlyStatsToApi(data));
-  } catch (error) {
-    next(error);
-  }
-};
+export const updateItemCategory = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const id = getRouteParam(req, 'id');
+  const { categoryId } = req.body;
 
-export const getAdvancedStats = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const data = await fetchAdvancedStats(familyGroupId);
-    sendSuccess(res, mapAdvancedStatsToApi(data));
-  } catch (error) {
-    next(error);
-  }
-};
+  const result = await updateItemCategoryById(Number(id), familyGroupId, categoryId);
+  sendSuccess(res, mapReceiptItemToDetail(result));
+});
 
-export const getFamilyMembers = async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const members = await listFamilyMembers(familyGroupId);
-    sendSuccess(res, mapFamilyMembersToSummary(members));
-  } catch (error) {
-    next(error);
-  }
-};
+export const getReceipts = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const { month, memberId } = req.query;
+  const receipts = await listReceipts({
+    familyGroupId,
+    memberId: typeof memberId === 'string' ? memberId : undefined,
+    month: typeof month === 'string' ? month : undefined,
+  });
+  sendSuccess(res, mapReceiptList(receipts));
+});
 
-export const updateItemSplits = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { familyGroupId } = requireTenantContext();
-    const itemId = getRouteParam(req, 'itemId');
-    const { splits } = req.body;
+export const getLatestReceipt = asyncHandler(async (_req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const receipt = await fetchLatestReceipt(familyGroupId);
+  sendSuccess(res, mapReceiptToDetail(receipt));
+});
 
-    const result = await updateItemSplitsById(
-      Number(itemId),
-      familyGroupId,
-      splits as SplitInput[] | undefined
-    );
+export const deleteReceipt = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  await deleteReceiptById(Number(getRouteParam(req, 'id')), familyGroupId);
+  sendMessage(res, 'Deleted');
+});
 
-    sendSuccess(res, mapItemSplitsUpdateResult(result));
-  } catch (error) {
-    next(error);
-  }
-};
+export const getMonthlyStats = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
+  const data = await fetchMonthlyStats(familyGroupId, month);
+  sendSuccess(res, mapMonthlyStatsToApi(data));
+});
+
+export const getAdvancedStats = asyncHandler(async (_req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const data = await fetchAdvancedStats(familyGroupId);
+  sendSuccess(res, mapAdvancedStatsToApi(data));
+});
+
+export const getFamilyMembers = asyncHandler(async (_req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const members = await listFamilyMembers(familyGroupId);
+  sendSuccess(res, mapFamilyMembersToSummary(members));
+});
+
+export const updateItemSplits = asyncHandler(async (req, res) => {
+  const { familyGroupId } = requireTenantContext();
+  const itemId = getRouteParam(req, 'itemId');
+  const { splits } = req.body;
+
+  const result = await updateItemSplitsById(
+    Number(itemId),
+    familyGroupId,
+    splits as SplitInput[] | undefined
+  );
+
+  sendSuccess(res, mapItemSplitsUpdateResult(result));
+});

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,48 +1,33 @@
-import { Request, Response, NextFunction } from 'express';
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendSuccess } from '../utils/sendApiResponse';
 import {
   createSettlementTransfer,
   deleteSettlementTransfer as removeSettlementTransfer,
   getSettlementStatusData,
 } from '../services/settlement/settlementService';
 
-export const getSettlementStatus = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const data = await getSettlementStatusData(ctx, req.query.month as string | undefined);
-    res.status(200).json({ success: true, data });
-  } catch (error) {
-    next(error);
-  }
-};
+export const getSettlementStatus = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  const data = await getSettlementStatusData(ctx, req.query.month as string | undefined);
+  sendSuccess(res, data);
+});
 
-export const addSettlementTransfer = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const ctx = requireTenantContext();
-    const { month, fromMemberId, toMemberId, amount } = req.body;
-    const newTransfer = await createSettlementTransfer(ctx, {
-      month,
-      fromMemberId,
-      toMemberId,
-      amount,
-    });
-    res.status(201).json({ success: true, data: newTransfer });
-  } catch (error) {
-    next(error);
-  }
-};
+export const addSettlementTransfer = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  const { month, fromMemberId, toMemberId, amount } = req.body;
+  const newTransfer = await createSettlementTransfer(ctx, {
+    month,
+    fromMemberId,
+    toMemberId,
+    amount,
+  });
+  sendSuccess(res, newTransfer, 201);
+});
 
-export const deleteSettlementTransfer = async (
-  req: Request<{ id: string }>,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const ctx = requireTenantContext();
-    const data = await removeSettlementTransfer(ctx, Number(getRouteParam(req, 'id')));
-    res.status(200).json({ success: true, data });
-  } catch (error) {
-    next(error);
-  }
-};
+export const deleteSettlementTransfer = asyncHandler(async (req, res) => {
+  const ctx = requireTenantContext();
+  const data = await removeSettlementTransfer(ctx, Number(getRouteParam(req, 'id')));
+  sendSuccess(res, data);
+});

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,23 +1,15 @@
-import { Request, Response, NextFunction } from 'express';
 import { requireTenantContext } from '../utils/context';
 import { getRouteParam } from '../utils/routeParams';
+import { asyncHandler } from '../utils/asyncHandler';
 import { resolveReceiptImagePath } from '../services/upload/receiptImageService';
 
 /**
  * [Issue #93-1 / G3] レシート画像の認証付き配信。
  */
-export const serveReceiptImage = async (
-  req: Request<{ filename: string }>,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const fullPath = await resolveReceiptImagePath(
-      requireTenantContext(),
-      getRouteParam(req, 'filename')
-    );
-    res.sendFile(fullPath);
-  } catch (error) {
-    next(error);
-  }
-};
+export const serveReceiptImage = asyncHandler(async (req, res) => {
+  const fullPath = await resolveReceiptImagePath(
+    requireTenantContext(),
+    getRouteParam(req, 'filename')
+  );
+  res.sendFile(fullPath);
+});

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -77,6 +77,6 @@ export const isAdmin = async (req: Request, res: Response, next: NextFunction) =
     next();
   } catch (error) {
     logger.error(`[AUTH] Admin Check Error:`, error);
-    res.status(500).json({ success: false, message: '権限の確認中にエラーが発生しました' });
+    next(error);
   }
 };

--- a/backend/src/middleware/errorHandler.test.ts
+++ b/backend/src/middleware/errorHandler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import type { Request, Response, NextFunction } from 'express';
 import { AppError } from '../utils/appError';
 import { errorHandler } from '../middleware/errorHandler';
@@ -47,6 +48,28 @@ describe('errorHandler', () => {
     expect(res.body).toEqual({
       success: false,
       message: '入力内容に不備があります',
+    });
+
+    process.env.NODE_ENV = prev;
+  });
+
+  it('formats ZodError with validation details in production', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const schema = z.object({ memberId: z.number() });
+    const parsed = schema.safeParse({ memberId: 'x' });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const res = createMockRes();
+    errorHandler(parsed.error, req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: '入力内容に不備があります',
+      details: [{ field: 'memberId', message: expect.any(String) }],
     });
 
     process.env.NODE_ENV = prev;

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
 import { AppError } from '../utils/appError';
+import { zodErrorToAppError } from '../utils/zodError';
 import logger from '../utils/logger';
 import { DuplicateReceiptError } from '../services/receipt/receiptDuplicateError';
 
 /**
- * 📂 グローバルエラーハンドリング・ミドルウェア [Issue #47 / #98-5]
+ * 📂 グローバルエラーハンドリング・ミドルウェア [Issue #47 / #98-5 / #103-4]
  */
 export const errorHandler = (
   err: unknown,
@@ -12,12 +14,16 @@ export const errorHandler = (
   res: Response,
   next: NextFunction
 ) => {
-  const isDev = process.env.NODE_ENV === 'development';
-  const error = err as Error & { statusCode?: number; details?: unknown; stack?: string };
+  const normalized =
+    err instanceof ZodError ? zodErrorToAppError(err) : err;
 
-  const statusCode = err instanceof AppError ? err.statusCode : (error.statusCode || 500);
+  const isDev = process.env.NODE_ENV === 'development';
+  const error = normalized as Error & { statusCode?: number; details?: unknown; stack?: string };
+
+  const statusCode =
+    normalized instanceof AppError ? normalized.statusCode : (error.statusCode || 500);
   const message = error.message || 'Internal Server Error';
-  const details = err instanceof AppError ? err.details : undefined;
+  const details = normalized instanceof AppError ? normalized.details : undefined;
 
   logger.error(`[${req.method}] ${req.path} - ${message}`, {
     statusCode,
@@ -25,15 +31,15 @@ export const errorHandler = (
     path: req.originalUrl,
     details,
     stack: error.stack,
-    internal: err,
+    internal: normalized,
   });
 
   // api-spec §2.3: 重複レシート（409）は existingId をトップレベルに含める
-  if (err instanceof DuplicateReceiptError) {
+  if (normalized instanceof DuplicateReceiptError) {
     return res.status(409).json({
       success: false,
       message: 'DUPLICATE',
-      existingId: err.existingId,
+      existingId: normalized.existingId,
     });
   }
 
@@ -43,7 +49,7 @@ export const errorHandler = (
       message,
       stack: error.stack,
       details,
-      internal: err,
+      internal: normalized,
     });
   }
 

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import { ZodError, type ZodType } from 'zod';
-import { AppError } from '../utils/appError';
+import type { ZodType } from 'zod';
+import { ZodError } from 'zod';
+import { zodErrorToAppError } from '../utils/zodError';
 
 /**
  * Zodバリデーションミドルウェア
@@ -13,12 +14,7 @@ export const validate = (schema: ZodType) =>
       next();
     } catch (error: unknown) {
       if (error instanceof ZodError) {
-        const details = error.issues.map((issue) => ({
-          field: issue.path.join('.') || 'unknown',
-          message: issue.message,
-        }));
-
-        return next(new AppError('入力内容に不備があります', 400, details));
+        return next(zodErrorToAppError(error));
       }
 
       next(error);

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -1,22 +1,16 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express from 'express';
 import multer from 'multer';
-import path from 'path';
-import sharp from 'sharp';
-import { receiptQueue } from '../queues/receiptQueue';
-import logger from '../utils/logger';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { tenantMiddleware } from '../middleware/tenantMiddleware';
-import { requireTenantContext } from '../utils/context';
 import { validate } from '../middleware/validate';
 import { uploadReceiptSchema } from '../schemas/receiptSchema';
-import { AppError } from '../utils/appError';
 
-import { 
-  getReceipts, 
-  createReceipt, 
-  updateReceipt, 
-  deleteReceipt, 
-  getLatestReceipt, 
+import {
+  getReceipts,
+  createReceipt,
+  updateReceipt,
+  deleteReceipt,
+  getLatestReceipt,
   updateItemCategory,
   getMonthlyStats,
   getJobStatus,
@@ -25,71 +19,30 @@ import {
   getAdvancedStats,
   commitReceipt,
   getFamilyMembers,
-  updateItemSplits // ★ Issue #78: 按分保存関数をインポート
+  updateItemSplits,
+  uploadReceipt,
 } from '../controllers/receiptController';
 import { serveReceiptImage } from '../controllers/uploadController';
 
 const router = express.Router();
 
-const storage = multer.memoryStorage();
-const upload = multer({ 
-  storage: storage,
-  limits: { fileSize: 10 * 1024 * 1024 } 
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
 });
 
-/**
- * レシートアップロード (非同期解析ジョブ投入)
- */
 router.post(
   '/receipts/upload',
   upload.single('image'),
   authMiddleware,
   tenantMiddleware,
   validate(uploadReceiptSchema),
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const file = req.file as Express.Multer.File;
-      if (!file) throw new AppError('画像がアップロードされていません。', 400);
-
-      const ctx = requireTenantContext();
-      const { familyGroupId, memberId } = ctx;
-
-      const timestamp = Date.now();
-      const baseFileName = `receipt-${timestamp}-${Math.round(Math.random() * 1e9)}`;
-      const uploadDir = 'uploads';
-      const imagePath = path.join(uploadDir, `${baseFileName}.webp`);
-
-      await sharp(file.buffer)
-        .rotate()
-        .resize(1000, 1000, { fit: 'inside', withoutEnlargement: true })
-        .webp({ quality: 75, effort: 6 })
-        .toFile(imagePath);
-
-      const job = await receiptQueue.add('analyze-receipt', {
-        memberId: memberId,
-        familyGroupId: familyGroupId,
-        imagePath: imagePath,
-      });
-
-      logger.info(`[Queue] 解析ジョブ登録: ID ${job.id} (世帯: ${familyGroupId}, 会員: ${memberId})`);
-
-      res.status(202).json({
-        success: true,
-        data: { jobId: job.id, status: 'queued' }
-      });
-    } catch (error) {
-      next(error);
-    }
-  }
+  uploadReceipt
 );
 
-// --- 共通認証・テナントミドルウェア ---
 router.use(authMiddleware, tenantMiddleware);
 
-// 所属世帯のメンバー一覧を取得するエンドポイント
 router.get('/family-groups/members', getFamilyMembers);
-
-// [Issue #93-1 / G3] 認証・テナント検証付き画像配信（公開 /uploads は廃止）
 router.get('/uploads/:filename', serveReceiptImage);
 
 router.get('/receipts', getReceipts);
@@ -101,14 +54,9 @@ router.get('/stats/monthly', getMonthlyStats);
 router.get('/stats/advanced', getAdvancedStats);
 router.post('/receipts', createReceipt);
 router.delete('/receipts/:id', deleteReceipt);
-
-// レシート・明細更新系
 router.patch('/receipts/:id', updateReceipt);
 router.patch('/receipts/items/:id', updateItemCategory);
-
-// ★ Issue #78: 明細ごとの按分設定（ItemSplit）を保存するエンドポイント
 router.post('/receipts/items/:itemId/splits', updateItemSplits);
-
 router.post('/receipts/commit', commitReceipt);
 
 export default router;

--- a/backend/src/utils/asyncHandler.test.ts
+++ b/backend/src/utils/asyncHandler.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { AppError } from './appError';
+import { asyncHandler } from './asyncHandler';
+
+describe('asyncHandler', () => {
+  it('forwards rejected promises to next', async () => {
+    const req = {} as Request;
+    const res = {} as Response;
+    const next = vi.fn() as NextFunction;
+    const error = new AppError('test', 400);
+
+    const handler = asyncHandler(async () => {
+      throw error;
+    });
+
+    handler(req, res, next);
+    await Promise.resolve();
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/backend/src/utils/asyncHandler.ts
+++ b/backend/src/utils/asyncHandler.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+type AsyncRequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<void>;
+
+/**
+ * async Controller / ルートハンドラ用ラッパー。
+ * 例外は next(error) で errorHandler に委譲する。
+ */
+export function asyncHandler(fn: AsyncRequestHandler): RequestHandler {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/backend/src/utils/sendApiResponse.ts
+++ b/backend/src/utils/sendApiResponse.ts
@@ -10,3 +10,7 @@ export function sendMessage(res: Response, message: string, status = 200): void 
   const body: ApiMessageResponse = { success: true, message };
   res.status(status).json(body);
 }
+
+export function sendOk(res: Response, status = 200): void {
+  res.status(status).json({ success: true });
+}

--- a/backend/src/utils/zodError.test.ts
+++ b/backend/src/utils/zodError.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { formatZodIssues, zodErrorToAppError } from './zodError';
+
+describe('zodError', () => {
+  it('converts ZodError to AppError with field details', () => {
+    const schema = z.object({ memberId: z.number() });
+    const parsed = schema.safeParse({ memberId: 'x' });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const appError = zodErrorToAppError(parsed.error);
+    expect(appError.statusCode).toBe(400);
+    expect(appError.message).toBe('入力内容に不備があります');
+    expect(formatZodIssues(parsed.error)[0].field).toBe('memberId');
+  });
+});

--- a/backend/src/utils/zodError.ts
+++ b/backend/src/utils/zodError.ts
@@ -1,0 +1,13 @@
+import { ZodError } from 'zod';
+import { AppError } from './appError';
+
+export function formatZodIssues(error: ZodError) {
+  return error.issues.map((issue) => ({
+    field: issue.path.join('.') || 'unknown',
+    message: issue.message,
+  }));
+}
+
+export function zodErrorToAppError(error: ZodError): AppError {
+  return new AppError('入力内容に不備があります', 400, formatZodIssues(error));
+}


### PR DESCRIPTION
## Summary

- `asyncHandler` を導入し、全 Controller の冗長な try/catch を `next(error)` 委譲に統一
- `zodErrorToAppError` を共通化し、`validate` / `errorHandler` で Zod 失敗を同一 envelope に整形
- `receiptRoutes` のインライン upload ハンドラを `receiptController.uploadReceipt` に集約
- `adminController` の独自 catch + 汎用 500 マスクを廃止し、Service 由来の `AppError` を errorHandler に委譲
- `isAdmin` ミドルウェアの未知例外を `next(error)` に変更

## Acceptance Criteria

- [x] 主要 Controller でエラー envelope が統一されている
- [x] Service が `res.status` を直接呼ばない（変更なし・維持）
- [x] 既存 integration test（エラーケース含む）がパス

## Test plan

- [x] `cd backend && npm test`（58 passed）
- [x] `errorHandler.test.ts` に ZodError ケース追加
- [x] `asyncHandler.test.ts` / `zodError.test.ts` 追加

Closes #479


Made with [Cursor](https://cursor.com)