### PR TITLE
feat(frontend): [Issue #106-0] 確認トレイの自動ポーリング廃止と手動更新

### DIFF
--- a/frontend/src/hooks/useReceiptJobs.ts
+++ b/frontend/src/hooks/useReceiptJobs.ts
@@ -1,20 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { receiptApi } from '../api/receiptApi';
 import { showApiErrorAlert } from '../utils/apiError';
 import { countActiveReceiptJobs } from '../utils/receiptJobDisplay';
 import type { ReceiptJobListItem } from '../types/receiptJob';
 
-const POLL_INTERVAL_MS = 2000;
-
 type RefreshOptions = {
   userInitiated?: boolean;
 };
 
+/**
+ * 確認トレイ用ジョブ一覧。
+ * 自動ポーリングは行わず、呼び出し元が refresh のタイミングを制御する（Issue #106-0）。
+ */
 export function useReceiptJobs(enabled: boolean) {
   const [jobs, setJobs] = useState<ReceiptJobListItem[]>([]);
   const [refreshing, setRefreshing] = useState(false);
-  const jobsRef = useRef(jobs);
-  jobsRef.current = jobs;
 
   const refresh = useCallback(
     async (options?: RefreshOptions) => {
@@ -39,6 +39,7 @@ export function useReceiptJobs(enabled: boolean) {
     [enabled]
   );
 
+  /** アプリ起動（Provider 有効化）時に 1 回取得 */
   useEffect(() => {
     if (!enabled) {
       setJobs([]);
@@ -46,18 +47,6 @@ export function useReceiptJobs(enabled: boolean) {
     }
 
     void refresh();
-  }, [enabled, refresh]);
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    const interval = setInterval(() => {
-      if (countActiveReceiptJobs(jobsRef.current) > 0) {
-        void refresh();
-      }
-    }, POLL_INTERVAL_MS);
-
-    return () => clearInterval(interval);
   }, [enabled, refresh]);
 
   const activeCount = countActiveReceiptJobs(jobs);

--- a/frontend/src/screens/ReceiptTrayScreen.tsx
+++ b/frontend/src/screens/ReceiptTrayScreen.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import React, { useCallback } from 'react';
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { AppBackButton } from '../components/ui';
+import { AppBackButton, AppButton } from '../components/ui';
 import { ReceiptTrayPanel } from '../components/ReceiptTrayPanel';
 import { useReceiptTray } from '../contexts/ReceiptTrayContext';
 import { colors } from '../theme/colors';
@@ -25,6 +26,13 @@ export function ReceiptTrayScreen({ onBack }: Props) {
     canDiscardTrayItem,
   } = useReceiptTray();
 
+  /** 解析一覧表示のたびに 1 回取得（自動ポーリングはしない） */
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh])
+  );
+
   return (
     <SafeAreaView style={screenLayout.container} edges={['left', 'right', 'bottom']}>
       <View style={[screenLayout.header, styles.headerTray]}>
@@ -35,13 +43,20 @@ export function ReceiptTrayScreen({ onBack }: Props) {
             {trayItemCount > 0 ? `${trayItemCount} 件の受付` : '受付中のレシートはありません'}
           </Text>
         </View>
-        {trayItemCount > 0 ? (
-          <View style={styles.countBadge}>
-            <Text style={styles.countBadgeText}>{trayItemCount}</Text>
-          </View>
-        ) : (
-          <View style={styles.headerSpacer} />
-        )}
+        <View style={styles.headerActions}>
+          <AppButton
+            title="状態を更新"
+            variant="outline"
+            size="sm"
+            loading={refreshing}
+            onPress={() => void refresh({ userInitiated: true })}
+          />
+          {trayItemCount > 0 ? (
+            <View style={styles.countBadge}>
+              <Text style={styles.countBadgeText}>{trayItemCount}</Text>
+            </View>
+          ) : null}
+        </View>
       </View>
 
       <ScrollView
@@ -90,6 +105,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
   countBadgeText: { color: colors.text.inverse, fontWeight: '700' },
-  headerSpacer: { width: 32 },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
   scrollContentTray: { paddingBottom: spacing.xl },
 });


### PR DESCRIPTION
## Summary

- 解析中の 2 秒間隔自動ポーリングを廃止（#531 / Epic #530）
- ジョブ一覧の自動取得タイミングを限定: アプリ起動・アップロード受付後・確認トレイ画面表示時（各1回）
- 確認トレイに「状態を更新」ボタンを追加（引っ張り更新は従来どおり）

## Related issues

- Closes #531
- Epic #530

## Test plan

- [x] `npm test`（frontend 64 tests）
- [ ] レシートアップロード後、ホームのトレイ件数が更新されること
- [ ] 解析中にバックエンドログへ 2 秒間隔の連続リクエストが出ないこと
- [ ] 確認トレイを開くと一覧が1回取得されること
- [ ] 「状態を更新」ボタンで手動更新できること
- [ ] 引っ張り更新も動作すること


Made with [Cursor](https://cursor.com)