### PR TITLE
test: itemLineTotal の FE/BE contract test と SSOT 明文化（#105-1）

### DIFF
--- a/backend/src/utils/itemLineTotal.test.ts
+++ b/backend/src/utils/itemLineTotal.test.ts
@@ -1,24 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { calcItemLineTotal } from './itemLineTotal';
 
-describe('calcItemLineTotal', () => {
-  it('rounds price × quantity to integer yen', () => {
-    expect(calcItemLineTotal(99.5, 2)).toBe(199);
-  });
+type ItemLineTotalVector = {
+  id: string;
+  price: unknown;
+  quantity?: unknown;
+  expected: number;
+};
 
-  it('parses string price and quantity', () => {
-    expect(calcItemLineTotal('108', '3')).toBe(324);
-  });
+type ItemLineTotalFixture = {
+  vectors: ItemLineTotalVector[];
+};
 
-  it('defaults quantity to 1', () => {
-    expect(calcItemLineTotal(498)).toBe(498);
-  });
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../docs/testing/fixtures/itemLineTotal-vectors.json'
+);
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8')) as ItemLineTotalFixture;
 
-  it('treats invalid quantity as 1', () => {
-    expect(calcItemLineTotal(100, 'abc')).toBe(100);
-  });
-
-  it('returns 0 for zero price', () => {
-    expect(calcItemLineTotal(0, 5)).toBe(0);
+describe('calcItemLineTotal contract (itemLineTotal-vectors.json)', () => {
+  it.each(fixture.vectors)('$id', ({ price, quantity, expected }) => {
+    if (quantity === undefined) {
+      expect(calcItemLineTotal(price)).toBe(expected);
+      return;
+    }
+    expect(calcItemLineTotal(price, quantity)).toBe(expected);
   });
 });

--- a/backend/src/utils/itemLineTotal.ts
+++ b/backend/src/utils/itemLineTotal.ts
@@ -1,6 +1,13 @@
 /**
- * 明細行の税込小計（円・整数丸め）。
- * Frontend の calcItemTotal（splitEditorSplits.ts）と同じ式。
+ * 明細行の税込小計（円・整数丸め）— **SSOT（Single Source of Truth）**
+ *
+ * 按分・精算の itemLineTotal 計算の正本。Frontend は UI プレビュー用に
+ * `frontend/src/domain/settlement/itemSplit.ts` の `calcItemTotal` がミラー実装。
+ *
+ * 変更時: `docs/testing/fixtures/itemLineTotal-vectors.json` を更新し、
+ * BE/FE の contract test がパスすることを確認する（#105-1）。
+ *
+ * @see docs/design/domain-model.md §4.1
  */
 export function calcItemLineTotal(price: unknown, quantity: unknown = 1): number {
   const unit =

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -163,12 +163,20 @@ erDiagram
 itemLineTotal = Math.round(price × quantity)
 ```
 
-| 実装 | ファイル |
+| 役割 | ファイル |
 |------|----------|
-| Backend | `backend/src/utils/itemLineTotal.ts` — `calcItemLineTotal()` |
-| Frontend | `frontend/src/utils/splitEditorSplits.ts` — `calcItemTotal()` |
+| **SSOT（正本）** | `backend/src/utils/itemLineTotal.ts` — `calcItemLineTotal()` |
+| FE ミラー（UI プレビュー） | `frontend/src/domain/settlement/itemSplit.ts` — `calcItemTotal()` |
+| Contract test | `docs/testing/fixtures/itemLineTotal-vectors.json` — BE/FE 同一ベクトル |
 
-Frontend / Backend で同一式を使用する（テスト [#91-2](https://github.com/yama180sx/receipt-ai-app/issues/279) で検証）。
+**ルール変更手順（#105-1）**
+
+1. `itemLineTotal.ts`（SSOT）を更新
+2. `itemLineTotal-vectors.json` にケースを追加
+3. `calcItemTotal`（FE ミラー）を同期
+4. `npm test`（frontend / backend）で contract test がパスすること
+
+保存・精算の正は Backend のみ。FE の `calcItemTotal` は編集中プレビュー用。
 
 ### 4.2 暗黙的デフォルト（splits 0 件）
 
@@ -244,8 +252,8 @@ UI 上の端数負担者（先頭） → payload では末尾 → Backend の al
 
 | 実装 | ファイル |
 |------|----------|
-| payload 生成 | `frontend/src/utils/splitEditorSplits.ts` — `buildItemSplitSavePayload()` |
-| テスト | `frontend/src/utils/splitEditorSplits.test.ts` |
+| payload 生成 | `frontend/src/domain/settlement/itemSplit.ts` — `buildItemSplitSavePayload()` |
+| テスト | `frontend/src/domain/settlement/itemSplit.test.ts` |
 
 > **T-ref-03**（[findings.md](../testing/findings.md)）: Frontend payload 末尾配置と Backend allocate 一致
 

--- a/docs/testing/fixtures/itemLineTotal-vectors.json
+++ b/docs/testing/fixtures/itemLineTotal-vectors.json
@@ -1,0 +1,47 @@
+{
+  "description": "明細行税込小計（itemLineTotal）の FE/BE contract test ベクトル。正本は backend/src/utils/itemLineTotal.ts（calcItemLineTotal）。",
+  "ssot": "backend/src/utils/itemLineTotal.ts",
+  "feMirror": "frontend/src/domain/settlement/itemSplit.ts",
+  "vectors": [
+    {
+      "id": "round-half-up",
+      "price": 99.5,
+      "quantity": 2,
+      "expected": 199
+    },
+    {
+      "id": "string-price-quantity",
+      "price": "108",
+      "quantity": "3",
+      "expected": 324
+    },
+    {
+      "id": "default-quantity",
+      "price": 498,
+      "expected": 498
+    },
+    {
+      "id": "invalid-quantity-falls-back-to-one",
+      "price": 100,
+      "quantity": "abc",
+      "expected": 100
+    },
+    {
+      "id": "zero-price",
+      "price": 0,
+      "quantity": 5,
+      "expected": 0
+    },
+    {
+      "id": "api-string-values",
+      "price": "250",
+      "quantity": "2",
+      "expected": 500
+    },
+    {
+      "id": "integer-unit-price-only",
+      "price": 108,
+      "expected": 108
+    }
+  ]
+}

--- a/frontend/src/domain/settlement/itemSplit.test.ts
+++ b/frontend/src/domain/settlement/itemSplit.test.ts
@@ -1,17 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildItemSplitSavePayload, calcItemTotal } from './itemSplit';
 
-describe('calcItemTotal', () => {
-  it('matches backend calcItemLineTotal rounding', () => {
-    expect(calcItemTotal({ price: 99.5, quantity: 2 })).toBe(199);
-  });
+type ItemLineTotalVector = {
+  id: string;
+  price: unknown;
+  quantity?: unknown;
+  expected: number;
+};
 
-  it('defaults quantity to 1', () => {
-    expect(calcItemTotal({ price: 108 })).toBe(108);
-  });
+type ItemLineTotalFixture = {
+  vectors: ItemLineTotalVector[];
+};
 
-  it('handles string-like values from API', () => {
-    expect(calcItemTotal({ price: '250', quantity: '2' })).toBe(500);
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../docs/testing/fixtures/itemLineTotal-vectors.json'
+);
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8')) as ItemLineTotalFixture;
+
+describe('calcItemTotal contract (itemLineTotal-vectors.json)', () => {
+  it.each(fixture.vectors)('$id', ({ price, quantity, expected }) => {
+    const item =
+      quantity === undefined ? { price } : { price, quantity };
+    expect(calcItemTotal(item)).toBe(expected);
   });
 });
 

--- a/frontend/src/domain/settlement/itemSplit.ts
+++ b/frontend/src/domain/settlement/itemSplit.ts
@@ -1,6 +1,12 @@
 import type { ItemSplitInput } from '../../api/generated';
 
-/** 明細の税込小計（Backend の calcItemLineTotal と同じ丸め） */
+/**
+ * 明細行の税込小計（UI プレビュー用ミラー）。
+ * 正本（SSOT）: `backend/src/utils/itemLineTotal.ts` — `calcItemLineTotal`
+ * Contract test: `docs/testing/fixtures/itemLineTotal-vectors.json`
+ *
+ * @see docs/design/domain-model.md §4.1
+ */
 export function calcItemTotal(item: {
   price?: unknown;
   quantity?: unknown;


### PR DESCRIPTION
## Summary

- `docs/testing/fixtures/itemLineTotal-vectors.json` を追加し、BE `calcItemLineTotal` と FE `calcItemTotal` が同一ベクトルで contract test されるようにした
- SSOT を `backend/src/utils/itemLineTotal.ts` と明文化し、`itemLineTotal.ts` / `itemSplit.ts` のコメントを統一
- `docs/design/domain-model.md` §4.1 / §4.4 のパス参照を現行構成に更新し、ルール変更手順を追記

Closes #514

## Test plan

- [x] `npm test`（frontend）— contract test 7 ケース + buildItemSplitSavePayload
- [x] `npm test -- src/utils/itemLineTotal.test.ts`（backend）— contract test 7 ケース


Made with [Cursor](https://cursor.com)