### PR TITLE
feat(frontend): categoryApi を openapi-fetch 移行 PoC（#105-5）

### DIFF
--- a/docs/design/api-spec.md
+++ b/docs/design/api-spec.md
@@ -733,6 +733,43 @@ npm run test:integration
 - [ ] docs/design/api-spec.md に as-built 追記
 ```
 
+### 9.6 手書き `*Api.ts` → openapi-fetch 移行（#105-5 PoC）
+
+Epic #105-5 以降、ドメイン単位で `axios` 手書きラッパーを **OpenAPI paths 型付きクライアント**（`openapi-fetch`）へ段階移行する。PoC 完了: **`categoryApi.ts`**。
+
+#### 前提
+
+| 項目 | 内容 |
+|------|------|
+| 契約 SSOT | `docs/openapi/openapi.yaml`（変更なし） |
+| 型生成 | 既存 `npm run generate:api` → `api/generated/schema.ts` |
+| 認証 | `utils/apiAuth.ts` — JWT / `x-member-id`（axios / openapi 共通） |
+| 外部 API | Hook は引き続き `api/index.ts` 経由（`categoryApi` 等の export 名は維持） |
+
+#### 移行チェックリスト（1 ドメインあたり）
+
+```
+1. [ ] openapi.yaml に path / operation が定義済みであることを確認
+2. [ ] categoryApi と同様、openapiClient.GET/POST/... で path を呼ぶ
+3. [ ] 戻り値は unwrapOpenApiResponse() で envelope を unwrap（失敗時 OpenApiHttpError）
+4. [ ] Hook / Screen の import パスは変更しない（api/index.ts 経由）
+5. [ ] apiError.ts が OpenApiHttpError を解釈することを確認（getApiErrorMessage 等）
+6. [ ] npm test（frontend）がパス
+7. [ ] 残り *Api.ts は axios のまま（一括移行しない）
+```
+
+#### 配置（as-built）
+
+| ファイル | 役割 |
+|----------|------|
+| `frontend/src/api/openapiClient.ts` | `createClient<paths>` + 認証 middleware |
+| `frontend/src/api/openapiHttpError.ts` | `unwrapOpenApiResponse`, `OpenApiHttpError` |
+| `frontend/src/utils/apiAuth.ts` | 認証ヘッダ構築（`apiClient` / `openapiClient` 共通） |
+| `frontend/src/api/categoryApi.ts` | **移行済 PoC** — generated paths 経由 |
+| `frontend/src/api/receiptApi.ts` 等 | 未移行 — 従来 axios `apiClient` |
+
+データフロー詳細: [architecture.md](./architecture.md) §6.3。
+
 ---
 
 ## 10. 関連資料

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -552,7 +552,7 @@ flowchart TB
 
 #### 6.3.1 手書き `*Api.ts` の位置づけ
 
-`statsApi.ts` / `receiptApi.ts` 等は **generated 型を使う薄いラッパー** である。
+`statsApi.ts` / `receiptApi.ts` 等は **generated 型を使う薄いラッパー** である。`categoryApi.ts` は **#105-5 PoC として openapi-fetch 移行済み**（`openapiClient` + generated paths）。その他は従来どおり axios `apiClient`。
 
 ```typescript
 // statsApi.ts — 典型パターン

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
+        "openapi-fetch": "^0.13.8",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -9438,6 +9439,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
+      "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -9458,6 +9468,12 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "10.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
+    "openapi-fetch": "^0.13.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/frontend/src/api/categoryApi.ts
+++ b/frontend/src/api/categoryApi.ts
@@ -1,4 +1,5 @@
-import apiClient from '../utils/apiClient';
+import { openapiClient } from './openapiClient';
+import { unwrapOpenApiResponse } from './openapiHttpError';
 import type {
   ApiMessageResponse,
   ApiSuccessResponse,
@@ -7,26 +8,30 @@ import type {
   OptimizeCategoryResponse,
 } from './generated';
 
-/** カテゴリ API（/api/categories） */
+/** カテゴリ API（/api/categories）— openapi-fetch + generated paths（#105-5 PoC） */
 export const categoryApi = {
   async listCategories(): Promise<ApiSuccessResponse<Category[]>> {
-    const res = await apiClient.get('/categories');
-    return res.data;
+    return (await unwrapOpenApiResponse(
+      openapiClient.GET('/categories')
+    )) as ApiSuccessResponse<Category[]>;
   },
 
   async createCategory(input: CreateCategoryRequest): Promise<ApiSuccessResponse<Category>> {
-    const res = await apiClient.post('/categories', input);
-    return res.data;
+    return (await unwrapOpenApiResponse(
+      openapiClient.POST('/categories', { body: input })
+    )) as ApiSuccessResponse<Category>;
   },
 
   async deleteCategory(id: number): Promise<ApiMessageResponse> {
-    const res = await apiClient.delete(`/categories/${id}`);
-    return res.data;
+    return (await unwrapOpenApiResponse(
+      openapiClient.DELETE('/categories/{id}', { params: { path: { id } } })
+    )) as ApiMessageResponse;
   },
 
   async optimizeCategories(): Promise<ApiSuccessResponse<OptimizeCategoryResponse>> {
-    const res = await apiClient.post('/categories/optimize', {});
-    return res.data;
+    return (await unwrapOpenApiResponse(
+      openapiClient.POST('/categories/optimize')
+    )) as ApiSuccessResponse<OptimizeCategoryResponse>;
   },
 };
 

--- a/frontend/src/api/openapiClient.ts
+++ b/frontend/src/api/openapiClient.ts
@@ -1,0 +1,40 @@
+import createClient from 'openapi-fetch';
+import type { Middleware } from 'openapi-fetch';
+import type { paths } from './generated/schema';
+import { buildAuthHeaders } from '../utils/apiAuth';
+import { showAlert } from '../utils/alertMessage';
+import { notifyUnauthorized } from '../utils/apiClient';
+
+const API_BASE = process.env.EXPO_PUBLIC_API_URL;
+if (!API_BASE) {
+  console.warn('[OpenAPI] Warning: EXPO_PUBLIC_API_URL is not defined. Falling back to localhost.');
+}
+
+const authMiddleware: Middleware = {
+  async onRequest({ request }) {
+    const headers = await buildAuthHeaders();
+    for (const [key, value] of Object.entries(headers)) {
+      request.headers.set(key, value);
+    }
+    return request;
+  },
+  async onResponse({ response }) {
+    if (response.status === 401) {
+      console.warn('[OpenAPI] Unauthorized');
+      notifyUnauthorized();
+    } else if (response.status === 403) {
+      console.warn('[OpenAPI] Forbidden');
+      showAlert('アクセス権限エラー', 'この操作を行う権限がありません。');
+    }
+    return response;
+  },
+};
+
+/** OpenAPI paths 型付き HTTP クライアント（#105-5 PoC） */
+export const openapiClient = createClient<paths>({
+  baseUrl: API_BASE || 'http://localhost:3000/api',
+});
+
+openapiClient.use(authMiddleware);
+
+export type { OpenApiHttpError } from './openapiHttpError';

--- a/frontend/src/api/openapiHttpError.test.ts
+++ b/frontend/src/api/openapiHttpError.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { OpenApiHttpError, unwrapOpenApiResponse } from './openapiHttpError';
+
+describe('OpenApiHttpError', () => {
+  it('reads message from error body', () => {
+    const err = new OpenApiHttpError(new Response(null, { status: 400 }), {
+      message: 'カテゴリ名が不正です',
+    });
+    expect(err.message).toBe('カテゴリ名が不正です');
+    expect(err.status).toBe(400);
+  });
+});
+
+describe('unwrapOpenApiResponse', () => {
+  it('returns data on success', async () => {
+    const payload = { success: true as const, data: [{ id: 1, name: '食費', color: '#fff' }] };
+    const result = await unwrapOpenApiResponse(
+      Promise.resolve({
+        data: payload,
+        error: undefined,
+        response: new Response(null, { status: 200 }),
+      })
+    );
+    expect(result).toEqual(payload);
+  });
+
+  it('throws OpenApiHttpError when response is not ok', async () => {
+    await expect(
+      unwrapOpenApiResponse(
+        Promise.resolve({
+          data: undefined,
+          error: { message: 'Not Found' },
+          response: new Response(null, { status: 404 }),
+        })
+      )
+    ).rejects.toBeInstanceOf(OpenApiHttpError);
+  });
+});

--- a/frontend/src/api/openapiHttpError.ts
+++ b/frontend/src/api/openapiHttpError.ts
@@ -1,0 +1,39 @@
+/** openapi-fetch 呼び出し失敗時の HTTP エラー（Axios 互換の message / status / data） */
+export class OpenApiHttpError extends Error {
+  readonly status: number;
+  readonly data: unknown;
+
+  constructor(response: Response, body: unknown) {
+    const message = readErrorMessage(body) ?? `HTTP ${response.status}`;
+    super(message);
+    this.name = 'OpenApiHttpError';
+    this.status = response.status;
+    this.data = body;
+  }
+}
+
+function readErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const record = body as Record<string, unknown>;
+  if (typeof record.message === 'string') return record.message;
+  if (typeof record.error === 'string') return record.error;
+  return undefined;
+}
+
+/** openapi-fetch の GET/POST 等の戻り値を envelope ごと返す。失敗時は throw */
+export async function unwrapOpenApiResponse<T>(
+  result: Promise<{
+    data?: T;
+    error?: unknown;
+    response: Response;
+  }>
+): Promise<T> {
+  const { data, error, response } = await result;
+  if (!response.ok || error !== undefined) {
+    throw new OpenApiHttpError(response, error ?? data);
+  }
+  if (data === undefined) {
+    throw new OpenApiHttpError(response, { message: 'Empty response body' });
+  }
+  return data;
+}

