### PR TITLE
Issue #103-3: settlement / stats ドメイン Mapper 適用

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -15,17 +15,16 @@ import { asyncHandler } from '../utils/asyncHandler';
 import logger from '../utils/logger';
 import type { ReceiptCommitPayload, ReceiptCreateItemInput } from '../types/receipt';
 import {
-  mapAdvancedStatsToApi,
   mapCategoriesToSummary,
   mapFamilyMembersToSummary,
   mapItemSplitsUpdateResult,
   mapJobToStatus,
-  mapMonthlyStatsToApi,
   mapReceiptItemToDetail,
   mapReceiptList,
   mapReceiptToDetail,
   mapUploadJobResponse,
 } from '../mappers/receiptMapper';
+import { mapAdvancedStatsToApi, mapMonthlyStatsToApi } from '../mappers/statsMapper';
 import { commitReceipt as commitReceiptService } from '../services/receipt/receiptCommitService';
 import { createManualReceipt } from '../services/receipt/receiptUpdateService';
 import {

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -3,6 +3,11 @@ import { getRouteParam } from '../utils/routeParams';
 import { asyncHandler } from '../utils/asyncHandler';
 import { sendSuccess } from '../utils/sendApiResponse';
 import {
+  mapDeletedSettlementTransferToApi,
+  mapSettlementStatusToApi,
+  mapSettlementTransferToApi,
+} from '../mappers/settlementMapper';
+import {
   createSettlementTransfer,
   deleteSettlementTransfer as removeSettlementTransfer,
   getSettlementStatusData,
@@ -11,7 +16,7 @@ import {
 export const getSettlementStatus = asyncHandler(async (req, res) => {
   const ctx = requireTenantContext();
   const data = await getSettlementStatusData(ctx, req.query.month as string | undefined);
-  sendSuccess(res, data);
+  sendSuccess(res, mapSettlementStatusToApi(data));
 });
 
 export const addSettlementTransfer = asyncHandler(async (req, res) => {
@@ -23,11 +28,11 @@ export const addSettlementTransfer = asyncHandler(async (req, res) => {
     toMemberId,
     amount,
   });
-  sendSuccess(res, newTransfer, 201);
+  sendSuccess(res, mapSettlementTransferToApi(newTransfer), 201);
 });
 
 export const deleteSettlementTransfer = asyncHandler(async (req, res) => {
   const ctx = requireTenantContext();
   const data = await removeSettlementTransfer(ctx, Number(getRouteParam(req, 'id')));
-  sendSuccess(res, data);
+  sendSuccess(res, mapDeletedSettlementTransferToApi(data.id));
 });

--- a/backend/src/mappers/receiptMapper.ts
+++ b/backend/src/mappers/receiptMapper.ts
@@ -2,12 +2,9 @@ import type { Job } from 'bullmq';
 import type { Category, ItemSplit } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import type {
-  AdvancedStatsData,
-  CategoryStatRow,
   CategorySummary,
   FamilyMemberSummary,
   ItemSplitSummary,
-  MonthlyStatsData,
   ReceiptDetail,
   ReceiptItemDetail,
   ReceiptJobListItem,
@@ -46,18 +43,6 @@ type AnalyzeJobReturn = {
   };
   imagePath?: string;
   validation?: { isSuspicious: boolean; warnings: string[] };
-};
-
-type MonthlyStatsDomain = {
-  month: string;
-  totalAmount: number;
-  stats: CategoryStatRow[];
-  latestReceipt: ReceiptWithItemsCategory | null;
-};
-
-type AdvancedStatsDomain = {
-  trend: AdvancedStatsData['trend'];
-  pareto: AdvancedStatsData['pareto'];
 };
 
 function toIsoDateString(date: Date | string | null | undefined): string | undefined {
@@ -156,19 +141,6 @@ export function mapItemSplitsUpdateResult(
     return mapItemSplitsToSummary(result);
   }
   return result;
-}
-
-export function mapMonthlyStatsToApi(domain: MonthlyStatsDomain): MonthlyStatsData {
-  return {
-    month: domain.month,
-    totalAmount: domain.totalAmount,
-    stats: domain.stats,
-    latestReceipt: mapReceiptToDetail(domain.latestReceipt),
-  };
-}
-
-export function mapAdvancedStatsToApi(domain: AdvancedStatsDomain): AdvancedStatsData {
-  return domain;
 }
 
 function summarizeParsedData(parsedData: AnalyzeJobReturn['parsedData']) {

--- a/backend/src/mappers/settlementMapper.test.ts
+++ b/backend/src/mappers/settlementMapper.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapDeletedSettlementTransferToApi,
+  mapSettlementStatusToApi,
+  mapSettlementTransferToApi,
+} from './settlementMapper';
+
+describe('settlementMapper', () => {
+  it('maps settlement status with ISO settledAt', () => {
+    const result = mapSettlementStatusToApi({
+      month: '2026-01',
+      members: [
+        {
+          memberId: 1,
+          name: '太郎',
+          totalPaid: 1000,
+          totalOwed: 400,
+          baseBalance: 600,
+          transferredOut: 100,
+          transferredIn: 0,
+          balance: 700,
+        },
+      ],
+      transfers: [
+        {
+          id: 9,
+          fromMemberId: 1,
+          toMemberId: 2,
+          amount: 100,
+          month: '2026-01',
+          settledAt: new Date('2026-01-20T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(result.month).toBe('2026-01');
+    expect(result.members[0].totalPaid).toBe(1000);
+    expect(result.transfers[0]).toEqual({
+      id: 9,
+      fromMemberId: 1,
+      toMemberId: 2,
+      amount: 100,
+      month: '2026-01',
+      settledAt: '2026-01-20T12:00:00.000Z',
+    });
+  });
+
+  it('maps single transfer and delete response', () => {
+    expect(
+      mapSettlementTransferToApi({
+        id: 3,
+        fromMemberId: 1,
+        toMemberId: 2,
+        amount: 500,
+        month: '2026-02',
+        settledAt: new Date('2026-02-01T00:00:00.000Z'),
+      })
+    ).toEqual({
+      id: 3,
+      fromMemberId: 1,
+      toMemberId: 2,
+      amount: 500,
+      month: '2026-02',
+      settledAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    expect(mapDeletedSettlementTransferToApi(3)).toEqual({ id: 3 });
+  });
+});

--- a/backend/src/mappers/settlementMapper.ts
+++ b/backend/src/mappers/settlementMapper.ts
@@ -1,0 +1,48 @@
+import type {
+  SettlementMemberSummary,
+  SettlementStatusData,
+  SettlementTransfer,
+} from '../types/apiSchemas';
+import type { SettlementMemberSummary as SettlementMemberDomain } from '../services/settlement/settlementAggregation';
+
+export type SettlementTransferDomain = {
+  id: number;
+  fromMemberId: number;
+  toMemberId: number;
+  amount: number;
+  month?: string;
+  settledAt: Date;
+};
+
+export type SettlementStatusDomain = {
+  month: string;
+  members: SettlementMemberDomain[];
+  transfers: SettlementTransferDomain[];
+};
+
+export function mapSettlementMemberToApi(member: SettlementMemberDomain): SettlementMemberSummary {
+  return member;
+}
+
+export function mapSettlementTransferToApi(transfer: SettlementTransferDomain): SettlementTransfer {
+  return {
+    id: transfer.id,
+    fromMemberId: transfer.fromMemberId,
+    toMemberId: transfer.toMemberId,
+    amount: transfer.amount,
+    month: transfer.month,
+    settledAt: transfer.settledAt.toISOString(),
+  };
+}
+
+export function mapSettlementStatusToApi(domain: SettlementStatusDomain): SettlementStatusData {
+  return {
+    month: domain.month,
+    members: domain.members.map(mapSettlementMemberToApi),
+    transfers: domain.transfers.map(mapSettlementTransferToApi),
+  };
+}
+
+export function mapDeletedSettlementTransferToApi(transferId: number) {
+  return { id: transferId };
+}

--- a/backend/src/mappers/statsMapper.test.ts
+++ b/backend/src/mappers/statsMapper.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mapCategoryStatRows, mapMonthlyStatsToApi } from './statsMapper';
+
+describe('statsMapper', () => {
+  it('maps monthly stats with category fallback and receipt detail', () => {
+    const result = mapMonthlyStatsToApi({
+      month: '2026-01',
+      totalAmount: 5000,
+      stats: [
+        {
+          categoryId: 1,
+          categoryName: null,
+          color: '#fff',
+          totalAmount: 5000,
+        },
+      ],
+      latestReceipt: null,
+    });
+
+    expect(result).toEqual({
+      month: '2026-01',
+      totalAmount: 5000,
+      stats: [
+        {
+          categoryId: 1,
+          categoryName: '未分類',
+          color: '#fff',
+          totalAmount: 5000,
+        },
+      ],
+      latestReceipt: null,
+    });
+  });
+
+  it('maps category stat rows', () => {
+    expect(
+      mapCategoryStatRows([
+        {
+          categoryId: 2,
+          categoryName: '食費',
+          color: null,
+          totalAmount: 100,
+        },
+      ])
+    ).toEqual([
+      {
+        categoryId: 2,
+        categoryName: '食費',
+        color: null,
+        totalAmount: 100,
+      },
+    ]);
+  });
+});

--- a/backend/src/mappers/statsMapper.ts
+++ b/backend/src/mappers/statsMapper.ts
@@ -1,0 +1,47 @@
+import type {
+  AdvancedStatsData,
+  CategoryStatRow,
+  MonthlyStatsData,
+} from '../types/apiSchemas';
+import { mapReceiptToDetail, type ReceiptWithItemsCategory } from './receiptMapper';
+
+export type MonthlyCategoryStatDomain = {
+  categoryId: number | null;
+  categoryName: string | null;
+  color: string | null;
+  totalAmount: number;
+};
+
+export type MonthlyStatsDomain = {
+  month: string;
+  totalAmount: number;
+  stats: MonthlyCategoryStatDomain[];
+  latestReceipt: ReceiptWithItemsCategory | null;
+};
+
+export type AdvancedStatsDomain = {
+  trend: AdvancedStatsData['trend'];
+  pareto: AdvancedStatsData['pareto'];
+};
+
+export function mapCategoryStatRows(rows: MonthlyCategoryStatDomain[]): CategoryStatRow[] {
+  return rows.map((row) => ({
+    categoryId: row.categoryId,
+    categoryName: row.categoryName || '未分類',
+    totalAmount: row.totalAmount,
+    color: row.color,
+  }));
+}
+
+export function mapMonthlyStatsToApi(domain: MonthlyStatsDomain): MonthlyStatsData {
+  return {
+    month: domain.month,
+    totalAmount: domain.totalAmount,
+    stats: mapCategoryStatRows(domain.stats),
+    latestReceipt: mapReceiptToDetail(domain.latestReceipt),
+  };
+}
+
+export function mapAdvancedStatsToApi(domain: AdvancedStatsDomain): AdvancedStatsData {
+  return domain;
+}

--- a/backend/src/repositories/settlementRepository.ts
+++ b/backend/src/repositories/settlementRepository.ts
@@ -48,6 +48,7 @@ export async function findSettlementTransfersByMonth(familyGroupId: number, mont
       fromMemberId: true,
       toMemberId: true,
       amount: true,
+      month: true,
       settledAt: true,
     },
   });

--- a/backend/src/services/receipt/receiptStatsService.ts
+++ b/backend/src/services/receipt/receiptStatsService.ts
@@ -15,10 +15,7 @@ export async function getMonthlyStats(familyGroupId: number, month: string) {
   return {
     month,
     totalAmount,
-    stats: categoryStats.map((s) => ({
-      ...s,
-      categoryName: s.categoryName || '未分類',
-    })),
+    stats: categoryStats,
     latestReceipt,
   };
 }

--- a/backend/src/services/settlement/settlementService.ts
+++ b/backend/src/services/settlement/settlementService.ts
@@ -73,10 +73,11 @@ export type SettlementTransferRecord = {
   fromMemberId: number;
   toMemberId: number;
   amount: number;
+  month: string;
   settledAt: Date;
 };
 
-export type SettlementStatusData = {
+export type SettlementStatusDomain = {
   month: string;
   members: ReturnType<typeof computeSettlementMemberSummaries>;
   transfers: SettlementTransferRecord[];
@@ -86,7 +87,7 @@ export type SettlementStatusData = {
 export async function getSettlementStatusData(
   ctx: TenantContext,
   month?: string
-): Promise<SettlementStatusData> {
+): Promise<SettlementStatusDomain> {
   const { familyGroupId } = ctx;
   const targetMonth = normalizeYearMonth(month) ?? getCurrentYearMonthLocal();
   const { start: startDate, end: endDate } = getLocalMonthDateRange(targetMonth);

--- a/backend/src/types/apiSchemas.ts
+++ b/backend/src/types/apiSchemas.ts
@@ -159,21 +159,25 @@ export type AdvancedStatsData = {
 export type SettlementMemberSummary = {
   memberId: number;
   name: string;
-  paidAmount: number;
-  owedAmount: number;
+  totalPaid: number;
+  totalOwed: number;
+  baseBalance: number;
+  transferredOut: number;
+  transferredIn: number;
   balance: number;
 };
 
 export type SettlementTransfer = {
   id: number;
-  month: string;
   fromMemberId: number;
   toMemberId: number;
   amount: number;
+  month?: string;
   settledAt: string;
 };
 
 export type SettlementStatusData = {
+  month: string;
   members: SettlementMemberSummary[];
   transfers: SettlementTransfer[];
 };

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -224,6 +224,7 @@ flowchart LR
 | FE ViewModel | 画面固有 | `frontend/src/types/` | generated の re-export + 拡張のみ |
 | FE Mapper | DTO → 表示用 | `frontend/src/mappers/` | — |
 | BE API DTO | OpenAPI 契約ミラー | `backend/src/types/apiSchemas.ts` | `apiSchemas.test.ts` で schema 名を検証（#102-3） |
+| BE Response Mapper | Prisma / ドメイン → API DTO | `backend/src/mappers/` | Controller が Service 戻り値を `apiSchemas` 形に変換（#103-1〜3） |
 | BE ドメイン型 | 内部モデル | `backend/src/types/receipt.ts` 等 | `ParsedReceipt` 等。HTTP レスポンスは apiSchemas を使用 |
 | BE Express 拡張 | リクエストコンテキスト | `backend/src/types/express.d.ts` | `req.user` 等 |
 | DB | Prisma | `backend/prisma/schema.prisma` | API DTO とは別層 |
@@ -325,7 +326,7 @@ Expo Router（`frontend/app/`）によるファイルベースルーティング
 
 **API 接続**: `frontend/src/api/*`（型付きラッパー）→ `apiClient.ts`（認証ヘッダ注入・403 通知）。DTO は [openapi.yaml](../openapi/openapi.yaml) 由来の `api/generated`（[api-spec.md](./api-spec.md) §9）。Screen / Hook から `categoryApi` / `receiptApi` / `statsApi` を直接 import しない（#100-14）。
 
-**Mapper**: API 生レスポンスの画面向け整形は `frontend/src/mappers/`（例: `statsMapper.ts`）。
+**Mapper**: API 生レスポンスの画面向け整形は `frontend/src/mappers/`（例: `statsMapper.ts`）。**BE** の `backend/src/mappers/statsMapper.ts` / `settlementMapper.ts` は Prisma・集計ドメイン → OpenAPI DTO への変換であり、FE Mapper とは責務が逆方向（DTO → ViewModel）である。統計画面では FE が `statsMapper.mapMonthlyStatsResponse` で表示用に正規化し、精算画面は API DTO をそのまま利用する箇所が多い（#103-3）。
 
 詳細は [frontend-screens.md](./frontend-screens.md)（#90-5 / #100-15）を参照。
 


### PR DESCRIPTION
## Summary

- `statsMapper.ts` を新設し、月次/高度統計の API 変換を `receiptMapper` から移管
- `settlementMapper.ts` を新設し、精算ステータス・送金記録の API 変換を集約
- `statsController` / `receiptController` を Mapper 経由の薄型化に更新
- `apiSchemas.ts` の `SettlementMemberSummary` / `SettlementStatusData` を OpenAPI 形に整合
- `architecture.md` に BE Mapper と FE `statsMapper` の責務境界を追記

## Acceptance Criteria

- [x] settlement / stats の API レスポンス整形が Mapper に集約されている
- [x] 精算・統計画面の integration test パス

## Test plan

- [x] `cd backend && npm test`（68 passed）
- [x] `statsMapper.test.ts` / `settlementMapper.test.ts` 追加

Closes #478


Made with [Cursor](https://cursor.com)