### PR TITLE
fix(backend): Gemini 日次枠 429 リトライ抑制と failed ジョブ画像アクセス

### DIFF
--- a/backend/src/__tests__/integration/receipt.integration.test.ts
+++ b/backend/src/__tests__/integration/receipt.integration.test.ts
@@ -255,4 +255,28 @@ describe.skipIf(!shouldRunDbIntegration())('Tenant isolation (#93-1)', () => {
 
     expect(res.status).toBe(200);
   });
+
+  it('allows failed job image access before receipt is saved', async () => {
+    const pendingImagePath = 'uploads/failed-preview-fixture.webp';
+    const fixturePath = path.join(process.cwd(), pendingImagePath);
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(fixturePath, Buffer.from('failed-preview-test'));
+
+    registerMockReceiptJob(
+      'failed-preview-job',
+      {
+        memberId: 1,
+        familyGroupId: 1,
+        imagePath: pendingImagePath,
+      },
+      { state: 'failed', failedReason: 'Gemini quota exceeded' }
+    );
+
+    const token = await loginAsTestMember(app, 1);
+    const res = await request(app)
+      .get(`/api/uploads/${path.basename(pendingImagePath)}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
 });

--- a/backend/src/services/imageAccessService.ts
+++ b/backend/src/services/imageAccessService.ts
@@ -11,7 +11,7 @@ async function hasQueueJobForImage(
   imagePath: string
 ): Promise<boolean> {
   const jobs = await receiptQueue.getJobs(
-    ['completed', 'waiting', 'active', 'delayed', 'paused'],
+    ['completed', 'waiting', 'active', 'delayed', 'paused', 'failed'],
     0,
     200,
     true
@@ -27,7 +27,7 @@ async function hasQueueJobForImage(
 /**
  * 自世帯が参照可能なレシート画像か判定する。
  * - DB に保存済み Receipt
- * - 解析ジョブ投入済み（保存前プレビュー用）
+ * - 解析ジョブ投入済み（保存前プレビュー用。failed 含む — 解析失敗時もサムネイル表示）
  */
 export async function canAccessReceiptImage(
   familyGroupId: number,

--- a/backend/src/utils/httpError.test.ts
+++ b/backend/src/utils/httpError.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getHttpStatusFromError,
+  isGeminiDailyQuotaError,
+  isRetryableHttpError,
+} from './httpError';
+
+const DAILY_QUOTA_MESSAGE = `[GoogleGenerativeAI Error]: [429 Too Many Requests]
+* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-3.5-flash
+"quotaId":"GenerateRequestsPerDayPerProjectPerModel-FreeTier"`;
+
+const RPM_LIMIT_MESSAGE = `[GoogleGenerativeAI Error]: [429 Too Many Requests]
+"quotaId":"GenerateRequestsPerMinutePerProjectPerModel-FreeTier"`;
+
+describe('httpError retry classification', () => {
+  it('detects Gemini daily free-tier quota exhaustion', () => {
+    const error = Object.assign(new Error(DAILY_QUOTA_MESSAGE), { status: 429 });
+    expect(isGeminiDailyQuotaError(error)).toBe(true);
+    expect(isRetryableHttpError(error)).toBe(false);
+  });
+
+  it('keeps per-minute 429 as retryable', () => {
+    const error = Object.assign(new Error(RPM_LIMIT_MESSAGE), { status: 429 });
+    expect(isGeminiDailyQuotaError(error)).toBe(false);
+    expect(isRetryableHttpError(error)).toBe(true);
+  });
+
+  it('keeps 5xx as retryable', () => {
+    expect(isRetryableHttpError({ status: 503, message: 'Service Unavailable' })).toBe(true);
+  });
+
+  it('reads HTTP status from nested response', () => {
+    expect(getHttpStatusFromError({ response: { status: 429 } })).toBe(429);
+  });
+});

--- a/backend/src/utils/httpError.ts
+++ b/backend/src/utils/httpError.ts
@@ -14,9 +14,22 @@ export function getHttpStatusFromError(error: unknown): number | undefined {
   return undefined;
 }
 
+/** Gemini 日次無料枠（RPD）切れ — リトライしても当日は回復しない */
+export function isGeminiDailyQuotaError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return (
+    message.includes('GenerateRequestsPerDay') ||
+    message.includes('PerDayPerProjectPerModel') ||
+    /generate_content_free_tier_requests/i.test(message)
+  );
+}
+
 export function isRetryableHttpError(error: unknown): boolean {
   const status = getHttpStatusFromError(error);
-  return status === 429 || (status !== undefined && status >= 500);
+  if (status === 429) {
+    return !isGeminiDailyQuotaError(error);
+  }
+  return status !== undefined && status >= 500;
 }
 
 export function getErrorMessage(error: unknown): string {

--- a/backend/src/workers/receiptWorker.ts
+++ b/backend/src/workers/receiptWorker.ts
@@ -1,10 +1,10 @@
-import { Worker, Job } from 'bullmq';
+import { Worker, Job, UnrecoverableError } from 'bullmq';
 import { redisConnection } from '../config/redis';
 import { RECEIPT_QUEUE_NAME } from '../queues/receiptQueue';
 import { analyzeOnly } from '../services/receiptService'; 
 import { runWithTenant } from '../utils/context';
 import logger from '../utils/logger';
-import { getErrorMessage } from '../utils/httpError';
+import { getErrorMessage, isRetryableHttpError } from '../utils/httpError';
 
 /**
  * [Issue #49-8 / #71]
@@ -33,9 +33,13 @@ const receiptWorker = new Worker(
         return result;
 
       } catch (error: unknown) {
-        logger.error(`[Worker] ジョブ失敗: ID ${job.id} - ${getErrorMessage(error)}`);
-        
-        // ジョブを失敗状態 (failed) にし、必要に応じて BullMQ のリトライ機能に委ねる
+        const message = getErrorMessage(error);
+        logger.error(`[Worker] ジョブ失敗: ID ${job.id} - ${message}`);
+
+        // 日次枠切れなど、BullMQ 再試行しても回復しないエラーは即 failed にする
+        if (!isRetryableHttpError(error)) {
+          throw new UnrecoverableError(message);
+        }
         throw error;
       }
     });


### PR DESCRIPTION
## Summary

- 日次無料枠切れ（`GenerateRequestsPerDay` / `free_tier_requests`）の 429 では `withRetry` と BullMQ 再試行を打ち切る
- 1アップロードあたりの Gemini API 呼び出しを、枠切れ時は最大12回→1回程度に抑制
- 解析失敗（`failed`）ジョブのレシート画像を `/api/uploads` で表示可能にする（`imageAccessService`）

## Test plan

- [x] `npm test -- --run src/utils/httpError.test.ts`（backend）
- [ ] 枠切れ時: ログに `⚠️ Gemini APIリトライ中...` が連発せず、ジョブが1回で failed になること
- [ ] 解析失敗ジョブのサムネイルが 404 にならないこと（dev）
- [ ] 解析成功の E2E は Gemini 枠回復後に確認


Made with [Cursor](https://cursor.com)