### PR TITLE
Issue #104-2: ReceiptScanScreen UI 分割（Form / Header / Preview）

### DIFF
--- a/frontend/src/features/receipt/components/ReceiptScanForm.tsx
+++ b/frontend/src/features/receipt/components/ReceiptScanForm.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { AppFormField, AppTextInput } from '../../../components/ui';
+import { modalStyles } from '../../../theme/modalStyles';
+import { colors } from '../../../theme/colors';
+import { spacing } from '../../../theme/spacing';
+import { cardStyles } from '../../../theme/cardStyles';
+import type { ReceiptScanFlow } from '../hooks/useReceiptScan';
+
+const c = colors;
+const s = colors.semantic.scan;
+
+type Props = {
+  scan: ReceiptScanFlow;
+};
+
+export function ReceiptScanForm({ scan }: Props) {
+  return (
+    <View style={[cardStyles.chartCard, styles.card]}>
+      <Text style={styles.sectionLabel}>基本情報</Text>
+      <AppFormField label="店舗名">
+        <AppTextInput
+          value={scan.receiptData.storeName}
+          onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, storeName: val })}
+          placeholder="店舗名"
+        />
+      </AppFormField>
+      <AppFormField label="購入日時">
+        <AppTextInput
+          value={scan.receiptData.purchaseDate}
+          onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, purchaseDate: val })}
+          placeholder="YYYY-MM-DD HH:mm"
+        />
+      </AppFormField>
+
+      <AppFormField label="消費税 (外税・加算額)">
+        <View style={modalStyles.inputWithUnit}>
+          <AppTextInput
+            variant="inline"
+            value={String(scan.receiptData.taxAmount)}
+            keyboardType="decimal-pad"
+            onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, taxAmount: val })}
+          />
+          <Text style={modalStyles.unitSuffix}>円</Text>
+        </View>
+      </AppFormField>
+
+      <View style={styles.totalDisplay}>
+        <Text style={styles.totalLabel}>支払合計 (税込)</Text>
+        <Text style={styles.totalValue}>¥ {scan.calculatedTotal.toLocaleString()}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { minHeight: undefined, alignItems: 'stretch', margin: spacing.md, marginTop: 0, elevation: 2 },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: s.textMuted,
+    textTransform: 'uppercase',
+    marginBottom: 12,
+  },
+  totalDisplay: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 8,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: s.borderInput,
+  },
+  totalLabel: { fontSize: 14, color: s.textSecondary },
+  totalValue: { fontSize: 24, fontWeight: 'bold', color: c.primary },
+});

--- a/frontend/src/features/receipt/components/ReceiptScanHeader.tsx
+++ b/frontend/src/features/receipt/components/ReceiptScanHeader.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { AppBackButton, AppButton } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { colors } from '../../../theme/colors';
+import { screenLayout } from '../../../theme/screenLayout';
+import type { ReceiptScanFlow } from '../hooks/useReceiptScan';
+
+const c = colors;
+const s = colors.semantic.scan;
+
+type Props = {
+  onCancel: () => void;
+  scan: ReceiptScanFlow;
+};
+
+export function ReceiptScanHeader({ onCancel, scan }: Props) {
+  return (
+    <View style={[screenLayout.header, styles.headerScan]}>
+      <AppBackButton onPress={onCancel} style={styles.headerBack} />
+      <Text style={[screenLayout.headerTitle, styles.headerTitleScan]}>解析結果の確認</Text>
+      <AppButton
+        title={BUTTON_LABELS.save}
+        onPress={scan.handleCommit}
+        loading={scan.loading}
+        disabled={scan.loading}
+        size="sm"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerScan: { backgroundColor: c.surface, borderBottomColor: s.borderLight },
+  headerTitleScan: { fontSize: 17, color: s.textTitle },
+  headerBack: { minWidth: 50 },
+});

