### PR TITLE
feat: 商品種別の手動修正と世帯学習を追加 #110-1

### DIFF
--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -34,6 +34,7 @@ import {
   listFamilyMembers,
 } from '../services/receipt/receiptQueryService';
 import { updateReceiptById, updateItemCategoryById } from '../services/receipt/receiptUpdateService';
+import { correctItemProductClassification } from '../services/productClassification/productClassificationCorrectionService';
 import { updateItemSplitsById } from '../services/settlement/itemSplitService';
 import {
   getMonthlyStats as fetchMonthlyStats,
@@ -160,6 +161,13 @@ export const updateItemCategory = asyncHandler(async (req, res) => {
   const { categoryId } = req.body;
 
   const result = await updateItemCategoryById(Number(id), familyGroupId, categoryId);
+  sendSuccess(res, mapReceiptItemToDetail(result));
+});
+
+export const updateItemProductClassification = asyncHandler(async (req, res) => {
+  const { familyGroupId, memberId } = requireTenantContext();
+  const itemId = getRouteParam(req, 'itemId');
+  const result = await correctItemProductClassification(Number(itemId), familyGroupId, memberId, req.body);
   sendSuccess(res, mapReceiptItemToDetail(result));
 });
 

--- a/backend/src/repositories/productClassificationRepository.ts
+++ b/backend/src/repositories/productClassificationRepository.ts
@@ -1,0 +1,70 @@
+import type { ClassificationCorrectionScope } from '@prisma/client';
+import type { PrismaTx } from '../utils/prismaTransaction';
+
+export async function findActiveProductTypeWithCategoryInTx(tx: PrismaTx, productTypeId: number) {
+  return tx.productType.findFirst({
+    where: {
+      id: productTypeId,
+      isActive: true,
+      standardCategory: { isActive: true },
+    },
+    include: { standardCategory: { include: { parent: true } } },
+  });
+}
+
+export async function findCategoryForProductTypeInTx(
+  tx: PrismaTx,
+  familyGroupId: number,
+  rootCategoryName: string
+) {
+  return tx.category.findFirst({
+    where: { familyGroupId, name: rootCategoryName },
+    select: { id: true },
+  });
+}
+
+export async function createClassificationCorrectionInTx(
+  tx: PrismaTx,
+  input: {
+    familyGroupId: number;
+    itemId: number;
+    actorMemberId: number;
+    previousProductTypeId: number | null;
+    nextProductTypeId: number;
+    scope: ClassificationCorrectionScope;
+  }
+) {
+  return tx.classificationCorrection.create({ data: input });
+}
+
+export async function upsertHouseholdProductDictionaryInTx(
+  tx: PrismaTx,
+  input: { familyGroupId: number; normalizedName: string; productTypeId: number }
+) {
+  return tx.householdProductDictionary.upsert({
+    where: {
+      familyGroupId_normalizedName: {
+        familyGroupId: input.familyGroupId,
+        normalizedName: input.normalizedName,
+      },
+    },
+    create: { ...input, isActive: true },
+    update: { productTypeId: input.productTypeId, isActive: true },
+  });
+}
+
+export async function upsertProductClassificationAliasInTx(
+  tx: PrismaTx,
+  input: { familyGroupId: number; normalizedName: string; productTypeId: number }
+) {
+  return tx.productClassificationAlias.upsert({
+    where: {
+      familyGroupId_normalizedName: {
+        familyGroupId: input.familyGroupId,
+        normalizedName: input.normalizedName,
+      },
+    },
+    create: { ...input, isActive: true },
+    update: { productTypeId: input.productTypeId, isActive: true },
+  });
+}

--- a/backend/src/routes/receiptRoutes.ts
+++ b/backend/src/routes/receiptRoutes.ts
@@ -3,7 +3,7 @@ import multer from 'multer';
 import { authMiddleware } from '../middleware/authMiddleware';
 import { tenantMiddleware } from '../middleware/tenantMiddleware';
 import { validate } from '../middleware/validate';
-import { uploadReceiptSchema } from '../schemas/receiptSchema';
+import { productClassificationCorrectionSchema, uploadReceiptSchema } from '../schemas/receiptSchema';
 
 import {
   getReceipts,
@@ -12,6 +12,7 @@ import {
   deleteReceipt,
   getLatestReceipt,
   updateItemCategory,
+  updateItemProductClassification,
   getMonthlyStats,
   getJobStatus,
   getReceiptJobs,
@@ -56,6 +57,11 @@ router.post('/receipts', createReceipt);
 router.delete('/receipts/:id', deleteReceipt);
 router.patch('/receipts/:id', updateReceipt);
 router.patch('/receipts/items/:id', updateItemCategory);
+router.patch(
+  '/receipts/items/:itemId/product-classification',
+  validate(productClassificationCorrectionSchema),
+  updateItemProductClassification
+);
 router.post('/receipts/items/:itemId/splits', updateItemSplits);
 router.post('/receipts/commit', commitReceipt);
 

--- a/backend/src/schemas/receiptSchema.test.ts
+++ b/backend/src/schemas/receiptSchema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { productClassificationCorrectionSchema } from './receiptSchema';
+
+describe('productClassificationCorrectionSchema', () => {
+  it('requires classificationName only for SAME_CLASSIFICATION_NAME', () => {
+    expect(
+      productClassificationCorrectionSchema.safeParse({
+        productTypeId: 1,
+        scope: 'same_classification_name',
+      }).success
+    ).toBe(false);
+
+    expect(
+      productClassificationCorrectionSchema.safeParse({
+        productTypeId: 1,
+        scope: 'same_classification_name',
+        classificationName: '牛乳',
+      }).success
+    ).toBe(true);
+  });
+});

--- a/backend/src/schemas/receiptSchema.ts
+++ b/backend/src/schemas/receiptSchema.ts
@@ -20,6 +20,22 @@ export const uploadReceiptSchema = z.object({
   // ここには定義しない、もしくは .optional() にします
 });
 
+export const productClassificationCorrectionSchema = z
+  .object({
+    productTypeId: z.coerce.number().int().positive(),
+    scope: z.enum(['item_only', 'same_ocr_name', 'same_classification_name']),
+    classificationName: z.string().trim().min(1).optional(),
+  })
+  .superRefine((input, ctx) => {
+    if (input.scope === 'same_classification_name' && !input.classificationName) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['classificationName'],
+        message: '分類用名称は必須です',
+      });
+    }
+  });
+
 /**
  * 3. 最終的な保存・更新用のバリデーション
  * DB保存時に整合性をチェックするために使用

--- a/backend/src/services/productClassification/productClassificationCorrectionService.test.ts
+++ b/backend/src/services/productClassification/productClassificationCorrectionService.test.ts
@@ -1,0 +1,103 @@
+import {
+  ClassificationConfidence,
+  ClassificationCorrectionScope,
+  ClassificationSource,
+  ProductTypeStatus,
+} from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repositoryMocks = vi.hoisted(() => ({
+  createClassificationCorrectionInTx: vi.fn(),
+  findActiveProductTypeWithCategoryInTx: vi.fn(),
+  findCategoryForProductTypeInTx: vi.fn(),
+  upsertHouseholdProductDictionaryInTx: vi.fn(),
+  upsertProductClassificationAliasInTx: vi.fn(),
+  findItemWithReceiptInTx: vi.fn(),
+  updateItemCategoryInTx: vi.fn(),
+}));
+
+vi.mock('../../utils/prismaTransaction', () => ({
+  runInTransaction: (callback: (tx: object) => unknown) => callback({}),
+}));
+vi.mock('../../repositories/productClassificationRepository', () => repositoryMocks);
+vi.mock('../../repositories/receiptRepository', () => repositoryMocks);
+
+import { correctItemProductClassification } from './productClassificationCorrectionService';
+
+describe('correctItemProductClassification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repositoryMocks.findItemWithReceiptInTx.mockResolvedValue({
+      id: 10,
+      name: '明治 おいしい牛乳',
+      productTypeId: 3,
+      receipt: { familyGroupId: 1 },
+    });
+    repositoryMocks.findActiveProductTypeWithCategoryInTx.mockResolvedValue({
+      id: 11,
+      standardCategoryId: 4,
+      standardCategory: { name: '乳製品', parent: { name: '食費' } },
+    });
+    repositoryMocks.findCategoryForProductTypeInTx.mockResolvedValue({ id: 2 });
+    repositoryMocks.updateItemCategoryInTx.mockResolvedValue({ id: 10 });
+  });
+
+  it('stores only an audit record for ITEM_ONLY', async () => {
+    await correctItemProductClassification(10, 1, 7, {
+      productTypeId: 11,
+      scope: ClassificationCorrectionScope.ITEM_ONLY,
+    });
+
+    expect(repositoryMocks.updateItemCategoryInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      10,
+      expect.objectContaining({
+        categoryId: 2,
+        productTypeId: 11,
+        productTypeStatus: ProductTypeStatus.CLASSIFIED,
+        classificationSource: ClassificationSource.MANUAL,
+        classificationConfidence: ClassificationConfidence.HIGH,
+      })
+    );
+    expect(repositoryMocks.createClassificationCorrectionInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        familyGroupId: 1,
+        itemId: 10,
+        actorMemberId: 7,
+        previousProductTypeId: 3,
+        nextProductTypeId: 11,
+        scope: ClassificationCorrectionScope.ITEM_ONLY,
+      })
+    );
+    expect(repositoryMocks.upsertHouseholdProductDictionaryInTx).not.toHaveBeenCalled();
+    expect(repositoryMocks.upsertProductClassificationAliasInTx).not.toHaveBeenCalled();
+  });
+
+  it('stores an OCR-name dictionary entry for SAME_OCR_NAME', async () => {
+    await correctItemProductClassification(10, 1, 7, {
+      productTypeId: 11,
+      scope: ClassificationCorrectionScope.SAME_OCR_NAME,
+    });
+
+    expect(repositoryMocks.upsertHouseholdProductDictionaryInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      { familyGroupId: 1, normalizedName: '明治 おいしい牛乳', productTypeId: 11 }
+    );
+    expect(repositoryMocks.upsertProductClassificationAliasInTx).not.toHaveBeenCalled();
+  });
+
+  it('stores a supplied classification name as an alias for SAME_CLASSIFICATION_NAME', async () => {
+    await correctItemProductClassification(10, 1, 7, {
+      productTypeId: 11,
+      scope: ClassificationCorrectionScope.SAME_CLASSIFICATION_NAME,
+      classificationName: '牛乳',
+    });
+
+    expect(repositoryMocks.upsertProductClassificationAliasInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      { familyGroupId: 1, normalizedName: '牛乳', productTypeId: 11 }
+    );
+    expect(repositoryMocks.upsertHouseholdProductDictionaryInTx).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/productClassification/productClassificationCorrectionService.ts
+++ b/backend/src/services/productClassification/productClassificationCorrectionService.ts
@@ -1,0 +1,94 @@
+import {
+  ClassificationConfidence,
+  ClassificationCorrectionScope,
+  ClassificationSource,
+  ProductTypeStatus,
+} from '@prisma/client';
+import { AppError } from '../../utils/appError';
+import { getCleanText } from '../../utils/normalizer';
+import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
+import {
+  createClassificationCorrectionInTx,
+  findActiveProductTypeWithCategoryInTx,
+  findCategoryForProductTypeInTx,
+  upsertHouseholdProductDictionaryInTx,
+  upsertProductClassificationAliasInTx,
+} from '../../repositories/productClassificationRepository';
+import { findItemWithReceiptInTx, updateItemCategoryInTx } from '../../repositories/receiptRepository';
+
+export type ProductClassificationCorrectionInput = {
+  productTypeId: number;
+  scope: ClassificationCorrectionScope;
+  classificationName?: string;
+};
+
+async function correctItemProductClassificationInTx(
+  tx: PrismaTx,
+  itemId: number,
+  familyGroupId: number,
+  actorMemberId: number,
+  input: ProductClassificationCorrectionInput
+) {
+  const item = await findItemWithReceiptInTx(tx, itemId);
+  if (!item || item.receipt.familyGroupId !== familyGroupId) {
+    throw new AppError('ItemNotFound', 404);
+  }
+
+  const productType = await findActiveProductTypeWithCategoryInTx(tx, input.productTypeId);
+  if (!productType) throw new AppError('ProductTypeNotFound', 404);
+
+  const rootCategoryName = productType.standardCategory.parent?.name ?? productType.standardCategory.name;
+  const category = await findCategoryForProductTypeInTx(tx, familyGroupId, rootCategoryName);
+  if (!category) throw new AppError('CategoryNotFound', 404);
+
+  const updatedItem = await updateItemCategoryInTx(tx, itemId, {
+    categoryId: category.id,
+    standardCategoryId: productType.standardCategoryId,
+    productTypeId: productType.id,
+    productTypeStatus: ProductTypeStatus.CLASSIFIED,
+    classificationSource: ClassificationSource.MANUAL,
+    classificationConfidence: ClassificationConfidence.HIGH,
+  });
+
+  await createClassificationCorrectionInTx(tx, {
+    familyGroupId,
+    itemId,
+    actorMemberId,
+    previousProductTypeId: item.productTypeId,
+    nextProductTypeId: productType.id,
+    scope: input.scope,
+  });
+
+  if (input.scope === ClassificationCorrectionScope.SAME_OCR_NAME) {
+    const normalizedName = getCleanText(item.name);
+    if (!normalizedName) throw new AppError('ItemNameRequired', 400);
+    await upsertHouseholdProductDictionaryInTx(tx, {
+      familyGroupId,
+      normalizedName,
+      productTypeId: productType.id,
+    });
+  }
+
+  if (input.scope === ClassificationCorrectionScope.SAME_CLASSIFICATION_NAME) {
+    const normalizedName = getCleanText(input.classificationName ?? '');
+    if (!normalizedName) throw new AppError('ClassificationNameRequired', 400);
+    await upsertProductClassificationAliasInTx(tx, {
+      familyGroupId,
+      normalizedName,
+      productTypeId: productType.id,
+    });
+  }
+
+  return updatedItem;
+}
+
+export async function correctItemProductClassification(
+  itemId: number,
+  familyGroupId: number,
+  actorMemberId: number,
+  input: ProductClassificationCorrectionInput
+) {
+  return runInTransaction((tx) =>
+    correctItemProductClassificationInTx(tx, itemId, familyGroupId, actorMemberId, input)
+  );
+}

--- a/backend/src/services/productClassification/productClassificationService.test.ts
+++ b/backend/src/services/productClassification/productClassificationService.test.ts
@@ -1,0 +1,34 @@
+import { ClassificationSource } from '@prisma/client';
+import { describe, expect, it, vi } from 'vitest';
+import { classifyItemByExactMatch } from './productClassificationService';
+
+describe('classifyItemByExactMatch', () => {
+  it('uses a household alias before the standard dictionary', async () => {
+    const alias = {
+      productTypeId: 11,
+      productType: {
+        standardCategory: { id: 4, name: '乳製品', parent: { name: '食費' } },
+      },
+    };
+    const tx = {
+      productClassificationHistory: { findUnique: vi.fn().mockResolvedValue(null) },
+      householdProductDictionary: { findUnique: vi.fn().mockResolvedValue(null) },
+      productClassificationAlias: { findUnique: vi.fn().mockResolvedValue(alias) },
+      standardProductDictionary: { findUnique: vi.fn() },
+      category: { findFirst: vi.fn().mockResolvedValue({ id: 2 }) },
+    };
+
+    const result = await classifyItemByExactMatch(tx as never, {
+      familyGroupId: 1,
+      itemName: 'いつもの牛乳',
+    });
+
+    expect(result).toMatchObject({
+      categoryId: 2,
+      standardCategoryId: 4,
+      productTypeId: 11,
+      classificationSource: ClassificationSource.HOUSEHOLD_DICTIONARY,
+    });
+    expect(tx.standardProductDictionary.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/productClassification/productClassificationService.ts
+++ b/backend/src/services/productClassification/productClassificationService.ts
@@ -41,20 +41,27 @@ async function findMatchedProductType(
         where: { familyGroupId_normalizedName: { familyGroupId, normalizedName } },
         include: { productType: { include: productTypeInclude } },
       });
-  const standard = history || dictionary
+  const alias = history || dictionary
+    ? null
+    : await tx.productClassificationAlias.findUnique({
+        where: { familyGroupId_normalizedName: { familyGroupId, normalizedName } },
+        include: { productType: { include: productTypeInclude } },
+      });
+  const standard = history || dictionary || alias
     ? null
     : await tx.standardProductDictionary.findUnique({
         where: { normalizedName },
         include: { standardCategory: { include: { parent: true } }, productType: true },
       });
 
-  if (history || dictionary) {
-    const record = history ?? dictionary!;
+  if (history || dictionary || alias) {
+    const record = history ?? dictionary ?? alias!;
     const category = record.productType.standardCategory;
     return {
       productTypeId: record.productTypeId,
       standardCategoryId: category.id,
       rootCategoryName: category.parent?.name ?? category.name,
+      // 別名も世帯内の辞書学習として API では household_dictionary に集約する。
       source: history ? ClassificationSource.HISTORY : ClassificationSource.HOUSEHOLD_DICTIONARY,
     };
   }

--- a/backend/src/types/apiSchemas.ts
+++ b/backend/src/types/apiSchemas.ts
@@ -60,9 +60,26 @@ export type ProductTypeStatus =
   | 'outside_initial_scope'
   | 'not_applicable';
 
-export type ClassificationSource = 'history' | 'household_dictionary' | 'standard_dictionary' | 'ai';
+export type ClassificationSource =
+  | 'history'
+  | 'household_dictionary'
+  | 'standard_dictionary'
+  | 'similarity'
+  | 'ai'
+  | 'manual';
 
 export type ClassificationConfidence = 'high' | 'medium' | 'low';
+
+export type ClassificationCorrectionScope =
+  | 'item_only'
+  | 'same_ocr_name'
+  | 'same_classification_name';
+
+export type UpdateItemProductClassificationRequest = {
+  productTypeId: number;
+  scope: ClassificationCorrectionScope;
+  classificationName?: string;
+};
 
 export type ItemSplitSummary = {
   id: number;
@@ -254,6 +271,8 @@ export const API_SCHEMA_EXPORTS = [
   'ProductTypeStatus',
   'ClassificationSource',
   'ClassificationConfidence',
+  'ClassificationCorrectionScope',
+  'UpdateItemProductClassificationRequest',
   'ItemSplitSummary',
   'ReceiptItemDetail',
   'ReceiptDetail',

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -473,6 +473,37 @@ paths:
                       data:
                         $ref: '#/components/schemas/ReceiptItemDetail'
 
+  /receipts/items/{itemId}/product-classification:
+    patch:
+      tags: [receipt]
+      summary: 明細商品種別修正
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateItemProductClassificationRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ReceiptItemDetail'
+
   /receipts/items/{itemId}/splits:
     post:
       tags: [receipt]
@@ -996,7 +1027,11 @@ components:
 
     ClassificationSource:
       type: string
-      enum: [history, household_dictionary, standard_dictionary, ai]
+      enum: [history, household_dictionary, standard_dictionary, similarity, ai, manual]
+
+    ClassificationCorrectionScope:
+      type: string
+      enum: [item_only, same_ocr_name, same_classification_name]
 
     ClassificationConfidence:
       type: string
@@ -1273,6 +1308,18 @@ components:
       properties:
         categoryId:
           type: integer
+
+    UpdateItemProductClassificationRequest:
+      type: object
+      required: [productTypeId, scope]
+      properties:
+        productTypeId:
+          type: integer
+        scope:
+          $ref: '#/components/schemas/ClassificationCorrectionScope'
+        classificationName:
+          type: string
+          description: scope が same_classification_name の場合は必須
 
     SaveItemSplitsRequest:
       type: object

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -720,6 +720,50 @@ export interface paths {
         };
         trace?: never;
     };
+    "/receipts/items/{itemId}/product-classification": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** 明細商品種別修正 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    itemId: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateItemProductClassificationRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["ReceiptItemDetail"];
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/receipts/items/{itemId}/splits": {
         parameters: {
             query?: never;
@@ -1400,7 +1444,9 @@ export interface components {
         /** @enum {string} */
         ProductTypeStatus: "classified" | "needs_review" | "unclassified" | "outside_initial_scope" | "not_applicable";
         /** @enum {string} */
