### PR TITLE
docs: 割り勘変更ガイド追加と domain-model の as-built 整合（#105-3）

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,6 +14,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | 全体像・技術スタック | [architecture.md](./architecture.md) |
 | DB 列定義・制約 | [database-schema.md](./database-schema.md) |
 | 精算・按分の業務ルール | [domain-model.md](./domain-model.md) |
+| **按分・精算ルールを変更するとき** | [settlement-change-guide.md](./settlement-change-guide.md) |
 | API 連携 | [api-spec.md](./api-spec.md) |
 | レシート AI 解析 | [ai-pipeline.md](./ai-pipeline.md) |
 | 画面・UX | [frontend-screens.md](./frontend-screens.md) |
@@ -30,6 +31,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | [architecture.md](./architecture.md) | アーキテクチャ・デプロイ | #90-1 |
 | [database-schema.md](./database-schema.md) | DB 列定義・制約（Prisma 準拠） | 統合（ChatGPT Phase1 突合） |
 | [domain-model.md](./domain-model.md) | ドメイン意味・精算・按分 | #90-2 |
+| [settlement-change-guide.md](./settlement-change-guide.md) | 按分・精算ルール変更時の触るファイル・順序 | #105-3 |
 | [api-spec.md](./api-spec.md) | API 仕様 | #90-3 |
 | [ai-pipeline.md](./ai-pipeline.md) | 3層正規化・AI パイプライン | #90-4 |
 | [frontend-screens.md](./frontend-screens.md) | 画面遷移・フロント | #90-5 |

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -155,6 +155,8 @@ erDiagram
 
 ## 4. 按分（ItemSplit）業務ルール
 
+> **変更時:** [settlement-change-guide.md](./settlement-change-guide.md) — 触るファイル一覧と作業順序
+
 ### 4.1 明細小計の算出
 
 明細行の税込小計は **整数円に四捨五入** する。
@@ -188,13 +190,15 @@ itemLineTotal = Math.round(price × quantity)
 | 按分クリア（空配列 POST） | 既存 ItemSplit を全削除 → 暗黙デフォルトに戻る |
 
 ```typescript
-// statsController.ts — 精算集計の分岐
+// settlementAggregation.ts — aggregateReceiptsIntoStats()
 if (item.splits.length > 0) {
   // 明示按分: 各 split.amount を totalOwed に加算
 } else {
   // 暗黙デフォルト: receipt.memberId に itemLineTotal を加算
 }
 ```
+
+> 実装: `backend/src/services/settlement/settlementAggregation.ts` — `aggregateReceiptsIntoStats()`
 
 > **T-ref-02**（[findings.md](../testing/findings.md)）: ItemSplit 0 件 = 登録者全額負担（暗黙）
 