--- a/frontend/src/features/receipt/components/ReceiptScanItemList.tsx
+++ b/frontend/src/features/receipt/components/ReceiptScanItemList.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { AppButton, AppFormField, AppSelect, AppTextInput } from '../../../components/ui';
+import { BUTTON_LABELS } from '../../../constants/buttonLabels';
+import { colors } from '../../../theme/colors';
+import { spacing } from '../../../theme/spacing';
+import { cardStyles } from '../../../theme/cardStyles';
+import type { ReceiptScanFlow } from '../hooks/useReceiptScan';
+
+const c = colors;
+const s = colors.semantic.scan;
+
+type Props = {
+  scan: ReceiptScanFlow;
+};
+
+export function ReceiptScanItemList({ scan }: Props) {
+  return (
+    <>
+      <View style={styles.itemsHeader}>
+        <Text style={styles.sectionLabel}>商品明細 ({scan.receiptData.items.length})</Text>
+        <AppButton
+          title={`+ ${BUTTON_LABELS.add}`}
+          onPress={scan.addItem}
+          variant="outline"
+          size="sm"
+        />
+      </View>
+
+      {scan.receiptData.items.map((item, idx) => (
+        <View key={idx} style={[cardStyles.chartCard, styles.itemCard]}>
+          <View style={styles.itemHeaderRow}>
+            <AppTextInput
+              style={styles.itemNameInput}
+              value={item.name}
+              onChangeText={(val) => scan.updateItem(idx, 'name', val)}
+              placeholder="商品名"
+            />
+            <TouchableOpacity onPress={() => scan.removeItem(idx)}>
+              <Text style={styles.deleteIcon}>🗑️</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.itemDetailRow}>
+            <View style={styles.itemSubGroup}>
+              <Text style={styles.subLabel}>単価 (¥)</Text>
+              <AppTextInput
+                value={String(item.price)}
+                keyboardType="decimal-pad"
+                onChangeText={(val) => scan.updateItem(idx, 'price', val)}
+              />
+            </View>
+            <View style={[styles.itemSubGroup, { flex: 0.6 }]}>
+              <Text style={styles.subLabel}>数量</Text>
+              <AppTextInput
+                value={String(item.quantity)}
+                keyboardType="decimal-pad"
+                onChangeText={(val) => scan.updateItem(idx, 'quantity', val)}
+              />
+            </View>
+            <View style={[styles.itemSubGroup, { alignItems: 'flex-end' }]}>
+              <Text style={styles.subLabel}>小計</Text>
+              <Text style={styles.subTotalText}>
+                ¥{' '}
+                {Math.round(
+                  (parseFloat(String(item.price)) || 0) * (parseFloat(String(item.quantity)) || 0)
+                ).toLocaleString()}
+              </Text>
+            </View>
+          </View>
+
+          <AppFormField label="カテゴリ">
+            <AppSelect<number | null>
+              selectedValue={item.categoryId}
+              onValueChange={(val) => scan.updateItem(idx, 'categoryId', val)}
+              options={scan.categorySelectOptions}
+              placeholder="未選択"
+            />
+          </AppFormField>
+        </View>
+      ))}
+      <View style={{ height: 60 }} />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  itemsHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginHorizontal: spacing.md,
+    marginBottom: 12,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: s.textMuted,
+    textTransform: 'uppercase',
+    marginBottom: 12,
+  },
+  itemCard: {
+    minHeight: undefined,
+    alignItems: 'stretch',
+    marginHorizontal: spacing.md,
+    marginBottom: 12,
+    borderLeftWidth: 4,
+    borderLeftColor: c.primary,
+    elevation: 1,
+  },
+  itemHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
+  itemNameInput: { flex: 1, marginRight: 8 },
+  deleteIcon: { fontSize: 18, color: s.deleteIcon },
+  itemDetailRow: { flexDirection: 'row', gap: 12, alignItems: 'center', marginBottom: 12 },
+  itemSubGroup: { flex: 1 },
+  subLabel: { fontSize: 10, color: s.textMuted, fontWeight: 'bold', marginBottom: 4 },
+  subTotalText: { fontSize: 14, fontWeight: '700', color: s.textItem, paddingTop: 4 },
+});