--- a/frontend/src/utils/apiAuth.ts
+++ b/frontend/src/utils/apiAuth.ts
@@ -1,0 +1,34 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AUTH_STORAGE_KEYS } from '../services/authService';
+
+async function getStorageItem(key: string): Promise<string | null> {
+  try {
+    return Platform.OS === 'web'
+      ? await AsyncStorage.getItem(key)
+      : await SecureStore.getItemAsync(key);
+  } catch (error) {
+    console.error(`[API-AUTH] Storage retrieval failed for key: ${key}`, error);
+    return null;
+  }
+}
+
+/** JWT / x-member-id を API リクエスト用ヘッダに載せる */
+export async function buildAuthHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+  const token = await getStorageItem(AUTH_STORAGE_KEYS.TOKEN);
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const memberId = await getStorageItem(AUTH_STORAGE_KEYS.MEMBER_ID);
+  if (memberId) {
+    headers['x-member-id'] = memberId;
+  }
+  return headers;
+}
+
+/** [Issue #73] 現在ログイン中ユーザーの Role */
+export async function getUserRole(): Promise<string | null> {
+  return getStorageItem(AUTH_STORAGE_KEYS.ROLE);
+}

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,9 +1,7 @@
 import { Platform } from 'react-native';
 import axios from 'axios';
