### PR TITLE
Issue #103-2: auth / admin ドメイン Mapper 適用

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -4,6 +4,11 @@ import { getRouteParam } from '../utils/routeParams';
 import { asyncHandler } from '../utils/asyncHandler';
 import { sendMessage, sendSuccess } from '../utils/sendApiResponse';
 import {
+  mapAdminCostStatsToApi,
+  mapPromptTemplateList,
+  mapPromptTemplateToApi,
+} from '../mappers/adminMapper';
+import {
   listPromptTemplates,
   createPromptTemplate,
   updatePromptTemplate,
@@ -22,12 +27,12 @@ function parsePromptId(req: Parameters<typeof getRouteParam>[0]): number {
 
 export const getPrompts = asyncHandler(async (_req, res) => {
   const prompts = await listPromptTemplates(requireTenantContext());
-  sendSuccess(res, prompts);
+  sendSuccess(res, mapPromptTemplateList(prompts));
 });
 
 export const createPrompt = asyncHandler(async (req, res) => {
   const newPrompt = await createPromptTemplate(requireTenantContext(), req.body);
-  sendSuccess(res, newPrompt);
+  sendSuccess(res, mapPromptTemplateToApi(newPrompt));
 });
 
 export const updatePrompt = asyncHandler(async (req, res) => {
@@ -36,7 +41,7 @@ export const updatePrompt = asyncHandler(async (req, res) => {
     parsePromptId(req),
     req.body
   );
-  sendSuccess(res, updated);
+  sendSuccess(res, mapPromptTemplateToApi(updated));
 });
 
 export const activatePrompt = asyncHandler(async (req, res) => {
@@ -51,5 +56,5 @@ export const deletePrompt = asyncHandler(async (req, res) => {
 
 export const getCostStats = asyncHandler(async (_req, res) => {
   const result = await getAdminCostStats(requireTenantContext());
-  sendSuccess(res, result);
+  sendSuccess(res, mapAdminCostStatsToApi(result));
 });

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -12,44 +12,75 @@ import {
 import { getRouteParam } from '../utils/routeParams';
 import { asyncHandler } from '../utils/asyncHandler';
 import { sendSuccess } from '../utils/sendApiResponse';
+import {
+  mapFamilyGroupToResolvedFamily,
+  mapLoginSessionToResponse,
+  mapMembersToAuthFamilyMembers,
+  mapTotpConfirmAccessToApi,
+  mapTotpSetupToApi,
+} from '../mappers/authMapper';
 
 type AuthUser = JWTPayload;
 
 const getAuthUser = (req: Request): AuthUser => (req as Request & { user: AuthUser }).user;
 
-const handle =
-  <T>(fn: (req: Request) => Promise<T>) =>
-  asyncHandler(async (req, res) => {
-    sendSuccess(res, await fn(req));
-  });
-
-export const resolveFamily = handle(async (req) => {
+export const resolveFamily = asyncHandler(async (req, res) => {
   const { inviteCode } = req.body;
-  return resolveFamilyByInviteCode(typeof inviteCode === 'string' ? inviteCode : '');
+  const familyGroup = await resolveFamilyByInviteCode(
+    typeof inviteCode === 'string' ? inviteCode : ''
+  );
+  sendSuccess(res, mapFamilyGroupToResolvedFamily(familyGroup));
 });
 
-export const getFamilyMembers = handle(async (req) => {
+export const getFamilyMembers = asyncHandler(async (req, res) => {
   const familyGroupId = parseInt(getRouteParam(req, 'familyGroupId'), 10);
   const inviteCode = typeof req.query.inviteCode === 'string' ? req.query.inviteCode : '';
-  return listFamilyMembersForInvite(familyGroupId, inviteCode);
+  const members = await listFamilyMembersForInvite(familyGroupId, inviteCode);
+  sendSuccess(res, mapMembersToAuthFamilyMembers(members));
 });
 
-export const login = handle(async (req) => loginMember(req.body));
+export const login = asyncHandler(async (req, res) => {
+  const session = await loginMember(req.body);
+  sendSuccess(res, mapLoginSessionToResponse(session));
+});
 
-export const startTotpSetup = handle(async (req) => startTotpSetupForMember(getAuthUser(req).id));
+export const startTotpSetup = asyncHandler(async (req, res) => {
+  const setup = await startTotpSetupForMember(getAuthUser(req).id);
+  sendSuccess(res, mapTotpSetupToApi(setup));
+});
 
-export const confirmTotpSetup = handle(async (req) => {
+export const confirmTotpSetup = asyncHandler(async (req, res) => {
   const user = getAuthUser(req);
   const { code } = req.body;
-  return confirmTotpSetupForMember(user.id, typeof code === 'string' ? code : '', user.purpose ?? 'access');
+  const result = await confirmTotpSetupForMember(
+    user.id,
+    typeof code === 'string' ? code : '',
+    user.purpose ?? 'access'
+  );
+
+  if ('token' in result) {
+    sendSuccess(res, mapLoginSessionToResponse(result));
+    return;
+  }
+
+  sendSuccess(res, mapTotpConfirmAccessToApi(result));
 });
 
-export const verifyTotp = handle(async (req) => {
+export const verifyTotp = asyncHandler(async (req, res) => {
   const { code } = req.body;
-  return verifyTotpForMember(getAuthUser(req).id, typeof code === 'string' ? code : '');
+  const session = await verifyTotpForMember(
+    getAuthUser(req).id,
+    typeof code === 'string' ? code : ''
+  );
+  sendSuccess(res, mapLoginSessionToResponse(session));
 });
 
-export const disableTotp = handle(async (req) => {
+export const disableTotp = asyncHandler(async (req, res) => {
   const { password, code } = req.body;
-  return disableTotpForMember(getAuthUser(req).id, String(password ?? ''), String(code ?? ''));
+  const result = await disableTotpForMember(
+    getAuthUser(req).id,
+    String(password ?? ''),
+    String(code ?? '')
+  );
+  sendSuccess(res, result);
 });

--- a/backend/src/mappers/adminMapper.test.ts
+++ b/backend/src/mappers/adminMapper.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { mapAdminCostStatsToApi, mapPromptTemplateToApi } from './adminMapper';
+
+describe('adminMapper', () => {
+  it('maps prompt template without internal timestamps', () => {
+    expect(
+      mapPromptTemplateToApi({
+        id: 1,
+        familyGroupId: 2,
+        key: 'RECEIPT_ANALYSIS',
+        name: '解析',
+        description: 'desc',
+        systemPrompt: 'prompt',
+        domainHints: { tax: true },
+        isActive: true,
+        version: 3,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+      })
+    ).toEqual({
+      id: 1,
+      familyGroupId: 2,
+      key: 'RECEIPT_ANALYSIS',
+      name: '解析',
+      description: 'desc',
+      systemPrompt: 'prompt',
+      domainHints: { tax: true },
+      isActive: true,
+      version: 3,
+    });
+  });
+
+  it('passes through admin cost stats domain rows', () => {
+    const rows = [
+      {
+        month: '2026-01',
+        modelId: 'gemini',
+        totalPromptTokens: 100,
+        totalCandidatesTokens: 50,
+        estimatedCostJpy: 12.34,
+      },
+    ];
+
+    expect(mapAdminCostStatsToApi(rows)).toEqual(rows);
+  });
+});

--- a/backend/src/mappers/adminMapper.ts
+++ b/backend/src/mappers/adminMapper.ts
@@ -1,0 +1,35 @@
+import type { PromptTemplate as PromptTemplateRecord } from '@prisma/client';
+import type { AdminCostStatRow, PromptTemplate } from '../types/apiSchemas';
+
+export function mapPromptTemplateToApi(record: PromptTemplateRecord): PromptTemplate {
+  return {
+    id: record.id,
+    key: record.key,
+    name: record.name,
+    description: record.description,
+    systemPrompt: record.systemPrompt,
+    domainHints:
+      record.domainHints && typeof record.domainHints === 'object'
+        ? (record.domainHints as Record<string, unknown>)
+        : null,
+    isActive: record.isActive,
+    version: record.version,
+    familyGroupId: record.familyGroupId,
+  };
+}
+
+export function mapPromptTemplateList(records: PromptTemplateRecord[]): PromptTemplate[] {
+  return records.map(mapPromptTemplateToApi);
+}
+
+export type AdminCostStatDomain = {
+  month: string;
+  modelId: string;
+  totalPromptTokens: number;
+  totalCandidatesTokens: number;
+  estimatedCostJpy: number;
+};
+
+export function mapAdminCostStatsToApi(stats: AdminCostStatDomain[]): AdminCostStatRow[] {
+  return stats;
+}

--- a/backend/src/mappers/authMapper.test.ts
+++ b/backend/src/mappers/authMapper.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapFamilyGroupToResolvedFamily,
+  mapLoginSessionToResponse,
+  mapMemberToLoginMember,
+  mapMembersToAuthFamilyMembers,
+  mapTotpSetupToApi,
+} from './authMapper';
+
+describe('authMapper', () => {
+  const member = {
+    id: 2,
+    name: '太郎',
+    familyGroupId: 1,
+    role: 'ADMIN' as const,
+    totpEnabled: true,
+  };
+
+  it('maps member to LoginMember', () => {
+    expect(mapMemberToLoginMember(member)).toEqual({
+      id: 2,
+      name: '太郎',
+      familyGroupId: 1,
+      role: 'ADMIN',
+      totpEnabled: true,
+    });
+  });
+
+  it('maps login session to LoginResponse', () => {
+    expect(
+      mapLoginSessionToResponse({
+        member,
+        token: 'access-token',
+        pendingToken: null,
+        requiresTotpVerification: false,
+        requiresTotpSetup: false,
+      })
+    ).toEqual({
+      token: 'access-token',
+      pendingToken: null,
+      member: mapMemberToLoginMember(member),
+      requiresTotpVerification: false,
+      requiresTotpSetup: false,
+    });
+  });
+
+  it('maps family group and invite members', () => {
+    expect(mapFamilyGroupToResolvedFamily({ id: 5, name: '山田家' })).toEqual({
+      familyGroupId: 5,
+      name: '山田家',
+    });
+
+    expect(mapMembersToAuthFamilyMembers([{ id: 1, name: 'A' }])).toEqual([
+      { id: 1, name: 'A' },
+    ]);
+  });
+
+  it('maps totp setup info', () => {
+    expect(
+      mapTotpSetupToApi({
+        secret: 'SECRET',
+        otpauthUrl: 'otpauth://totp/test',
+      })
+    ).toEqual({
+      secret: 'SECRET',
+      otpauthUrl: 'otpauth://totp/test',
+    });
+  });
+});

--- a/backend/src/mappers/authMapper.ts
+++ b/backend/src/mappers/authMapper.ts
@@ -1,0 +1,95 @@
+import type { Role } from '@prisma/client';
+import type {
+  AuthFamilyMember,
+  LoginMember,
+  LoginResponse,
+  ResolvedFamily,
+  TotpSetupInfo,
+} from '../types/apiSchemas';
+
+export type AuthMemberRecord = {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
+};
+
+export type LoginSessionDomain = {
+  member: AuthMemberRecord;
+  token: string | null;
+  pendingToken: string | null;
+  requiresTotpVerification: boolean;
+  requiresTotpSetup: boolean;
+};
+
+export type TotpConfirmAccessDomain = {
+  member: AuthMemberRecord;
+  totpEnabled: true;
+};
+
+export function mapMemberToLoginMember(member: AuthMemberRecord): LoginMember {
+  return {
+    id: member.id,
+    name: member.name,
+    familyGroupId: member.familyGroupId,
+    role: member.role,
+    totpEnabled: member.totpEnabled,
+  };
+}
+
+export function mapLoginSessionToResponse(domain: LoginSessionDomain): LoginResponse {
+  return {
+    token: domain.token,
+    pendingToken: domain.pendingToken,
+    member: mapMemberToLoginMember(domain.member),
+    requiresTotpVerification: domain.requiresTotpVerification,
+    requiresTotpSetup: domain.requiresTotpSetup,
+  };
+}
+
+export function mapFamilyGroupToResolvedFamily(familyGroup: {
+  id: number;
+  name: string;
+}): ResolvedFamily {
+  return {
+    familyGroupId: familyGroup.id,
+    name: familyGroup.name,
+  };
+}
+
+export function mapMembersToAuthFamilyMembers(
+  members: Array<{ id: number; name: string }>
+): AuthFamilyMember[] {
+  return members.map((member) => ({
+    id: member.id,
+    name: member.name,
+  }));
+}
+
+export function mapTotpSetupToApi(info: { secret: string; otpauthUrl: string }): TotpSetupInfo {
+  return info;
+}
+
+export function mapTotpConfirmAccessToApi(domain: TotpConfirmAccessDomain) {
+  return {
+    member: mapMemberToLoginMember(domain.member),
+    totpEnabled: domain.totpEnabled,
+  };
+}
+
+export function toAuthMemberRecord(member: {
+  id: number;
+  name: string;
+  familyGroupId: number;
+  role: Role;
+  totpEnabled: boolean;
+}): AuthMemberRecord {
+  return {
+    id: member.id,
+    name: member.name,
+    familyGroupId: member.familyGroupId,
+    role: member.role,
+    totpEnabled: member.totpEnabled,
+  };
+}

--- a/backend/src/services/admin/adminService.ts
+++ b/backend/src/services/admin/adminService.ts
@@ -14,6 +14,7 @@ import {
   updatePromptTemplateRecord,
 } from '../../repositories/promptRepository';
 import { queryAdminCostStatsByFamilyGroup } from '../../repositories/apiUsageLogRepository';
+import type { AdminCostStatDomain } from '../../mappers/adminMapper';
 
 const RATE_USD_TO_JPY = 150;
 const PRICE_USD_PER_INPUT = 0.075 / 1000000;
@@ -127,13 +128,7 @@ export async function deletePromptTemplate(ctx: TenantContext, id: number) {
   await syncPromptsToJson(ctx.familyGroupId);
 }
 
-type CostStatRow = {
-  month: string;
-  modelId: string;
-  totalPromptTokens: number;
-  totalCandidatesTokens: number;
-  estimatedCostJpy: number;
-};
+type CostStatRow = AdminCostStatDomain;
 
 export async function getAdminCostStats(ctx: TenantContext): Promise<CostStatRow[]> {
   const stats = await queryAdminCostStatsByFamilyGroup(ctx.familyGroupId);

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,5 +1,4 @@
 import bcrypt from 'bcrypt';
-import { Role } from '@prisma/client';
 import { AppError } from '../utils/appError';
 import {
   generateAccessToken,
@@ -24,81 +23,51 @@ import {
   findMembersByFamilyGroupId,
   saveMemberTotpSetup,
 } from '../repositories/memberRepository';
+import {
+  type AuthMemberRecord,
+  type LoginSessionDomain,
+  type TotpConfirmAccessDomain,
+  toAuthMemberRecord,
+} from '../mappers/authMapper';
 
-export type AuthMemberDto = {
-  id: number;
-  name: string;
-  familyGroupId: number;
-  role: Role;
-  totpEnabled: boolean;
-};
-
-export type AccessLoginData = {
-  token: string;
-  pendingToken: null;
-  member: AuthMemberDto;
-  requiresTotpVerification: false;
-  requiresTotpSetup: false;
-};
-
-export type PendingLoginData = {
-  token: null;
-  pendingToken: string;
-  member: AuthMemberDto;
-  requiresTotpVerification: boolean;
-  requiresTotpSetup: boolean;
-};
-
-type AuthMemberRecord = {
-  id: number;
-  name: string;
-  familyGroupId: number;
-  role: Role;
-  totpEnabled: boolean;
+type AuthMemberSource = AuthMemberRecord & {
   password_hash?: string | null;
   totpSecret?: string | null;
 };
 
-function formatMember(member: AuthMemberRecord): AuthMemberDto {
+function buildAccessSession(member: AuthMemberSource): LoginSessionDomain {
+  const record = toAuthMemberRecord(member);
   return {
-    id: member.id,
-    name: member.name,
-    familyGroupId: member.familyGroupId,
-    role: member.role,
-    totpEnabled: member.totpEnabled,
-  };
-}
-
-function buildAccessResponse(member: AuthMemberRecord): AccessLoginData {
-  return {
+    member: record,
     token: generateAccessToken({
-      id: member.id,
-      name: member.name,
-      familyGroupId: member.familyGroupId,
-      role: member.role,
+      id: record.id,
+      name: record.name,
+      familyGroupId: record.familyGroupId,
+      role: record.role,
     }),
     pendingToken: null,
-    member: formatMember(member),
     requiresTotpVerification: false,
     requiresTotpSetup: false,
   };
 }
 
-function buildPendingResponse(
-  member: AuthMemberRecord,
+function buildPendingSession(
+  member: AuthMemberSource,
   purpose: 'totp_pending' | 'totp_setup'
-): PendingLoginData {
-  const tokenInput = {
-    id: member.id,
-    name: member.name,
-    familyGroupId: member.familyGroupId,
-    role: member.role,
-  };
-
+): LoginSessionDomain {
+  const record = toAuthMemberRecord(member);
   return {
+    member: record,
     token: null,
-    pendingToken: generatePendingToken(tokenInput, purpose),
-    member: formatMember(member),
+    pendingToken: generatePendingToken(
+      {
+        id: record.id,
+        name: record.name,
+        familyGroupId: record.familyGroupId,
+        role: record.role,
+      },
+      purpose
+    ),
     requiresTotpVerification: purpose === 'totp_pending',
     requiresTotpSetup: purpose === 'totp_setup',
   };
@@ -115,10 +84,7 @@ export async function resolveFamilyByInviteCode(inviteCode: string) {
     throw new AppError('招待コードが正しくありません。', 404);
   }
 
-  return {
-    familyGroupId: familyGroup.id,
-    name: familyGroup.name,
-  };
+  return familyGroup;
 }
 
 export async function listFamilyMembersForInvite(familyGroupId: number, inviteCode: string) {
@@ -143,7 +109,7 @@ export async function loginMember(input: {
   familyGroupId: unknown;
   memberId: unknown;
   password: unknown;
-}): Promise<AccessLoginData | PendingLoginData> {
+}): Promise<LoginSessionDomain> {
   const { familyGroupId, memberId, password } = input;
 
   if (!familyGroupId || !memberId || !password) {
@@ -176,14 +142,14 @@ export async function loginMember(input: {
   }
 
   if (member.totpEnabled) {
-    return buildPendingResponse(member, 'totp_pending');
+    return buildPendingSession(member, 'totp_pending');
   }
 
   if (isTotpRequiredForRole(member.role)) {
-    return buildPendingResponse(member, 'totp_setup');
+    return buildPendingSession(member, 'totp_setup');
   }
 
-  return buildAccessResponse(member);
+  return buildAccessSession(member);
 }
 
 export async function startTotpSetupForMember(memberId: number) {
@@ -208,7 +174,7 @@ export async function confirmTotpSetupForMember(
   memberId: number,
   code: string,
   purpose: TokenPurpose
-): Promise<AccessLoginData | { member: AuthMemberDto; totpEnabled: true }> {
+): Promise<LoginSessionDomain | TotpConfirmAccessDomain> {
   if (!code.trim()) {
     throw new AppError('認証コードを入力してください。', 400);
   }
@@ -227,16 +193,21 @@ export async function confirmTotpSetupForMember(
   }
 
   const updated = await enableMemberTotp(member.id);
-  const memberDto = formatMember(updated);
 
   if (purpose === 'totp_setup') {
-    return buildAccessResponse(updated);
+    return buildAccessSession(updated);
   }
 
-  return { member: memberDto, totpEnabled: true };
+  return {
+    member: toAuthMemberRecord(updated),
+    totpEnabled: true,
+  };
 }
 
-export async function verifyTotpForMember(memberId: number, code: string): Promise<AccessLoginData> {
+export async function verifyTotpForMember(
+  memberId: number,
+  code: string
+): Promise<LoginSessionDomain> {
   if (!code.trim()) {
     throw new AppError('認証コードを入力してください。', 400);
   }
@@ -251,7 +222,7 @@ export async function verifyTotpForMember(memberId: number, code: string): Promi
     throw new AppError('認証コードが正しくありません。', 401);
   }
 
-  return buildAccessResponse(member);
+  return buildAccessSession(member);
 }
 
 export async function disableTotpForMember(memberId: number, password: string, code: string) {

--- a/backend/src/types/apiSchemas.ts
+++ b/backend/src/types/apiSchemas.ts
@@ -9,9 +9,8 @@
 
 // --- auth ---
 export type ResolvedFamily = {
-  id: number;
+  familyGroupId: number;
   name: string;
-  inviteCode: string;
 };
 
 export type AuthFamilyMember = {
@@ -208,13 +207,14 @@ export type MergeStoreNamesResponse = {
 // --- admin ---
 export type PromptTemplate = {
   id: number;
-  name: string;
-  description: string | null;
+  key: string;
+  name?: string | null;
+  description?: string | null;
   systemPrompt: string;
-  domainHints: string | null;
+  domainHints?: Record<string, unknown> | null;
   isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
+  version: number;
+  familyGroupId?: number;
 };
 
 export type AdminCostStatRow = {


### PR DESCRIPTION
## Summary

- `authMapper.ts` を新設し、`AuthMemberDto` / `formatMember` / ログイン envelope 整形を移行
- `adminMapper.ts` を新設し、`PromptTemplate` / `AdminCostStatRow` の API 変換を集約
- `authService` は `LoginSessionDomain` 等のドメイン型を返し、Controller が Mapper 経由で `apiSchemas` DTO に変換
- `apiSchemas.ts` の `ResolvedFamily` / `PromptTemplate` を OpenAPI 形に整合

## Acceptance Criteria

- [x] auth / admin の API レスポンス整形が Mapper に集約されている
- [x] 認証フロー・管理画面 API の integration test パス

## Test plan

- [x] `cd backend && npm test`（64 passed）
- [x] `authMapper.test.ts` / `adminMapper.test.ts` 追加

Closes #477


Made with [Cursor](https://cursor.com)