--- a/frontend/src/features/receipt/components/ReceiptScanPreview.tsx
+++ b/frontend/src/features/receipt/components/ReceiptScanPreview.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, ImageSourcePropType } from 'react-native';
+import { colors } from '../../../theme/colors';
+import { spacing } from '../../../theme/spacing';
+import { borderRadius } from '../../../theme/radii';
+import type { ReceiptScanInitialData } from '../../../types/receiptScan';
+
+const c = colors;
+const s = colors.semantic.scan;
+
+type Props = {
+  initialData: ReceiptScanInitialData;
+  imageSource: ImageSourcePropType | null;
+};
+
+export function ReceiptScanPreview({ initialData, imageSource }: Props) {
+  return (
+    <>
+      {initialData.duplicateSuspected ? (
+        <View style={styles.duplicateBanner}>
+          <Text style={styles.duplicateBannerTitle}>重複の疑い</Text>
+          <Text style={styles.duplicateBannerText}>
+            同じ店名・日付・金額のレシートが登録済みの可能性があります。
+            {initialData.existingReceiptId
+              ? `（既存レシート ID: ${initialData.existingReceiptId}）`
+              : ''}
+            {' '}内容を確認のうえ、問題なければ保存できます。
+          </Text>
+        </View>
+      ) : null}
+
+      {imageSource ? (
+        <View style={styles.imageContainer}>
+          <Image source={imageSource} style={styles.receiptImage} resizeMode="contain" />
+          <View style={styles.imageLabel}>
+            <Text style={styles.imageLabelText}>加工済みプレビュー</Text>
+          </View>
+        </View>
+      ) : null}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  duplicateBanner: {
+    marginHorizontal: spacing.md,
+    marginTop: spacing.md,
+    marginBottom: spacing.sm,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.semantic.warning.bg,
+    borderWidth: 1,
+    borderColor: colors.semantic.warning.border,
+  },
+  duplicateBannerTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.semantic.warning.text,
+    marginBottom: 4,
+  },
+  duplicateBannerText: {
+    fontSize: 13,
+    color: colors.semantic.warning.text,
+    lineHeight: 20,
+  },
+  imageContainer: {
+    width: '100%',
+    height: 260,
+    backgroundColor: s.imageBg,
+    marginBottom: spacing.md,
+    position: 'relative',
+  },
+  receiptImage: { width: '100%', height: '100%' },
+  imageLabel: {
+    position: 'absolute',
+    bottom: 8,
+    right: 8,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: borderRadius.sm,
+  },
+  imageLabelText: { color: c.text.inverse, fontSize: 10, fontWeight: 'bold' },
+});

--- a/frontend/src/features/receipt/hooks/useReceiptScan.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptScan.ts
@@ -125,3 +125,5 @@ export function useReceiptScan({
     handleCommit,
   };
 }
+
+export type ReceiptScanFlow = ReturnType<typeof useReceiptScan>;

--- a/frontend/src/features/receipt/index.ts
+++ b/frontend/src/features/receipt/index.ts
@@ -1,10 +1,15 @@
 export { useReceiptDetail } from './hooks/useReceiptDetail';
 export type { ReceiptDetailFlow } from './hooks/useReceiptDetail';
 export { useReceiptScan } from './hooks/useReceiptScan';
+export type { ReceiptScanFlow } from './hooks/useReceiptScan';
 export { ReceiptDetailComponent } from './components/ReceiptDetailComponent';
 export type { ReceiptDetailComponentProps } from './components/ReceiptDetailComponent';
 export { ReceiptDetailActions } from './components/ReceiptDetailActions';
 export { ReceiptDetailHeader } from './components/ReceiptDetailHeader';
 export { ReceiptDetailImagePanel } from './components/ReceiptDetailImagePanel';
 export { ReceiptDetailItemList } from './components/ReceiptDetailItemList';