-        ClassificationSource: "history" | "household_dictionary" | "standard_dictionary" | "ai";
+        ClassificationSource: "history" | "household_dictionary" | "standard_dictionary" | "similarity" | "ai" | "manual";
+        /** @enum {string} */
+        ClassificationCorrectionScope: "item_only" | "same_ocr_name" | "same_classification_name";
         /** @enum {string} */
         ClassificationConfidence: "high" | "medium" | "low";
         ItemSplitSummary: {
@@ -1518,6 +1564,12 @@ export interface components {
         };
         UpdateItemCategoryRequest: {
             categoryId: number;
+        };
+        UpdateItemProductClassificationRequest: {
+            productTypeId: number;
+            scope: components["schemas"]["ClassificationCorrectionScope"];
+            /** @description scope が same_classification_name の場合は必須 */
+            classificationName?: string;
         };
         SaveItemSplitsRequest: {
             splits: components["schemas"]["ItemSplitInput"][];


### PR DESCRIPTION
## 概要

Issue #110-1（商品種別の確認・修正、世帯別学習）を実装します。

## 変更内容

- 明細の商品種別修正APIを追加
- 手動修正時に分類状態・分類元・信頼度と監査履歴を保存
- 適用範囲に応じて世帯別完全一致辞書または別名辞書を更新
- 完全一致分類の優先順位を、確定履歴 → 世帯別完全一致辞書 → 別名辞書 → 標準辞書へ拡張
- OpenAPI契約とフロントエンド生成API型を更新

## 影響

- DBスキーマ変更、migration適用、データ初期化は含みません。
- stable環境には変更を加えていません。

## 検証

- Backend: `npm test`（78 passed、29 skipped）
- Backend: `npx tsc --noEmit`
- Backend: `npm run check:openapi`
- Frontend: `npm test`（66 passed）
- Frontend: `npx tsc --noEmit`

Closes #549