@@ -223,7 +227,8 @@ if (item.splits.length > 0) {
 | バリデーション | 重複 memberId 禁止、負数禁止、合計 ≠ 小計は 400 エラー |
 | テナント検証 | 全 `familyMemberId` が同一 `familyGroupId` 所属であること |
 
-実装: `backend/src/utils/itemSplitAllocation.ts`
+実装: `backend/src/utils/itemSplitAllocation.ts`  
+保存: `backend/src/services/receipt/receiptSplitService.ts` — `updateItemSplitsById()`
 
 #### 端数ルール（最後のメンバーに残額）
 
@@ -261,6 +266,8 @@ UI 上の端数負担者（先頭） → payload では末尾 → Backend の al
 
 ## 5. 精算サマリー — 概念モデル
 
+> **変更時:** [settlement-change-guide.md](./settlement-change-guide.md) §2.4
+
 月次精算（`GET /api/stats/settlement`）は、対象月の全レシートと送金記録から **メンバーごとの残額** を算出する。
 
 ### 5.1 集計フロー
@@ -277,7 +284,13 @@ flowchart TD
     G --> H[balance を算出]
 ```
 
-実装: `backend/src/controllers/statsController.ts` — `getSettlementStatus()`
+実装:
+
+| レイヤー | ファイル |
+|----------|----------|
+| 集計（純粋関数） | `backend/src/services/settlement/settlementAggregation.ts` — `computeSettlementMemberSummaries()` |
+| データ取得 | `backend/src/services/settlement/settlementService.ts` — `getSettlementStatusData()` |
+| HTTP | `backend/src/controllers/statsController.ts` — `getSettlementStatus()` |
 
 ### 5.2 メンバーごとの指標
 
@@ -384,6 +397,7 @@ A が B へ 100 円送金を記録（`SettlementTransfer`）すると:
 
 ## 9. 関連資料
 
+- [settlement-change-guide.md](./settlement-change-guide.md) — 按分・精算ルール変更時のファイル一覧・作業順序（#105-3）
 - [domain-model.md](./domain-model.md) — 業務ルール・精算
 - [database-schema.md](./database-schema.md) — DB 列定義
 - [architecture.md](./architecture.md) — システム構成（#90-1）

--- a/docs/design/settlement-change-guide.md
+++ b/docs/design/settlement-change-guide.md
@@ -1,0 +1,197 @@
+# 割り勘・精算ルール変更ガイド
+
+Epic: [#512 Issue #105](https://github.com/yama180sx/receipt-ai-app/issues/512)  
+子 Issue: [#516 Issue #105-3](https://github.com/yama180sx/receipt-ai-app/issues/516)
+
+業務ルールの正本は [domain-model.md](./domain-model.md) §4〜§5。本ガイドは **ルール変更時にどのファイルを、どの順序で触るか** を as-built で示す。
+
+| 資料 | 内容 |
+|------|------|
+| [domain-model.md](./domain-model.md) | 按分・精算の業務ルール（What） |
+| [api-spec.md](./api-spec.md) | 精算 API エンドポイント |
+| [docs/openapi/openapi.yaml](../openapi/openapi.yaml) | API 契約 SSOT（機械可読） |
+| [docs/testing/fixtures/itemLineTotal-vectors.json](../testing/fixtures/itemLineTotal-vectors.json) | 明細小計の FE/BE contract test |
+
+---
+
+## 1. レイヤー概要
+
+按分・精算ロジックは FE domain / FE features / BE services / BE utils に跨る。**保存・精算の正は Backend のみ**。Frontend は編集 UI とプレビュー。
+
+```mermaid
+flowchart LR
+  subgraph fe [Frontend]
+    Domain["domain/settlement/<br/>itemSplit, splitEditorInit"]
+    Features["features/settlement/<br/>hooks, mutations, UI"]
+    Api["api/receiptApi, statsApi"]
+  end
+
+  subgraph be [Backend]
+    Routes["routes/receiptRoutes, statsRoutes"]
+    Services["receiptSplitService<br/>settlementService"]
+    Utils["itemLineTotal<br/>itemSplitAllocation"]
+    Agg["settlementAggregation"]
+  end
+
+  OpenAPI["docs/openapi/openapi.yaml"]
+
+  Features --> Domain
+  Features --> Api
+  Api --> Routes
+  Routes --> Services
+  Services --> Utils
+  Services --> Agg
+  OpenAPI -.-> Routes
+```
+
+---
+
+## 2. 変更種別ごとのチェックリスト
+
+### 2.1 明細小計（itemLineTotal）— domain-model §4.1
+
+| 順序 | 触る場所 | 役割 |
+|------|----------|------|
+| 1 | `backend/src/utils/itemLineTotal.ts` | **SSOT** — `calcItemLineTotal()` |
+| 2 | `docs/testing/fixtures/itemLineTotal-vectors.json` | contract test ベクトル追加 |
+| 3 | `frontend/src/domain/settlement/itemSplit.ts` | FE ミラー — `calcItemTotal()` |
+| 4 | `backend/src/utils/itemLineTotal.test.ts` | BE contract test |
+| 5 | `frontend/src/domain/settlement/itemSplit.test.ts` | FE contract test |
+| 6 | `docs/design/domain-model.md` §4.1 | 業務ルール記述 |
+
+**確認:** `npm test`（frontend / backend）で contract test がパスすること。
+
+### 2.2 按分額の算出（allocateItemSplits）— §4.3
+
+| 順序 | 触る場所 | 役割 |
+|------|----------|------|
+| 1 | `backend/src/utils/itemSplitAllocation.ts` | 端数・ratio/amount ルールの **SSOT** |
+| 2 | `backend/src/utils/itemSplitAllocation.test.ts` | 単体テスト（T-ref-01 等） |
+| 3 | `backend/src/services/receipt/receiptSplitService.ts` | 保存オーケストレーション（`calcItemLineTotal` → `allocateItemSplits` → DB） |
+| 4 | `frontend/src/domain/settlement/itemSplit.ts` | `buildItemSplitSavePayload()` — 端数負担者を配列末尾へ |
+| 5 | `frontend/src/domain/settlement/itemSplit.test.ts` | payload 順序テスト（T-ref-03） |
+| 6 | `frontend/src/features/settlement/utils/splitEditorMutations.ts` | UI 編集時の percent / amount 計算 |
+| 7 | `frontend/src/features/settlement/utils/splitEditorMutations.test.ts` | UI  mutation テスト |
+| 8 | `docs/design/domain-model.md` §4.3, §4.4 | 業務ルール記述 |
+
+**API 契約を変える場合（追加）:**
+
+| 順序 | 触る場所 |
+|------|----------|
+| A | `docs/openapi/openapi.yaml` — `/receipts/items/{itemId}/splits` |
+| B | `docs/design/api-spec.md` |
+| C | `npm run generate:api`（frontend）— generated 型の再生成 |
+| D | `backend/src/openapiDrift.test.ts` がパスすること |
+
+### 2.3 暗黙デフォルト（splits 0 件）— §4.2
+
+| 順序 | 触る場所 | 役割 |
+|------|----------|------|
+| 1 | `backend/src/services/receipt/receiptSplitService.ts` | 空配列 POST → ItemSplit 全削除 |
+| 2 | `backend/src/services/settlement/settlementAggregation.ts` | `aggregateReceiptsIntoStats()` — splits 0 件時の totalOwed |
+| 3 | `backend/src/services/settlement/settlementAggregation.test.ts` | 集計単体テスト |
+| 4 | `frontend/src/domain/settlement/splitEditorInit.ts` | 編集画面の初期 active members |
+| 5 | `docs/design/domain-model.md` §4.2 | 業務ルール記述 |
+
+### 2.4 精算サマリー（月次 balance）— §5
+
+| 順序 | 触る場所 | 役割 |
+|------|----------|------|
+| 1 | `backend/src/services/settlement/settlementAggregation.ts` | 純粋集計 — `computeSettlementMemberSummaries()` |
+| 2 | `backend/src/services/settlement/settlementService.ts` | DB 取得 + 集計呼び出し |
+| 3 | `backend/src/mappers/settlementMapper.ts` | Domain → API レスポンス |
+| 4 | `backend/src/controllers/statsController.ts` | HTTP ハンドラ（薄い） |
+| 5 | `frontend/src/features/settlement/hooks/useSettlementSummary.ts` | 精算画面データ取得 |
+| 6 | `frontend/src/api/statsApi.ts` | API クライアント |
+| 7 | `docs/design/domain-model.md` §5 | 業務ルール記述 |
+
+**送金 API を変える場合:** `docs/openapi/openapi.yaml` の `/stats/settlement/transfers` を先に更新。
+
+### 2.5 UI のみ（表示・入力 UX）
+
+按分ルール自体は変えず、画面操作だけ変える場合:
+
+| 触る場所 | 例 |
+|----------|-----|
+| `frontend/src/features/settlement/hooks/useSplitEditor.ts` | 保存フロー、端数負担者（先頭 member） |
+| `frontend/src/features/settlement/components/*` | テーブル・入力 UI |
+| `frontend/src/screens/SplitEditorScreen.tsx` | 画面構成 |
+| `frontend/app/(app)/history/[receiptId]/split.tsx` | ルート |
+
+**注意:** UI で端数を「先頭メンバー」に見せても、保存時は `buildItemSplitSavePayload()` が **配列末尾** に並べ替える（§4.4）。
+
+---
+
+## 3. ファイル一覧（クイックリファレンス）
+
+### Frontend
+
+| パス | 責務 |
+|------|------|
+| `frontend/src/domain/settlement/itemSplit.ts` | 小計ミラー、保存 payload 生成 |
+| `frontend/src/domain/settlement/splitEditorInit.ts` | 編集画面の初期状態 |
+| `frontend/src/domain/settlement/itemSplit.test.ts` | contract test + payload test |
+| `frontend/src/features/settlement/hooks/useSplitEditor.ts` | 按分編集 hook |
+| `frontend/src/features/settlement/hooks/useSettlementSummary.ts` | 精算サマリー hook |
+| `frontend/src/features/settlement/utils/splitEditorMutations.ts` | 編集中の amount / percent 更新 |
+| `frontend/src/features/settlement/components/*` | 精算・按分 UI |
+| `frontend/src/api/receiptApi.ts` | `saveItemSplits` 等 |
+| `frontend/src/api/statsApi.ts` | 精算サマリー・送金 API |
+
+### Backend
+
+| パス | 責務 |
+|------|------|
+| `backend/src/utils/itemLineTotal.ts` | 明細小計 SSOT |
+| `backend/src/utils/itemSplitAllocation.ts` | 按分 allocate SSOT |
+| `backend/src/services/receipt/receiptSplitService.ts` | ItemSplit 保存 |
+| `backend/src/services/settlement/settlementAggregation.ts` | 精算集計（純粋関数） |
+| `backend/src/services/settlement/settlementService.ts` | 精算データ取得・送金 CRUD |
+| `backend/src/mappers/settlementMapper.ts` | API レスポンス整形 |
+| `backend/src/controllers/statsController.ts` | `/stats/settlement` HTTP |
+| `backend/src/controllers/receiptController.ts` | 按分 POST ハンドラ |
+| `backend/src/repositories/settlementRepository.ts` | 精算 DB アクセス |
+| `backend/src/repositories/receipt/receiptWriteRepository.ts` | ItemSplit 書き込み |
+
+### テスト・契約
+
+| パス | 責務 |
+|------|------|
+| `docs/testing/fixtures/itemLineTotal-vectors.json` | 小計 FE/BE contract |
+| `backend/src/utils/itemSplitAllocation.test.ts` | 按分 allocate |
+| `backend/src/services/settlement/settlementAggregation.test.ts` | 精算集計 |
+| `backend/src/services/settlement/settlementService.test.ts` | サービス層 |
+| `docs/testing/findings.md` | T-ref-01〜03 確定挙動 |
+
+---
+
+## 4. 推奨作業順序（まとめ）
+
+1. **業務ルールを domain-model.md に書く**（変更内容の What）
+2. **Backend SSOT を更新**（`itemLineTotal` / `itemSplitAllocation` / `settlementAggregation`）
+3. **Backend テストを追加・更新**
+4. **API 契約が変わるなら openapi.yaml を先に更新** → `openapiDrift.test` / `generate:api`
+5. **Frontend domain を Backend に同期**（`itemSplit.ts` 等）
+6. **Frontend features / hooks を更新**
+7. **contract test ベクトル更新**（小計変更時）
+8. **domain-model.md / api-spec.md を as-built に合わせる**
+9. **`npm test`（frontend + backend）**
+
+---
+
+## 5. スコープ外（別 Issue）
+
+| 内容 | Issue |
+|------|-------|
+| BE settlement 物理集約（`services/settlement/` へのファイル移動） | #105-6 |
+| DTO / Domain / Mapper フロー図 | #105-4 |
+| API generated 移行 PoC | #105-5 |
+
+---
+
+## 6. 関連資料
+
+- [domain-model.md](./domain-model.md) — 按分・精算業務ルール
+- [frontend-screens.md](./frontend-screens.md) — SplitEditor / Settlement 画面
+- [docs/reviews/issue-87/README.md](../reviews/issue-87/README.md) — 精算ドメイン LLM レビュー
+- [docs/refactor/plan.md](../refactor/plan.md) §12 — Epic #105 全体計画


### PR DESCRIPTION
## Summary

- `docs/design/settlement-change-guide.md` を新規追加 — 按分・精算ルール変更時の FE/BE ファイル一覧、変更種別ごとのチェックリスト、推奨作業順序
- `docs/design/domain-model.md` を as-built に更新 — §4.2 の集計参照を `settlementAggregation.ts` に、§4.3/§5 に `receiptSplitService` / `settlementService` 層を追記、変更ガイドへの導線
- `docs/design/README.md` からガイドへ導線を追加

Closes #516

## Test plan

- [x] `grep splitEditorSplits docs/design/domain-model.md` — 0 件（#105-1 以降の現行パスのみ）
- [x] ドキュメントのみの変更（コード・テスト変更なし）


Made with [Cursor](https://cursor.com)