+export { ReceiptScanHeader } from './components/ReceiptScanHeader';
+export { ReceiptScanPreview } from './components/ReceiptScanPreview';
+export { ReceiptScanForm } from './components/ReceiptScanForm';
+export { ReceiptScanItemList } from './components/ReceiptScanItemList';
 export { receiptDetailStyles } from './styles/receiptDetailStyles';

--- a/frontend/src/screens/ReceiptScanScreen.tsx
+++ b/frontend/src/screens/ReceiptScanScreen.tsx
@@ -1,28 +1,17 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  ScrollView,
-  TouchableOpacity,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  Image,
-} from 'react-native';
+import { StyleSheet, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { AppBackButton, AppButton, AppFormField, AppSelect, AppTextInput } from '../components/ui';
-import { useReceiptScan } from '../features/receipt';
-import { modalStyles } from '../theme/modalStyles';
+import {
+  ReceiptScanForm,
+  ReceiptScanHeader,
+  ReceiptScanItemList,
+  ReceiptScanPreview,
+  useReceiptScan,
+} from '../features/receipt';
 import { colors } from '../theme/colors';
-import { spacing } from '../theme/spacing';
-import { borderRadius } from '../theme/radii';
-import { cardStyles } from '../theme/cardStyles';
 import { screenLayout } from '../theme/screenLayout';
-import { BUTTON_LABELS } from '../constants/buttonLabels';
 import type { ReceiptScanInitialData } from '../types/receiptScan';
 
-const c = colors;
 const s = colors.semantic.scan;
 
 interface ReceiptScanScreenProps {
@@ -33,7 +22,7 @@ interface ReceiptScanScreenProps {
 }
 
 /**
- * [Issue #67 / #71 / #100-14] レシート解析結果の確認・編集画面 — Hook + UI
+ * [Issue #67 / #71 / #100-14 / #104-2] レシート解析結果の確認・編集画面 — Hook + UI
  */
 export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
   initialData,
@@ -46,134 +35,11 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
   return (
     <SafeAreaView style={[screenLayout.container, styles.containerScan]}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
-        <View style={[screenLayout.header, styles.headerScan]}>
-          <AppBackButton onPress={onCancel} style={styles.headerBack} />
-          <Text style={[screenLayout.headerTitle, styles.headerTitleScan]}>解析結果の確認</Text>
-          <AppButton
-            title={BUTTON_LABELS.save}
-            onPress={scan.handleCommit}
-            loading={scan.loading}
-            disabled={scan.loading}
-            size="sm"
-          />
-        </View>
-
+        <ReceiptScanHeader onCancel={onCancel} scan={scan} />
         <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-          {initialData.duplicateSuspected ? (
-            <View style={styles.duplicateBanner}>
-              <Text style={styles.duplicateBannerTitle}>重複の疑い</Text>
-              <Text style={styles.duplicateBannerText}>
-                同じ店名・日付・金額のレシートが登録済みの可能性があります。
-                {initialData.existingReceiptId
-                  ? `（既存レシート ID: ${initialData.existingReceiptId}）`
-                  : ''}
-                {' '}内容を確認のうえ、問題なければ保存できます。
-              </Text>
-            </View>
-          ) : null}
-
-          {scan.imageSource && (
-            <View style={styles.imageContainer}>
-              <Image source={scan.imageSource} style={styles.receiptImage} resizeMode="contain" />
-              <View style={styles.imageLabel}><Text style={styles.imageLabelText}>加工済みプレビュー</Text></View>
-            </View>
-          )}
-
-          <View style={[cardStyles.chartCard, styles.card]}>
-            <Text style={styles.sectionLabel}>基本情報</Text>
-            <AppFormField label="店舗名">
-              <AppTextInput
-                value={scan.receiptData.storeName}
-                onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, storeName: val })}
-                placeholder="店舗名"
-              />
-            </AppFormField>
-            <AppFormField label="購入日時">
-              <AppTextInput
-                value={scan.receiptData.purchaseDate}
-                onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, purchaseDate: val })}
-                placeholder="YYYY-MM-DD HH:mm"
-              />
-            </AppFormField>
-
-            <AppFormField label="消費税 (外税・加算額)">
-              <View style={modalStyles.inputWithUnit}>
-                <AppTextInput
-                  variant="inline"
-                  value={String(scan.receiptData.taxAmount)}
-                  keyboardType="decimal-pad"
-                  onChangeText={(val) => scan.setReceiptData({ ...scan.receiptData, taxAmount: val })}
-                />
-                <Text style={modalStyles.unitSuffix}>円</Text>
-              </View>
-            </AppFormField>
-
-            <View style={styles.totalDisplay}>
-              <Text style={styles.totalLabel}>支払合計 (税込)</Text>
-              <Text style={styles.totalValue}>¥ {scan.calculatedTotal.toLocaleString()}</Text>
-            </View>
-          </View>
-
-          <View style={styles.itemsHeader}>
-            <Text style={styles.sectionLabel}>商品明細 ({scan.receiptData.items.length})</Text>
-            <AppButton
-              title={`+ ${BUTTON_LABELS.add}`}
-              onPress={scan.addItem}
-              variant="outline"
-              size="sm"
-            />
-          </View>
-
-          {scan.receiptData.items.map((item, idx) => (
-            <View key={idx} style={[cardStyles.chartCard, styles.itemCard]}>
-              <View style={styles.itemHeaderRow}>
-                <AppTextInput
-                  style={styles.itemNameInput}
-                  value={item.name}
-                  onChangeText={(val) => scan.updateItem(idx, 'name', val)}
-                  placeholder="商品名"
-                />
-                <TouchableOpacity onPress={() => scan.removeItem(idx)}>
-                  <Text style={styles.deleteIcon}>🗑️</Text>
-                </TouchableOpacity>
-              </View>
-
-              <View style={styles.itemDetailRow}>
-                <View style={styles.itemSubGroup}>
-                  <Text style={styles.subLabel}>単価 (¥)</Text>
-                  <AppTextInput
-                    value={String(item.price)}
-                    keyboardType="decimal-pad"
-                    onChangeText={(val) => scan.updateItem(idx, 'price', val)}
-                  />
-                </View>
-                <View style={[styles.itemSubGroup, { flex: 0.6 }]}>
-                  <Text style={styles.subLabel}>数量</Text>
-                  <AppTextInput
-                    value={String(item.quantity)}
-                    keyboardType="decimal-pad"
-                    onChangeText={(val) => scan.updateItem(idx, 'quantity', val)}
-                  />
-                </View>
-                <View style={[styles.itemSubGroup, { alignItems: 'flex-end' }]}>
-                  <Text style={styles.subLabel}>小計</Text>
-                  <Text style={styles.subTotalText}>
-                    ¥ {Math.round((parseFloat(String(item.price)) || 0) * (parseFloat(String(item.quantity)) || 0)).toLocaleString()}
-                  </Text>
-                </View>
-              </View>
-
-              <AppFormField label="カテゴリ">
-                <AppSelect<number | null>
-                  selectedValue={item.categoryId}
-                  onValueChange={(val) => scan.updateItem(idx, 'categoryId', val)}
-                  options={scan.categorySelectOptions}
-                  placeholder="未選択"
-                />
-              </AppFormField>
-            </View>
-          ))}
-          <View style={{ height: 60 }} />
+          <ReceiptScanPreview initialData={initialData} imageSource={scan.imageSource} />
+          <ReceiptScanForm scan={scan} />
+          <ReceiptScanItemList scan={scan} />
         </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -182,55 +48,5 @@ export const ReceiptScanScreen: React.FC<ReceiptScanScreenProps> = ({
 
 const styles = StyleSheet.create({
   containerScan: { backgroundColor: s.background },
-  headerScan: { backgroundColor: c.surface, borderBottomColor: s.borderLight },
-  headerTitleScan: { fontSize: 17, color: s.textTitle },
-  headerBack: { minWidth: 50 },
-  duplicateBanner: {
-    marginHorizontal: spacing.md,
-    marginTop: spacing.md,
-    marginBottom: spacing.sm,
-    padding: spacing.md,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.semantic.warning.bg,
-    borderWidth: 1,
-    borderColor: colors.semantic.warning.border,
-  },
-  duplicateBannerTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: colors.semantic.warning.text,
-    marginBottom: 4,
-  },
-  duplicateBannerText: {
-    fontSize: 13,
-    color: colors.semantic.warning.text,
-    lineHeight: 20,
-  },
   scrollView: { flex: 1 },
-  imageContainer: { width: '100%', height: 260, backgroundColor: s.imageBg, marginBottom: spacing.md, position: 'relative' },
-  receiptImage: { width: '100%', height: '100%' },
-  imageLabel: { position: 'absolute', bottom: 8, right: 8, backgroundColor: 'rgba(0,0,0,0.6)', paddingHorizontal: 8, paddingVertical: 4, borderRadius: borderRadius.sm },
-  imageLabelText: { color: c.text.inverse, fontSize: 10, fontWeight: 'bold' },
-  card: { minHeight: undefined, alignItems: 'stretch', margin: spacing.md, marginTop: 0, elevation: 2 },
-  sectionLabel: { fontSize: 12, fontWeight: 'bold', color: s.textMuted, textTransform: 'uppercase', marginBottom: 12 },
-  totalDisplay: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 8, paddingTop: spacing.md, borderTopWidth: 1, borderTopColor: s.borderInput },
-  totalLabel: { fontSize: 14, color: s.textSecondary },
-  totalValue: { fontSize: 24, fontWeight: 'bold', color: c.primary },
-  itemsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginHorizontal: spacing.md, marginBottom: 12 },
-  itemCard: {
-    minHeight: undefined,
-    alignItems: 'stretch',
-    marginHorizontal: spacing.md,
-    marginBottom: 12,
-    borderLeftWidth: 4,
-    borderLeftColor: c.primary,
-    elevation: 1,
-  },
-  itemHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
-  itemNameInput: { flex: 1, marginRight: 8 },
-  deleteIcon: { fontSize: 18, color: s.deleteIcon },
-  itemDetailRow: { flexDirection: 'row', gap: 12, alignItems: 'center', marginBottom: 12 },
-  itemSubGroup: { flex: 1 },
-  subLabel: { fontSize: 10, color: s.textMuted, fontWeight: 'bold', marginBottom: 4 },
-  subTotalText: { fontSize: 14, fontWeight: '700', color: s.textItem, paddingTop: 4 },
 });


### PR DESCRIPTION
## Summary

- `ReceiptScanScreen`（237行）を子コンポーネントに分割し **52行** に整理
- `features/receipt/components/` に `ReceiptScanHeader` / `ReceiptScanPreview` / `ReceiptScanForm` / `ReceiptScanItemList` を新設
- `useReceiptScan` に `ReceiptScanFlow` 型を export 追加

Closes #505

## 行数

| ファイル | 行数 |
|----------|------|
| `ReceiptScanScreen.tsx` | 237 → **52** |
| `ReceiptScanHeader.tsx` | 37 |
| `ReceiptScanPreview.tsx` | 84 |
| `ReceiptScanForm.tsx` | 76 |
| `ReceiptScanItemList.tsx` | 118 |

## 依存

- #104-1（PR #508）マージ済み

## Test plan

- [x] `cd frontend && npm test` パス
- [ ] 手動: 解析結果表示・明細編集・保存・重複バナー・キャンセル


Made with [Cursor](https://cursor.com)