-import * as SecureStore from 'expo-secure-store';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { showAlert } from './alertMessage';
-import { AUTH_STORAGE_KEYS } from '../services/authService';
+import { buildAuthHeaders } from './apiAuth';
 
 /**
  * 401エラー時にセッション Context / ルート側でログアウト処理を発火させるためのハンドラ
@@ -13,6 +11,10 @@ let onUnauthorizedHandler: (() => void) | null = null;
 export const setOnUnauthorized = (handler: () => void) => {
   onUnauthorizedHandler = handler;
 };
+
+export function notifyUnauthorized(): void {
+  onUnauthorizedHandler?.();
+}
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL;
 if (!API_BASE) {
@@ -28,37 +30,14 @@ const apiClient = axios.create({
 });
 
 /**
- * ストレージから値を安全に取得するユーティリティ
+ * ストレージから値を安全に取得するユーティリティ — @deprecated use apiAuth.getUserRole
  */
-const getStorageItem = async (key: string): Promise<string | null> => {
-  try {
-    return Platform.OS === 'web'
-      ? await AsyncStorage.getItem(key)
-      : await SecureStore.getItemAsync(key);
-  } catch (error) {
-    console.error(`[API-AUTH] Storage retrieval failed for key: ${key}`, error);
-    return null;
-  }
-};
-
-/**
- * [Issue #73] 現在ログイン中のユーザーの Role を取得するユーティリティ
- */
-export const getUserRole = async (): Promise<string | null> => {
-  return await getStorageItem(AUTH_STORAGE_KEYS.ROLE);
-};
+export { getUserRole } from './apiAuth';
 
 // --- リクエストインターセプター：送信前に認証情報を自動注入 ---
 apiClient.interceptors.request.use(async (config) => {
-  const token = await getStorageItem(AUTH_STORAGE_KEYS.TOKEN);
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-
-  const memberId = await getStorageItem(AUTH_STORAGE_KEYS.MEMBER_ID);
-  if (memberId) {
-    config.headers['x-member-id'] = memberId;
-  }
+  const authHeaders = await buildAuthHeaders();
+  Object.assign(config.headers, authHeaders);
 
   const isFormData =
     typeof FormData !== 'undefined' &&

--- a/frontend/src/utils/apiError.test.ts
+++ b/frontend/src/utils/apiError.test.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { OpenApiHttpError } from '../api/openapiHttpError';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getApiErrorMessage,
@@ -16,6 +17,16 @@ describe('apiError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('extracts error field from OpenApiHttpError', () => {
+    const error = new OpenApiHttpError(new Response(null, { status: 403 }), {
+      error: '権限がありません',
+    });
+
+    expect(getApiErrorStatus(error)).toBe(403);
+    expect(getApiErrorResponseData(error)).toEqual({ error: '権限がありません' });
+    expect(getApiErrorMessage(error)).toBe('権限がありません');
   });
 
   it('extracts error field from axios response', () => {

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { OpenApiHttpError } from '../api/openapiHttpError';
 import { showAlert } from './alertMessage';
 
 function readStringField(data: unknown, key: 'error' | 'message'): string | undefined {
@@ -9,6 +10,9 @@ function readStringField(data: unknown, key: 'error' | 'message'): string | unde
 
 /** Axios レスポンス body（存在する場合） */
 export function getApiErrorResponseData(error: unknown): unknown {
+  if (error instanceof OpenApiHttpError) {
+    return error.data;
+  }
   if (axios.isAxiosError(error)) {
     return error.response?.data;
   }
@@ -17,6 +21,9 @@ export function getApiErrorResponseData(error: unknown): unknown {
 
 /** HTTP ステータス（Axios エラー時） */
 export function getApiErrorStatus(error: unknown): number | undefined {
+  if (error instanceof OpenApiHttpError) {
+    return error.status;
+  }
   if (axios.isAxiosError(error)) {
     return error.response?.status;
   }


### PR DESCRIPTION
## Summary

- `openapi-fetch` + `createClient<paths>` による `openapiClient` を追加（認証 middleware、401/403 ハンドリング）
- **`categoryApi.ts` を PoC として移行** — `GET/POST/DELETE /categories*` を generated paths 経由に
- 認証ヘッダを `utils/apiAuth.ts` に共通化（axios `apiClient` / openapi 両方）
- `OpenApiHttpError` + `unwrapOpenApiResponse` — 既存 `getApiErrorMessage` / `showApiErrorAlert` と互換
- Hook / Screen の import は `api/index.ts` 経由のまま（外部 API 不変）
- 移行手順: `docs/design/api-spec.md` §9.6

Closes #518

## Test plan

- [x] `npm test`（frontend）— 64 passed（openapiHttpError / apiError 含む）
- [x] `receiptApi` / `statsApi` 等は axios のまま（一括移行なし）


Made with [Cursor](https://cursor.com)