### PR TITLE
Issue #104-1: 残存 Screen の feature 化（ProductMaster / AdminStats / TotpSettings）

### DIFF
--- a/frontend/src/features/admin/hooks/useAdminStats.ts
+++ b/frontend/src/features/admin/hooks/useAdminStats.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+import { adminApi, type AdminCostStatRow } from '../../../api';
+import { getApiErrorMessage } from '../../../utils/apiError';
+
+export function useAdminStats() {
+  const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState<AdminCostStatRow[]>([]);
+  const [totalCost, setTotalCost] = useState(0);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    try {
+      setLoading(true);
+      setErrorMessage(null);
+      const res = await adminApi.getCostStats();
+      const rows = res.data ?? [];
+      setStats(rows);
+      const total = rows.reduce((sum, item) => sum + item.estimatedCostJpy, 0);
+      setTotalCost(total);
+    } catch (error: unknown) {
+      setErrorMessage(getApiErrorMessage(error, 'コスト統計の取得に失敗しました。'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchStats();
+  }, [fetchStats]);
+
+  return {
+    loading,
+    stats,
+    totalCost,
+    errorMessage,
+  };
+}

--- a/frontend/src/features/admin/index.ts
+++ b/frontend/src/features/admin/index.ts
@@ -1,3 +1,4 @@
 export { usePromptEditor } from './hooks/usePromptEditor';
+export { useAdminStats } from './hooks/useAdminStats';
 export { PromptEditorForm } from './components/PromptEditorForm';
 export { PromptEditorList } from './components/PromptEditorList';

--- a/frontend/src/features/auth/hooks/useTotpSettings.ts
+++ b/frontend/src/features/auth/hooks/useTotpSettings.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { loginService } from '../../../services/loginService';
+import { showAlert } from '../../../utils/alertMessage';
+
+type UseTotpSettingsOptions = {
+  onChanged: (enabled: boolean) => void;
+};
+
+export function useTotpSettings({ onChanged }: UseTotpSettingsOptions) {
+  const [secret, setSecret] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleStartEnable = async () => {
+    setLoading(true);
+    try {
+      const setup = await loginService.startTotpSetupForUser();
+      setSecret(setup.secret);
+      setCode('');
+    } catch (e: unknown) {
+      showAlert('エラー', e instanceof Error ? e.message : 'セットアップに失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmEnable = async () => {
+    if (!code.trim()) {
+      showAlert('入力エラー', '6桁コードを入力してください。');
+      return;
+    }
+    setLoading(true);
+    try {
+      await loginService.enableTotpForUser(code);
+      setSecret(null);
+      setCode('');
+      onChanged(true);
+      showAlert('完了', '二要素認証を有効にしました。');
+    } catch (e: unknown) {
+      showAlert('エラー', e instanceof Error ? e.message : '有効化に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    secret,
+    code,
+    setCode,
+    loading,
+    handleStartEnable,
+    handleConfirmEnable,
+  };
+}

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 export { useLoginFlow } from './hooks/useLoginFlow';
+export { useTotpSettings } from './hooks/useTotpSettings';
 export type { LoginFlow } from './hooks/useLoginFlow';
 export type { LoginStep } from './types';
 export { InviteCodeStep } from './components/InviteCodeStep';

--- a/frontend/src/features/productMaster/hooks/useProductMaster.ts
+++ b/frontend/src/features/productMaster/hooks/useProductMaster.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, Platform } from 'react-native';
+import { productMasterApi, type ProductMaster } from '../../../api';
+import { showAlert } from '../../../utils/alertMessage';
+import { showApiErrorAlert } from '../../../utils/apiError';
+import { showConfirmDialog } from '../../../utils/confirmDialog';
+
+type UseProductMasterOptions = {
+  currentMemberId: number | null;
+};
+
+export function useProductMaster({ currentMemberId }: UseProductMasterOptions) {
+  const [masters, setMasters] = useState<ProductMaster[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [storeFilter, setStoreFilter] = useState('');
+
+  const fetchMasters = useCallback(async () => {
+    if (!currentMemberId) return;
+
+    try {
+      setLoading(true);
+      const res = await productMasterApi.listProductMasters({
+        q: searchQuery,
+        store: storeFilter,
+      });
+      setMasters(res.data ?? []);
+    } catch (err) {
+      showApiErrorAlert('エラー', err, '学習マスタの取得に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, [searchQuery, storeFilter, currentMemberId]);
+
+  useEffect(() => {
+    if (currentMemberId) {
+      void fetchMasters();
+    }
+  }, [fetchMasters, currentMemberId]);
+
+  const handleDelete = useCallback(
+    (id: number) => {
+      showConfirmDialog('確認', 'この学習データを削除しますか？', [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '削除',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await productMasterApi.deleteProductMaster(id);
+              await fetchMasters();
+            } catch (err) {
+              showApiErrorAlert('エラー', err, '削除に失敗しました。');
+            }
+          },
+        },
+      ]);
+    },
+    [fetchMasters]
+  );
+
+  const handleMergeStores = useCallback(() => {
+    if (Platform.OS !== 'ios') {
+      showAlert('通知', '店舗統合機能は現在iOSのみの対応です。');
+      return;
+    }
+
+    Alert.prompt(
+      '店舗名の統合',
+      '統合元の店舗名を入力（例: ｾﾌﾞﾝ）',
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '次へ',
+          onPress: (source: string | undefined) => {
+            if (!source) return;
+            Alert.prompt(
+              '統合先名称',
+              `${source} をどの名称に統合しますか？`,
+              [
+                {
+                  text: '実行',
+                  onPress: async (target: string | undefined) => {
+                    if (!target) return;
+                    try {
+                      await productMasterApi.mergeStoreNames({
+                        sourceStoreName: source,
+                        targetStoreName: target,
+                      });
+                      showAlert('完了', '統合完了しました');
+                      await fetchMasters();
+                    } catch (err) {
+                      showApiErrorAlert('エラー', err, '統合に失敗しました。');
+                    }
+                  },
+                },
+              ]
+            );
+          },
+        },
+      ]
+    );
+  }, [fetchMasters]);
+
+  return {
+    masters,
+    loading,
+    searchQuery,
+    setSearchQuery,
+    storeFilter,
+    setStoreFilter,
+    handleDelete,
+    handleMergeStores,
+  };
+}

--- a/frontend/src/features/productMaster/index.ts
+++ b/frontend/src/features/productMaster/index.ts
@@ -1,0 +1,1 @@
+export { useProductMaster } from './hooks/useProductMaster';

--- a/frontend/src/screens/AdminStatsScreen.tsx
+++ b/frontend/src/screens/AdminStatsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   View,
   Text,
@@ -7,6 +7,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { AppBackButton } from '../components/ui';
+import { useAdminStats } from '../features/admin';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
 import { borderRadius } from '../theme/radii';
@@ -14,8 +15,6 @@ import { shadows } from '../theme/shadows';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
 import { tableStyles } from '../theme/tableStyles';
-import { adminApi, type AdminCostStatRow } from '../api';
-import { getApiErrorMessage } from '../utils/apiError';
 
 interface AdminStatsScreenProps {
   onBack: () => void;
@@ -24,30 +23,9 @@ interface AdminStatsScreenProps {
 const adm = colors.semantic.admin;
 
 export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) => {
-  const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState<AdminCostStatRow[]>([]);
-  const [totalCost, setTotalCost] = useState(0);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const stats = useAdminStats();
 
-  useEffect(() => {
-    fetchStats();
-  }, []);
-
-  const fetchStats = async () => {
-    try {
-      const res = await adminApi.getCostStats();
-      const rows = res.data ?? [];
-      setStats(rows);
-      const total = rows.reduce((sum, item) => sum + item.estimatedCostJpy, 0);
-      setTotalCost(total);
-    } catch (error: unknown) {
-      setErrorMsg(getApiErrorMessage(error, 'コスト統計の取得に失敗しました。'));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  if (loading) {
+  if (stats.loading) {
     return (
       <View style={[screenLayout.container, styles.loadingContainer]}>
         <ActivityIndicator size="large" color={colors.primary} />
@@ -64,16 +42,16 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
       </View>
 
       <ScrollView contentContainerStyle={[screenLayout.scrollContent, styles.content]}>
-        {errorMsg ? (
+        {stats.errorMessage ? (
           <View style={styles.errorContainer}>
             <Text style={styles.errorTitle}>アクセス権限エラー</Text>
-            <Text style={styles.errorSubText}>{errorMsg}</Text>
+            <Text style={styles.errorSubText}>{stats.errorMessage}</Text>
           </View>
         ) : (
           <>
             <View style={[cardStyles.summaryCard, styles.primarySummaryCard]}>
               <Text style={styles.summaryLabel}>累計利用コスト (概算)</Text>
-              <Text style={styles.summaryAmount}>¥{totalCost.toFixed(2)}</Text>
+              <Text style={styles.summaryAmount}>¥{stats.totalCost.toFixed(2)}</Text>
               <Text style={styles.summaryNote}>※為替レート150円/$、Gemini 2.0 Flashでの算出</Text>
             </View>
 
@@ -85,12 +63,12 @@ export const AdminStatsScreen: React.FC<AdminStatsScreenProps> = ({ onBack }) =>
                   <Text style={[tableStyles.cell, styles.colCost, tableStyles.headerText]}>概算(円)</Text>
                 </View>
 
-                {stats.length === 0 ? (
+                {stats.stats.length === 0 ? (
                   <View style={[tableStyles.row, styles.emptyRow]}>
                     <Text style={[tableStyles.cell, tableStyles.bodyText]}>データがありません</Text>
                   </View>
                 ) : (
-                  stats.map((item, index) => (
+                  stats.stats.map((item, index) => (
                     <View key={`${item.month}-${item.modelId}-${index}`} style={tableStyles.row}>
                       <View style={[tableStyles.cell, styles.colMonth]}>
                         <Text style={tableStyles.bodyText}>{item.month}</Text>

--- a/frontend/src/screens/ProductMasterScreen.tsx
+++ b/frontend/src/screens/ProductMasterScreen.tsx
@@ -1,10 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, Alert, ActivityIndicator, Platform } from 'react-native';
-import { productMasterApi, type ProductMaster } from '../api';
-import { showAlert } from '../utils/alertMessage';
-import { showApiErrorAlert } from '../utils/apiError';
-import { showConfirmDialog } from '../utils/confirmDialog';
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, ActivityIndicator, Platform } from 'react-native';
 import { AppBackButton, AppButton, AppListItem, AppTextInput } from '../components/ui';
+import { useProductMaster } from '../features/productMaster';
 import { BUTTON_LABELS } from '../constants/buttonLabels';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
@@ -17,102 +14,16 @@ export const ProductMasterScreen = ({
   onBack: () => void;
   currentMemberId: number | null;
 }) => {
-  const [masters, setMasters] = useState<ProductMaster[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [storeFilter, setStoreFilter] = useState('');
+  const pm = useProductMaster({ currentMemberId });
 
-  const fetchMasters = useCallback(async () => {
-    if (!currentMemberId) return;
-
-    try {
-      setLoading(true);
-      const res = await productMasterApi.listProductMasters({
-        q: searchQuery,
-        store: storeFilter,
-      });
-      setMasters(res.data ?? []);
-    } catch (err) {
-      showApiErrorAlert('エラー', err, '学習マスタの取得に失敗しました。');
-    } finally {
-      setLoading(false);
-    }
-  }, [searchQuery, storeFilter, currentMemberId]);
-
-  useEffect(() => {
-    if (currentMemberId) {
-      fetchMasters();
-    }
-  }, [fetchMasters, currentMemberId]);
-
-  const handleDelete = (id: number) => {
-    showConfirmDialog('確認', 'この学習データを削除しますか？', [
-      { text: 'キャンセル', style: 'cancel' },
-      {
-        text: '削除',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            await productMasterApi.deleteProductMaster(id);
-            fetchMasters();
-          } catch (err) {
-            showApiErrorAlert('エラー', err, '削除に失敗しました。');
-          }
-        },
-      },
-    ]);
-  };
-
-  const handleMergeStores = () => {
-    if (Platform.OS === 'ios') {
-      Alert.prompt(
-        '店舗名の統合',
-        '統合元の店舗名を入力（例: ｾﾌﾞﾝ）',
-        [
-          { text: 'キャンセル', style: 'cancel' },
-          {
-            text: '次へ',
-            onPress: (source: string | undefined) => {
-              if (!source) return;
-              Alert.prompt(
-                '統合先名称',
-                `${source} をどの名称に統合しますか？`,
-                [
-                  {
-                    text: '実行',
-                    onPress: async (target: string | undefined) => {
-                      if (!target) return;
-                      try {
-                        await productMasterApi.mergeStoreNames({
-                          sourceStoreName: source,
-                          targetStoreName: target,
-                        });
-                        showAlert('完了', '統合完了しました');
-                        fetchMasters();
-                      } catch (err) {
-                        showApiErrorAlert('エラー', err, '統合に失敗しました。');
-                      }
-                    },
-                  },
-                ]
-              );
-            },
-          },
-        ]
-      );
-    } else {
-      showAlert('通知', '店舗統合機能は現在iOSのみの対応です。');
-    }
-  };
-
-  const renderItem = ({ item }: { item: ProductMaster }) => (
+  const renderItem = ({ item }: { item: (typeof pm.masters)[number] }) => (
     <AppListItem
       title={item.name}
       subtitle={`店舗: ${item.storeName || '共通'}`}
       right={
         <AppButton
           title={BUTTON_LABELS.delete}
-          onPress={() => handleDelete(item.id)}
+          onPress={() => pm.handleDelete(item.id)}
           variant="dangerFilled"
           size="sm"
         />
@@ -136,31 +47,31 @@ export const ProductMasterScreen = ({
         <Text style={[screenLayout.headerTitle, styles.titleProduct]}>
           学習マスタ ({currentMemberId === 1 ? '個人' : 'その他'})
         </Text>
-        <AppButton title="店舗統合" onPress={handleMergeStores} variant="ghost" size="sm" />
+        <AppButton title="店舗統合" onPress={pm.handleMergeStores} variant="ghost" size="sm" />
       </View>
 
       <View style={styles.searchBar}>
         <AppTextInput
           placeholder="品名検索..."
           style={styles.searchInput}
-          value={searchQuery}
-          onChangeText={setSearchQuery}
+          value={pm.searchQuery}
+          onChangeText={pm.setSearchQuery}
         />
         <AppTextInput
           placeholder="店舗名..."
           style={styles.searchInput}
-          value={storeFilter}
-          onChangeText={setStoreFilter}
+          value={pm.storeFilter}
+          onChangeText={pm.setStoreFilter}
         />
       </View>
 
       {!currentMemberId ? (
         <Text style={styles.empty}>メンバーを選択してください</Text>
-      ) : loading ? (
+      ) : pm.loading ? (
         <ActivityIndicator size="large" color={colors.primary} style={{ marginTop: 20 }} />
       ) : (
         <FlatList
-          data={masters}
+          data={pm.masters}
           keyExtractor={(item) => item.id.toString()}
           renderItem={renderItem}
           contentContainerStyle={styles.listContent}

--- a/frontend/src/screens/TotpSettingsScreen.tsx
+++ b/frontend/src/screens/TotpSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
@@ -7,13 +7,12 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { loginService } from '../services/loginService';
+import { useTotpSettings } from '../features/auth';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
 import { borderRadius } from '../theme/radii';
 import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
-import { showAlert } from '../utils/alertMessage';
 
 type Props = {
   totpEnabled: boolean;
@@ -22,41 +21,7 @@ type Props = {
 };
 
 export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
-  const [secret, setSecret] = useState<string | null>(null);
-  const [code, setCode] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const handleStartEnable = async () => {
-    setLoading(true);
-    try {
-      const setup = await loginService.startTotpSetupForUser();
-      setSecret(setup.secret);
-      setCode('');
-    } catch (e: unknown) {
-      showAlert('エラー', e instanceof Error ? e.message : 'セットアップに失敗しました。');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleConfirmEnable = async () => {
-    if (!code.trim()) {
-      showAlert('入力エラー', '6桁コードを入力してください。');
-      return;
-    }
-    setLoading(true);
-    try {
-      await loginService.enableTotpForUser(code);
-      setSecret(null);
-      setCode('');
-      onChanged(true);
-      showAlert('完了', '二要素認証を有効にしました。');
-    } catch (e: unknown) {
-      showAlert('エラー', e instanceof Error ? e.message : '有効化に失敗しました。');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const totp = useTotpSettings({ onChanged });
 
   return (
     <View style={[screenLayout.container, styles.content]}>
@@ -72,12 +37,12 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
             二要素認証は全メンバー必須のため、無効にできません。
           </Text>
         </>
-      ) : secret ? (
+      ) : totp.secret ? (
         <>
           <Text style={styles.subtitle}>認証アプリに以下のキーを登録してください</Text>
           <View style={[cardStyles.listCard, styles.secretBox]}>
             <Text style={styles.secret} selectable>
-              {secret}
+              {totp.secret}
             </Text>
           </View>
           <TextInput
@@ -85,15 +50,15 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
             placeholder="6桁コード"
             keyboardType="number-pad"
             maxLength={6}
-            value={code}
-            onChangeText={setCode}
+            value={totp.code}
+            onChangeText={totp.setCode}
           />
           <TouchableOpacity
             style={styles.primaryButton}
-            onPress={handleConfirmEnable}
-            disabled={loading}
+            onPress={totp.handleConfirmEnable}
+            disabled={totp.loading}
           >
-            {loading ? (
+            {totp.loading ? (
               <ActivityIndicator color={colors.primary} />
             ) : (
               <Text style={styles.primaryButtonText}>有効化</Text>
@@ -105,10 +70,10 @@ export function TotpSettingsScreen({ totpEnabled, onBack, onChanged }: Props) {
           <Text style={styles.subtitle}>ログイン時に認証コードの入力が必要になります。</Text>
           <TouchableOpacity
             style={styles.primaryButton}
-            onPress={handleStartEnable}
-            disabled={loading}
+            onPress={totp.handleStartEnable}
+            disabled={totp.loading}
           >
-            {loading ? (
+            {totp.loading ? (
               <ActivityIndicator color={colors.primary} />
             ) : (
               <Text style={styles.primaryButtonText}>セットアップを開始</Text>


### PR DESCRIPTION
## Summary

- `useProductMaster` / `useAdminStats` / `useTotpSettings` を新設し、Screen から API・service 直 import を除去
- `features/productMaster/` を新設、`admin` / `auth` の index に export 追加
- 3 Screen をすべて **150行以内** に整理

Closes #504

## 行数

| Screen | Before | After |
|--------|--------|-------|
| ProductMasterScreen | 196 | 107 |
| AdminStatsScreen | 154 | 132 |
| TotpSettingsScreen | 150 | 115 |

## Test plan

- [x] `cd frontend && npm test` パス
- [ ] ProductMaster: 検索・削除・店舗統合（iOS）
- [ ] AdminStats: 一覧表示・権限エラー
- [ ] Totp: セットアップ・有効化フロー


Made with [Cursor](https://cursor.com)