### PR TITLE
fix(docker): frontend ビルドの ECONNRESET 対策とコンテキスト軽量化

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+.expo
+.expo-shared
+web-build
+coverage
+*.log
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+**/*.test.ts
+**/*.test.tsx
+.vscode
+.cursor

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Expo CLIをグローバルにインストール
-RUN npm install -g expo-cli
+RUN npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 20000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm install -g expo-cli
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.web
+++ b/frontend/Dockerfile.web
@@ -4,8 +4,11 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # 依存関係のインストール (キャッシュ利用)
-COPY package*.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 20000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm ci
 
 # ソースコピー
 COPY . .


### PR DESCRIPTION
## Summary

- `frontend/.dockerignore` を追加 — `node_modules` / `.expo` / `dist` 等をビルドコンテキストから除外（334MB → 軽量化）
- `Dockerfile.web` — `npm install` → `npm ci` + npm fetch リトライ設定（ECONNRESET 対策）
- `frontend/Dockerfile` — `expo-cli` グローバルインストールにも同様のリトライ設定

## 背景

`docker compose build --no-cache` 実行時、`frontend` イメージの `npm install` が `ECONNRESET` で失敗していた。ネットワーク一時断に加え、`.dockerignore` 不在で巨大なビルドコンテキストが転送されていた。

## Test plan

- [x] `docker compose build frontend` が成功することを確認


Made with [Cursor](https://cursor.com)