### PR TITLE
feat: 商品分類データモデルと標準マスタを追加

### DIFF
--- a/backend/prisma/migrations/20260728075557_add_product_classification_data_model/migration.sql
+++ b/backend/prisma/migrations/20260728075557_add_product_classification_data_model/migration.sql
@@ -1,0 +1,222 @@
+-- CreateEnum
+CREATE TYPE "ProductTypeStatus" AS ENUM ('classified', 'needs_review', 'unclassified', 'outside_initial_scope', 'not_applicable');
+
+-- CreateEnum
+CREATE TYPE "ClassificationSource" AS ENUM ('history', 'household_dictionary', 'standard_dictionary', 'similarity', 'ai', 'manual');
+
+-- CreateEnum
+CREATE TYPE "ClassificationConfidence" AS ENUM ('high', 'medium', 'low');
+
+-- CreateEnum
+CREATE TYPE "ClassificationCorrectionScope" AS ENUM ('item_only', 'same_ocr_name', 'same_classification_name');
+
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "classificationConfidence" "ClassificationConfidence",
+ADD COLUMN     "classificationSource" "ClassificationSource",
+ADD COLUMN     "productTypeId" INTEGER,
+ADD COLUMN     "productTypeStatus" "ProductTypeStatus" NOT NULL DEFAULT 'unclassified',
+ADD COLUMN     "standardCategoryId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "StandardCategory" (
+    "id" SERIAL NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "parentId" INTEGER,
+    "displayOrder" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "color" TEXT,
+
+    CONSTRAINT "StandardCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProductType" (
+    "id" SERIAL NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "standardCategoryId" INTEGER NOT NULL,
+    "displayOrder" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "ProductType_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StandardProductDictionary" (
+    "id" SERIAL NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "standardCategoryId" INTEGER NOT NULL,
+    "productTypeId" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "StandardProductDictionary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "HouseholdProductDictionary" (
+    "id" SERIAL NOT NULL,
+    "familyGroupId" INTEGER NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "productTypeId" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "HouseholdProductDictionary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProductClassificationHistory" (
+    "id" SERIAL NOT NULL,
+    "familyGroupId" INTEGER NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "productTypeId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "ProductClassificationHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProductClassificationAlias" (
+    "id" SERIAL NOT NULL,
+    "familyGroupId" INTEGER NOT NULL,
+    "normalizedName" TEXT NOT NULL,
+    "productTypeId" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "ProductClassificationAlias_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ClassificationCorrection" (
+    "id" SERIAL NOT NULL,
+    "familyGroupId" INTEGER NOT NULL,
+    "itemId" INTEGER NOT NULL,
+    "actorMemberId" INTEGER,
+    "previousProductTypeId" INTEGER,
+    "nextProductTypeId" INTEGER,
+    "scope" "ClassificationCorrectionScope" NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ClassificationCorrection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StandardCategory_code_key" ON "StandardCategory"("code");
+
+-- CreateIndex
+CREATE INDEX "StandardCategory_parentId_displayOrder_idx" ON "StandardCategory"("parentId", "displayOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StandardCategory_parentId_name_key" ON "StandardCategory"("parentId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductType_code_key" ON "ProductType"("code");
+
+-- CreateIndex
+CREATE INDEX "ProductType_standardCategoryId_displayOrder_idx" ON "ProductType"("standardCategoryId", "displayOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductType_standardCategoryId_name_key" ON "ProductType"("standardCategoryId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StandardProductDictionary_normalizedName_key" ON "StandardProductDictionary"("normalizedName");
+
+-- CreateIndex
+CREATE INDEX "StandardProductDictionary_standardCategoryId_idx" ON "StandardProductDictionary"("standardCategoryId");
+
+-- CreateIndex
+CREATE INDEX "StandardProductDictionary_productTypeId_idx" ON "StandardProductDictionary"("productTypeId");
+
+-- CreateIndex
+CREATE INDEX "HouseholdProductDictionary_productTypeId_idx" ON "HouseholdProductDictionary"("productTypeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HouseholdProductDictionary_familyGroupId_normalizedName_key" ON "HouseholdProductDictionary"("familyGroupId", "normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ProductClassificationHistory_productTypeId_idx" ON "ProductClassificationHistory"("productTypeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductClassificationHistory_familyGroupId_normalizedName_key" ON "ProductClassificationHistory"("familyGroupId", "normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ProductClassificationAlias_productTypeId_idx" ON "ProductClassificationAlias"("productTypeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductClassificationAlias_familyGroupId_normalizedName_key" ON "ProductClassificationAlias"("familyGroupId", "normalizedName");
+
+-- CreateIndex
+CREATE INDEX "ClassificationCorrection_familyGroupId_createdAt_idx" ON "ClassificationCorrection"("familyGroupId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ClassificationCorrection_itemId_idx" ON "ClassificationCorrection"("itemId");
+
+-- CreateIndex
+CREATE INDEX "ClassificationCorrection_actorMemberId_idx" ON "ClassificationCorrection"("actorMemberId");
+
+-- CreateIndex
+CREATE INDEX "Item_standardCategoryId_idx" ON "Item"("standardCategoryId");
+
+-- CreateIndex
+CREATE INDEX "Item_productTypeId_idx" ON "Item"("productTypeId");
+
+-- CreateIndex
+CREATE INDEX "Item_productTypeStatus_idx" ON "Item"("productTypeStatus");
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_standardCategoryId_fkey" FOREIGN KEY ("standardCategoryId") REFERENCES "StandardCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_productTypeId_fkey" FOREIGN KEY ("productTypeId") REFERENCES "ProductType"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StandardCategory" ADD CONSTRAINT "StandardCategory_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "StandardCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductType" ADD CONSTRAINT "ProductType_standardCategoryId_fkey" FOREIGN KEY ("standardCategoryId") REFERENCES "StandardCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StandardProductDictionary" ADD CONSTRAINT "StandardProductDictionary_standardCategoryId_fkey" FOREIGN KEY ("standardCategoryId") REFERENCES "StandardCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StandardProductDictionary" ADD CONSTRAINT "StandardProductDictionary_productTypeId_fkey" FOREIGN KEY ("productTypeId") REFERENCES "ProductType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HouseholdProductDictionary" ADD CONSTRAINT "HouseholdProductDictionary_familyGroupId_fkey" FOREIGN KEY ("familyGroupId") REFERENCES "FamilyGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HouseholdProductDictionary" ADD CONSTRAINT "HouseholdProductDictionary_productTypeId_fkey" FOREIGN KEY ("productTypeId") REFERENCES "ProductType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductClassificationHistory" ADD CONSTRAINT "ProductClassificationHistory_familyGroupId_fkey" FOREIGN KEY ("familyGroupId") REFERENCES "FamilyGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductClassificationHistory" ADD CONSTRAINT "ProductClassificationHistory_productTypeId_fkey" FOREIGN KEY ("productTypeId") REFERENCES "ProductType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductClassificationAlias" ADD CONSTRAINT "ProductClassificationAlias_familyGroupId_fkey" FOREIGN KEY ("familyGroupId") REFERENCES "FamilyGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductClassificationAlias" ADD CONSTRAINT "ProductClassificationAlias_productTypeId_fkey" FOREIGN KEY ("productTypeId") REFERENCES "ProductType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassificationCorrection" ADD CONSTRAINT "ClassificationCorrection_familyGroupId_fkey" FOREIGN KEY ("familyGroupId") REFERENCES "FamilyGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassificationCorrection" ADD CONSTRAINT "ClassificationCorrection_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassificationCorrection" ADD CONSTRAINT "ClassificationCorrection_actorMemberId_fkey" FOREIGN KEY ("actorMemberId") REFERENCES "FamilyMember"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassificationCorrection" ADD CONSTRAINT "ClassificationCorrection_previousProductTypeId_fkey" FOREIGN KEY ("previousProductTypeId") REFERENCES "ProductType"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassificationCorrection" ADD CONSTRAINT "ClassificationCorrection_nextProductTypeId_fkey" FOREIGN KEY ("nextProductTypeId") REFERENCES "ProductType"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,39 +10,73 @@ datasource db {
 // [Issue #73] ユーザーの権限レベルを定義
 enum Role {
   ADMIN // 管理者 (プロンプト編集・コスト統計の閲覧が可能)
-  USER  // 一般ユーザー (レシートの登録・閲覧のみ)
+  USER // 一般ユーザー (レシートの登録・閲覧のみ)
+}
+
+enum ProductTypeStatus {
+  CLASSIFIED            @map("classified")
+  NEEDS_REVIEW          @map("needs_review")
+  UNCLASSIFIED          @map("unclassified")
+  OUTSIDE_INITIAL_SCOPE @map("outside_initial_scope")
+  NOT_APPLICABLE        @map("not_applicable")
+}
+
+enum ClassificationSource {
+  HISTORY              @map("history")
+  HOUSEHOLD_DICTIONARY @map("household_dictionary")
+  STANDARD_DICTIONARY  @map("standard_dictionary")
+  SIMILARITY           @map("similarity")
+  AI                   @map("ai")
+  MANUAL               @map("manual")
+}
+
+enum ClassificationConfidence {
+  HIGH   @map("high")
+  MEDIUM @map("medium")
+  LOW    @map("low")
+}
+
+enum ClassificationCorrectionScope {
+  ITEM_ONLY                @map("item_only")
+  SAME_OCR_NAME            @map("same_ocr_name")
+  SAME_CLASSIFICATION_NAME @map("same_classification_name")
 }
 
 // [Issue #45] 世帯（テナント）最上位テーブル
 model FamilyGroup {
-  id                 Int                  @id @default(autoincrement())
-  name               String               // 世帯名 (例: 山本家)
-  inviteCode         String               @unique @default(cuid()) // 家族招待用のコード
-  members            FamilyMember[]
-  receipts           Receipt[]
-  productMasters     ProductMaster[]
-  categories         Category[]
-  stores             Store[]
-  promptTemplates    PromptTemplate[]
-  settlementTransfers SettlementTransfer[]
-  createdAt          DateTime             @default(now()) @db.Timestamptz(3)
+  id                        Int                            @id @default(autoincrement())
+  name                      String // 世帯名 (例: 山本家)
+  inviteCode                String                         @unique @default(cuid()) // 家族招待用のコード
+  members                   FamilyMember[]
+  receipts                  Receipt[]
+  productMasters            ProductMaster[]
+  categories                Category[]
+  stores                    Store[]
+  promptTemplates           PromptTemplate[]
+  settlementTransfers       SettlementTransfer[]
+  productDictionaries       HouseholdProductDictionary[]
+  productHistories          ProductClassificationHistory[]
+  productAliases            ProductClassificationAlias[]
+  classificationCorrections ClassificationCorrection[]
+  createdAt                 DateTime                       @default(now()) @db.Timestamptz(3)
 }
 
 // 家族構成
 model FamilyMember {
-  id            Int           @id @default(autoincrement())
-  name          String
-  password_hash String?
-  familyGroupId Int           // ★ 所属世帯
-  role          Role          @default(USER) // [Issue #73] デフォルトは一般ユーザー
-  totpSecret    String?       // [Issue #93-5] TOTP シークレット（暗号化保存）
-  totpEnabled   Boolean       @default(false)
-  totpVerifiedAt DateTime?    @db.Timestamptz(3)
-  familyGroup   FamilyGroup   @relation(fields: [familyGroupId], references: [id])
-  receipts      Receipt[]
-  apiUsageLogs  ApiUsageLog[] // [Issue #59] トークンログとのリレーション
-  itemSplits    ItemSplit[]   // [Issue #78] 負担明細へのリレーション
-  
+  id                        Int                        @id @default(autoincrement())
+  name                      String
+  password_hash             String?
+  familyGroupId             Int // ★ 所属世帯
+  role                      Role                       @default(USER) // [Issue #73] デフォルトは一般ユーザー
+  totpSecret                String? // [Issue #93-5] TOTP シークレット（暗号化保存）
+  totpEnabled               Boolean                    @default(false)
+  totpVerifiedAt            DateTime?                  @db.Timestamptz(3)
+  familyGroup               FamilyGroup                @relation(fields: [familyGroupId], references: [id])
+  receipts                  Receipt[]
+  apiUsageLogs              ApiUsageLog[] // [Issue #59] トークンログとのリレーション
+  itemSplits                ItemSplit[] // [Issue #78] 負担明細へのリレーション
+  classificationCorrections ClassificationCorrection[]
+
   // ★ [Issue #81] 送金履歴リレーション
   sentTransfers     SettlementTransfer[] @relation("TransferSender")
   receivedTransfers SettlementTransfer[] @relation("TransferReceiver")
@@ -79,17 +113,17 @@ model Store {
 
 model Receipt {
   id            Int           @id @default(autoincrement())
-  familyGroupId Int           // ★ 世帯ID (論理分離の主軸)
+  familyGroupId Int // ★ 世帯ID (論理分離の主軸)
   familyGroup   FamilyGroup   @relation(fields: [familyGroupId], references: [id])
   memberId      Int
   member        FamilyMember  @relation(fields: [memberId], references: [id])
   storeName     String
   date          DateTime      @db.Timestamptz(3)
-  totalAmount   Int           // 支払合計（税込）
+  totalAmount   Int // 支払合計（税込）
   // [Issue #71] 外税額を保持するフィールド
   taxAmount     Float         @default(0.0)
   rawText       Json?
-  imagePath     String?       
+  imagePath     String?
   items         Item[]
   apiUsageLogs  ApiUsageLog[] // [Issue #59] トークンログとのリレーション
   createdAt     DateTime      @default(now()) @db.Timestamptz(3)
@@ -98,30 +132,165 @@ model Receipt {
 }
 
 model Item {
-  id         Int         @id @default(autoincrement())
-  receiptId  Int
-  receipt    Receipt     @relation(fields: [receiptId], references: [id], onDelete: Cascade)
-  categoryId Int?
-  category   Category?   @relation(fields: [categoryId], references: [id])
-  name       String
-  price      Float
-  quantity   Float       @default(1.0)
-  
+  id                       Int                       @id @default(autoincrement())
+  receiptId                Int
+  receipt                  Receipt                   @relation(fields: [receiptId], references: [id], onDelete: Cascade)
+  categoryId               Int?
+  category                 Category?                 @relation(fields: [categoryId], references: [id])
+  standardCategoryId       Int?
+  standardCategory         StandardCategory?         @relation(fields: [standardCategoryId], references: [id])
+  productTypeId            Int?
+  productType              ProductType?              @relation(fields: [productTypeId], references: [id])
+  productTypeStatus        ProductTypeStatus         @default(UNCLASSIFIED)
+  classificationSource     ClassificationSource?
+  classificationConfidence ClassificationConfidence?
+  name                     String
+  price                    Float
+  quantity                 Float                     @default(1.0)
+
   // [Issue #78] 負担割合の内訳（1対多）
-  splits     ItemSplit[] 
+  splits                    ItemSplit[]
+  classificationCorrections ClassificationCorrection[]
+
+  @@index([standardCategoryId])
+  @@index([productTypeId])
+  @@index([productTypeStatus])
+}
+
+// 共通の固定家計簿カテゴリ。世帯ごとのCategoryから段階的に移行する。
+model StandardCategory {
+  id           Int                @id @default(autoincrement())
+  code         String             @unique
+  name         String
+  parentId     Int?
+  parent       StandardCategory?  @relation("StandardCategoryHierarchy", fields: [parentId], references: [id])
+  children     StandardCategory[] @relation("StandardCategoryHierarchy")
+  displayOrder Int
+  isActive     Boolean            @default(true)
+  color        String?
+
+  productTypes      ProductType[]
+  dictionaryEntries StandardProductDictionary[]
+  items             Item[]
+
+  @@unique([parentId, name])
+  @@index([parentId, displayOrder])
+}
+
+// 共通の商品種別。必ず標準カテゴリに属する。
+model ProductType {
+  id                 Int              @id @default(autoincrement())
+  code               String           @unique
+  name               String
+  standardCategoryId Int
+  standardCategory   StandardCategory @relation(fields: [standardCategoryId], references: [id])
+  displayOrder       Int
+  isActive           Boolean          @default(true)
+
+  items                     Item[]
+  standardDictionaryEntries StandardProductDictionary[]
+  householdDictionaries     HouseholdProductDictionary[]
+  classificationHistories   ProductClassificationHistory[]
+  classificationAliases     ProductClassificationAlias[]
+  previousCorrections       ClassificationCorrection[]     @relation("PreviousProductType")
+  nextCorrections           ClassificationCorrection[]     @relation("NextProductType")
+
+  @@unique([standardCategoryId, name])
+  @@index([standardCategoryId, displayOrder])
+}
+
+// リポジトリで管理する完全一致用の標準辞書。
+model StandardProductDictionary {
+  id                 Int              @id @default(autoincrement())
+  normalizedName     String           @unique
+  standardCategoryId Int
+  standardCategory   StandardCategory @relation(fields: [standardCategoryId], references: [id])
+  productTypeId      Int
+  productType        ProductType      @relation(fields: [productTypeId], references: [id])
+  isActive           Boolean          @default(true)
+  createdAt          DateTime         @default(now()) @db.Timestamptz(3)
+  updatedAt          DateTime         @updatedAt @db.Timestamptz(3)
+
+  @@index([standardCategoryId])
+  @@index([productTypeId])
+}
+
+// 以下は世帯固有の学習データ。すべてfamilyGroupIdで分離する。
+model HouseholdProductDictionary {
+  id             Int         @id @default(autoincrement())
+  familyGroupId  Int
+  familyGroup    FamilyGroup @relation(fields: [familyGroupId], references: [id], onDelete: Cascade)
+  normalizedName String
+  productTypeId  Int
+  productType    ProductType @relation(fields: [productTypeId], references: [id])
+  isActive       Boolean     @default(true)
+  createdAt      DateTime    @default(now()) @db.Timestamptz(3)
+  updatedAt      DateTime    @updatedAt @db.Timestamptz(3)
+
+  @@unique([familyGroupId, normalizedName])
+  @@index([productTypeId])
+}
+
+model ProductClassificationHistory {
+  id             Int         @id @default(autoincrement())
+  familyGroupId  Int
+  familyGroup    FamilyGroup @relation(fields: [familyGroupId], references: [id], onDelete: Cascade)
+  normalizedName String
+  productTypeId  Int
+  productType    ProductType @relation(fields: [productTypeId], references: [id])
+  createdAt      DateTime    @default(now()) @db.Timestamptz(3)
+  updatedAt      DateTime    @updatedAt @db.Timestamptz(3)
+
+  @@unique([familyGroupId, normalizedName])
+  @@index([productTypeId])
+}
+
+model ProductClassificationAlias {
+  id             Int         @id @default(autoincrement())
+  familyGroupId  Int
+  familyGroup    FamilyGroup @relation(fields: [familyGroupId], references: [id], onDelete: Cascade)
+  normalizedName String
+  productTypeId  Int
+  productType    ProductType @relation(fields: [productTypeId], references: [id])
+  isActive       Boolean     @default(true)
+  createdAt      DateTime    @default(now()) @db.Timestamptz(3)
+  updatedAt      DateTime    @updatedAt @db.Timestamptz(3)
+
+  @@unique([familyGroupId, normalizedName])
+  @@index([productTypeId])
+}
+
+model ClassificationCorrection {
+  id                    Int                           @id @default(autoincrement())
+  familyGroupId         Int
+  familyGroup           FamilyGroup                   @relation(fields: [familyGroupId], references: [id], onDelete: Cascade)
+  itemId                Int
+  item                  Item                          @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  actorMemberId         Int?
+  actorMember           FamilyMember?                 @relation(fields: [actorMemberId], references: [id], onDelete: SetNull)
+  previousProductTypeId Int?
+  previousProductType   ProductType?                  @relation("PreviousProductType", fields: [previousProductTypeId], references: [id])
+  nextProductTypeId     Int?
+  nextProductType       ProductType?                  @relation("NextProductType", fields: [nextProductTypeId], references: [id])
+  scope                 ClassificationCorrectionScope
+  createdAt             DateTime                      @default(now()) @db.Timestamptz(3)
+
+  @@index([familyGroupId, createdAt])
+  @@index([itemId])
+  @@index([actorMemberId])
 }
 
 // [Issue #78] レシート明細ごとの負担内訳
 // レコードが存在しない場合（0件）は「レシート登録者の全額負担」とみなす（暗黙的デフォルト）
 model ItemSplit {
-  id             Int          @id @default(autoincrement())
+  id             Int      @id @default(autoincrement())
   itemId         Int
   familyMemberId Int
-  amount         Int          // 精算用金額（端数を丸めた日本円のためInt）
-  createdAt      DateTime     @default(now()) @db.Timestamptz(3)
+  amount         Int // 精算用金額（端数を丸めた日本円のためInt）
+  createdAt      DateTime @default(now()) @db.Timestamptz(3)
 
-  item           Item         @relation(fields: [itemId], references: [id], onDelete: Cascade)
-  familyMember   FamilyMember @relation(fields: [familyMemberId], references: [id])
+  item         Item         @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  familyMember FamilyMember @relation(fields: [familyMemberId], references: [id])
 
   @@index([itemId])
   @@index([familyMemberId])
@@ -129,14 +298,14 @@ model ItemSplit {
 
 // ★ [Issue #81] 送金履歴（締め処理の実績管理）
 model SettlementTransfer {
-  id            Int          @id @default(autoincrement())
+  id            Int         @id @default(autoincrement())
   familyGroupId Int
-  familyGroup   FamilyGroup  @relation(fields: [familyGroupId], references: [id])
-  month         String       // 例: "2026-05" (精算対象月)
-  fromMemberId  Int          // 送金した人
-  toMemberId    Int          // 受け取った人
-  amount        Int          // 送金額
-  settledAt     DateTime     @default(now()) @db.Timestamptz(3)
+  familyGroup   FamilyGroup @relation(fields: [familyGroupId], references: [id])
+  month         String // 例: "2026-05" (精算対象月)
+  fromMemberId  Int // 送金した人
+  toMemberId    Int // 受け取った人
+  amount        Int // 送金額
+  settledAt     DateTime    @default(now()) @db.Timestamptz(3)
 
   sender   FamilyMember @relation("TransferSender", fields: [fromMemberId], references: [id])
   receiver FamilyMember @relation("TransferReceiver", fields: [toMemberId], references: [id])
@@ -149,14 +318,14 @@ model SettlementTransfer {
 
 // 学習マスタ (世帯ごとに学習結果を分離)
 model ProductMaster {
-  id            Int         @id @default(autoincrement())
+  id            Int    @id @default(autoincrement())
   name          String
   storeName     String
   categoryId    Int
   familyGroupId Int
-  
-  familyGroup   FamilyGroup @relation(fields: [familyGroupId], references: [id])
-  category      Category    @relation(fields: [categoryId], references: [id])
+
+  familyGroup FamilyGroup @relation(fields: [familyGroupId], references: [id])
+  category    Category    @relation(fields: [categoryId], references: [id])
 
   @@unique([name, storeName, familyGroupId], name: "name_storeName_familyGroupId")
 }
@@ -164,14 +333,14 @@ model ProductMaster {
 // [Issue #59] Gemini API トークン使用量トラッキング
 model ApiUsageLog {
   id               Int           @id @default(autoincrement())
-  familyMemberId   Int?          // 実行したユーザー
+  familyMemberId   Int? // 実行したユーザー
   familyMember     FamilyMember? @relation(fields: [familyMemberId], references: [id])
-  receiptId        Int?          // 関連するレシート
+  receiptId        Int? // 関連するレシート
   receipt          Receipt?      @relation(fields: [receiptId], references: [id])
-  modelId          String        // 例: "gemini-1.5-flash"
-  promptTokens     Int           // 入力トークン
-  candidatesTokens Int           // 出力トークン
-  totalTokens      Int           // 合計トークン
+  modelId          String // 例: "gemini-1.5-flash"
+  promptTokens     Int // 入力トークン
+  candidatesTokens Int // 出力トークン
+  totalTokens      Int // 合計トークン
   createdAt        DateTime      @default(now()) @db.Timestamptz(3)
 
   @@index([familyMemberId])
@@ -183,7 +352,7 @@ model PromptTemplate {
   id            Int         @id @default(autoincrement())
   familyGroupId Int
   familyGroup   FamilyGroup @relation(fields: [familyGroupId], references: [id])
-  key           String      // 例: "RECEIPT_ANALYSIS"
+  key           String // 例: "RECEIPT_ANALYSIS"
   name          String      @default("デフォルトプロンプト")
   description   String?
   systemPrompt  String      @db.Text

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -4,6 +4,11 @@ import process from 'node:process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { syncAllSeedTableSequences, syncPostgresIdSequence } from './syncSequences';
+import {
+  INITIAL_PRODUCT_TYPES,
+  INITIAL_STANDARD_PRODUCT_DICTIONARY,
+  STANDARD_CATEGORIES,
+} from './standardProductClassificationSeed';
 
 const prisma = new PrismaClient();
 
@@ -88,6 +93,64 @@ async function seedMastersForFamily(
   });
 }
 
+async function seedStandardProductClassificationMasters() {
+  const categoryIdByCode = new Map<string, number>();
+
+  for (const category of STANDARD_CATEGORIES) {
+    const parentId = category.parentCode
+      ? categoryIdByCode.get(category.parentCode)
+      : undefined;
+
+    if (category.parentCode && !parentId) {
+      throw new Error(`StandardCategory parent is missing: ${category.parentCode}`);
+    }
+
+    const created = await prisma.standardCategory.create({
+      data: {
+        code: category.code,
+        name: category.name,
+        parentId,
+        displayOrder: category.displayOrder,
+      },
+    });
+    categoryIdByCode.set(category.code, created.id);
+  }
+
+  const productTypeIdByCode = new Map<string, number>();
+  for (const productType of INITIAL_PRODUCT_TYPES) {
+    const standardCategoryId = categoryIdByCode.get(productType.standardCategoryCode);
+    if (!standardCategoryId) {
+      throw new Error(`ProductType category is missing: ${productType.standardCategoryCode}`);
+    }
+
+    const created = await prisma.productType.create({
+      data: {
+        code: productType.code,
+        name: productType.name,
+        standardCategoryId,
+        displayOrder: productType.displayOrder,
+      },
+    });
+    productTypeIdByCode.set(productType.code, created.id);
+  }
+
+  for (const entry of INITIAL_STANDARD_PRODUCT_DICTIONARY) {
+    const standardCategoryId = categoryIdByCode.get(entry.standardCategoryCode);
+    const productTypeId = productTypeIdByCode.get(entry.productTypeCode);
+    if (!standardCategoryId || !productTypeId) {
+      throw new Error(`StandardProductDictionary reference is missing: ${entry.normalizedName}`);
+    }
+
+    await prisma.standardProductDictionary.create({
+      data: {
+        normalizedName: entry.normalizedName,
+        standardCategoryId,
+        productTypeId,
+      },
+    });
+  }
+}
+
 async function main() {
   console.log('--- 🚀 Seeding Start (Multi-Tenancy Architecture) ---');
 
@@ -95,6 +158,13 @@ async function main() {
   const password_hash = await bcrypt.hash(devPassword, 10);
 
   await prisma.item.deleteMany();
+  await prisma.classificationCorrection.deleteMany();
+  await prisma.productClassificationAlias.deleteMany();
+  await prisma.productClassificationHistory.deleteMany();
+  await prisma.householdProductDictionary.deleteMany();
+  await prisma.standardProductDictionary.deleteMany();
+  await prisma.productType.deleteMany();
+  await prisma.standardCategory.deleteMany();
   await prisma.settlementTransfer.deleteMany();
   await prisma.productMaster.deleteMany();
   await prisma.receipt.deleteMany();
@@ -105,6 +175,9 @@ async function main() {
   await prisma.familyGroup.deleteMany();
 
   console.log('🗑️ Existing data cleared.');
+
+  await seedStandardProductClassificationMasters();
+  console.log('🗂️ Standard product classification masters seeded.');
 
   const familyGroup = await prisma.familyGroup.create({
     data: { id: 1, name: '山本家', inviteCode: 'YAMAMOTO-2026' },

--- a/backend/prisma/standardProductClassificationSeed.ts
+++ b/backend/prisma/standardProductClassificationSeed.ts
@@ -1,0 +1,67 @@
+export type StandardCategorySeed = {
+  code: string;
+  name: string;
+  parentCode?: string;
+  displayOrder: number;
+};
+
+export type ProductTypeSeed = {
+  code: string;
+  name: string;
+  standardCategoryCode: string;
+  displayOrder: number;
+};
+
+export type StandardProductDictionarySeed = {
+  normalizedName: string;
+  standardCategoryCode: string;
+  productTypeCode: string;
+};
+
+export const STANDARD_CATEGORIES: StandardCategorySeed[] = [
+  { code: 'food', name: '食費', displayOrder: 10 },
+  { code: 'food-snacks', name: 'お菓子', parentCode: 'food', displayOrder: 11 },
+  { code: 'food-instant', name: 'インスタント食品', parentCode: 'food', displayOrder: 12 },
+  { code: 'food-dairy', name: '乳製品', parentCode: 'food', displayOrder: 13 },
+  { code: 'daily-goods', name: '日用品', displayOrder: 20 },
+  { code: 'daily-laundry', name: '洗濯用品', parentCode: 'daily-goods', displayOrder: 21 },
+  { code: 'daily-paper', name: '紙製品', parentCode: 'daily-goods', displayOrder: 22 },
+  { code: 'housing', name: '住居', displayOrder: 30 },
+  { code: 'utilities', name: '水道光熱費', displayOrder: 40 },
+  { code: 'transport-communication', name: '交通・通信', displayOrder: 50 },
+  { code: 'medical-health', name: '医療・健康', displayOrder: 60 },
+  { code: 'education-culture', name: '教育・教養', displayOrder: 70 },
+  { code: 'entertainment', name: '娯楽', displayOrder: 80 },
+  { code: 'clothing-beauty', name: '衣服・美容', displayOrder: 90 },
+  { code: 'social', name: '交際費', displayOrder: 100 },
+  { code: 'special', name: '特別支出', displayOrder: 110 },
+  { code: 'other', name: 'その他', displayOrder: 120 },
+];
+
+export const INITIAL_PRODUCT_TYPES: ProductTypeSeed[] = [
+  { code: 'potato-chips', name: 'ポテトチップス', standardCategoryCode: 'food-snacks', displayOrder: 1 },
+  { code: 'other-snacks', name: 'その他スナック菓子', standardCategoryCode: 'food-snacks', displayOrder: 2 },
+  { code: 'chocolate', name: 'チョコレート', standardCategoryCode: 'food-snacks', displayOrder: 3 },
+  { code: 'cookies-biscuits', name: 'クッキー・ビスケット', standardCategoryCode: 'food-snacks', displayOrder: 4 },
+  { code: 'rice-crackers', name: 'せんべい・米菓', standardCategoryCode: 'food-snacks', displayOrder: 5 },
+  { code: 'ice-cream', name: 'アイス', standardCategoryCode: 'food-snacks', displayOrder: 6 },
+  { code: 'cup-noodles', name: 'カップ麺', standardCategoryCode: 'food-instant', displayOrder: 1 },
+  { code: 'bag-noodles', name: '袋麺', standardCategoryCode: 'food-instant', displayOrder: 2 },
+  { code: 'retort-food', name: 'レトルト食品', standardCategoryCode: 'food-instant', displayOrder: 3 },
+  { code: 'frozen-food', name: '冷凍食品', standardCategoryCode: 'food-instant', displayOrder: 4 },
+  { code: 'milk', name: '牛乳', standardCategoryCode: 'food-dairy', displayOrder: 1 },
+  { code: 'laundry-detergent', name: '洗濯洗剤', standardCategoryCode: 'daily-laundry', displayOrder: 1 },
+  { code: 'fabric-softener', name: '柔軟剤', standardCategoryCode: 'daily-laundry', displayOrder: 2 },
+  { code: 'bleach', name: '漂白剤', standardCategoryCode: 'daily-laundry', displayOrder: 3 },
+  { code: 'tissues', name: 'ティッシュ', standardCategoryCode: 'daily-paper', displayOrder: 1 },
+  { code: 'toilet-paper', name: 'トイレットペーパー', standardCategoryCode: 'daily-paper', displayOrder: 2 },
+  { code: 'kitchen-paper', name: 'キッチンペーパー', standardCategoryCode: 'daily-paper', displayOrder: 3 },
+];
+
+// Phase 1では各ProductTypeの標準名称を完全一致辞書として登録する。
+export const INITIAL_STANDARD_PRODUCT_DICTIONARY: StandardProductDictionarySeed[] =
+  INITIAL_PRODUCT_TYPES.map((productType) => ({
+    normalizedName: productType.name,
+    standardCategoryCode: productType.standardCategoryCode,
+    productTypeCode: productType.code,
+  }));

--- a/backend/src/mappers/receiptMapper.test.ts
+++ b/backend/src/mappers/receiptMapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ProductTypeStatus } from '@prisma/client';
 import {
   mapCategoriesToSummary,
   mapFamilyMembersToSummary,
@@ -34,6 +35,11 @@ describe('receiptMapper', () => {
         id: 100,
         receiptId: 10,
         categoryId: 1,
+        standardCategoryId: null,
+        productTypeId: null,
+        productTypeStatus: ProductTypeStatus.UNCLASSIFIED,
+        classificationSource: null,
+        classificationConfidence: null,
         name: 'りんご',
         price: 120,
         quantity: 10,
@@ -93,6 +99,11 @@ describe('receiptMapper', () => {
       id: 101,
       receiptId: 10,
       categoryId: null,
+      standardCategoryId: null,
+      productTypeId: null,
+      productTypeStatus: ProductTypeStatus.UNCLASSIFIED,
+      classificationSource: null,
+      classificationConfidence: null,
       name: '牛乳',
       price: 200,
       quantity: 1,

--- a/backend/src/services/productClassification/standardProductClassificationSeed.test.ts
+++ b/backend/src/services/productClassification/standardProductClassificationSeed.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INITIAL_PRODUCT_TYPES,
+  INITIAL_STANDARD_PRODUCT_DICTIONARY,
+  STANDARD_CATEGORIES,
+} from '../../../prisma/standardProductClassificationSeed';
+
+describe('standard product classification seed', () => {
+  it('defines the agreed standard category hierarchy roots and children', () => {
+    expect(STANDARD_CATEGORIES.filter((category) => !category.parentCode)).toHaveLength(12);
+    expect(STANDARD_CATEGORIES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'food', name: '食費' }),
+        expect.objectContaining({ code: 'food-snacks', parentCode: 'food' }),
+        expect.objectContaining({ code: 'daily-goods', name: '日用品' }),
+        expect.objectContaining({ code: 'daily-paper', parentCode: 'daily-goods' }),
+      ])
+    );
+  });
+
+  it('defines exactly the initial 17 product types', () => {
+    expect(INITIAL_PRODUCT_TYPES).toHaveLength(17);
+    expect(new Set(INITIAL_PRODUCT_TYPES.map((productType) => productType.code)).size).toBe(17);
+  });
+
+  it('maps every initial product type to a valid category and dictionary entry', () => {
+    const categoryCodes = new Set(STANDARD_CATEGORIES.map((category) => category.code));
+    const dictionaryCodes = new Set(
+      INITIAL_STANDARD_PRODUCT_DICTIONARY.map((entry) => entry.productTypeCode)
+    );
+
+    for (const productType of INITIAL_PRODUCT_TYPES) {
+      expect(categoryCodes).toContain(productType.standardCategoryCode);
+      expect(dictionaryCodes).toContain(productType.code);
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Issue #109-1（商品分類データモデル・標準マスタ・シード）を実装します。

## 変更内容

- `StandardCategory`、`ProductType`、標準辞書、世帯別学習・監査モデルをPrismaへ追加
- `Item`へ標準カテゴリ、商品種別、分類状態、分類元、信頼度を追加
- 標準カテゴリ階層、初期17種のProductType、最小標準辞書のシードを追加
- Prisma migrationを追加
- シード定義テストと既存Mapper fixtureを更新

## 影響と適用方針

- 既存の世帯別`Category`、`Item.categoryId`、`ProductMaster`は後続Issueで切り替えるため、このPRでは維持します。
- migrationは生成済みですが、開発環境・stable環境とも未適用です。
- 開発環境のバックアップ、migration適用、データ初期化、標準マスタの実投入は Issue #109-4 の手順で明示承認後に行います。

## 検証

- `cd backend && npx prisma validate`
- `cd backend && npm test`（77 passed / 30 skipped）
- `git diff --check`

Closes #544
