### PR TITLE
fix(backend): receiptApi の query 組み立てから as any を除去（#105-2）

### DIFF
--- a/backend/src/api/receiptApi.ts
+++ b/backend/src/api/receiptApi.ts
@@ -44,9 +44,16 @@ export const updateItemCategory = async (itemId: number, categoryId: number): Pr
  * レシート一覧を取得
  * @param params { memberId?: number, month?: string }
  */
-export const fetchReceipts = async (params: { memberId?: number, month?: string } = {}) => {
-  const query = new URLSearchParams(params as any).toString();
-  const response = await fetch(`${BASE_URL}/receipts?${query}`);
+export const fetchReceipts = async (params: { memberId?: number; month?: string } = {}) => {
+  const search = new URLSearchParams();
+  if (params.memberId !== undefined) {
+    search.set('memberId', String(params.memberId));
+  }
+  if (params.month !== undefined) {
+    search.set('month', params.month);
+  }
+  const query = search.toString();
+  const response = await fetch(`${BASE_URL}/receipts${query ? `?${query}` : ''}`);
   if (!response.ok) throw new Error('Failed to fetch receipts');
   return response.json();
 };


### PR DESCRIPTION
## Summary

- `backend/src/api/receiptApi.ts` の `URLSearchParams(params as any)` を、optional パラメータを明示的に `set` する型安全な実装に置き換え
- `backend/src/` 配下の `as any` を 0 件に（スクリプト・テストの `expect.any` はスコープ外のまま）

Closes #515

## Test plan

- [x] `grep 'as any' backend/src` — 0 件
- [x] `npm test`（backend）— 70 passed


Made with [Cursor](https://cursor.com)