### PR TITLE
feat: 商品種別修正UIを追加 #110-2

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import receiptRoutes from './routes/receiptRoutes';
 import categoryRoutes from './routes/categoryRoutes';
 import adminRoutes from './routes/adminRoutes';
 import statsRoutes from './routes/statsRoutes';
+import productTypeRoutes from './routes/productTypeRoutes';
 import { AppError } from './utils/appError';
 import { errorHandler } from './middleware/errorHandler';
 import logger from './utils/logger';
@@ -73,6 +74,7 @@ export function createApp() {
   protectedApi.use(tenantMiddleware);
   protectedApi.use('/', receiptRoutes);
   protectedApi.use('/categories', categoryRoutes);
+  protectedApi.use('/product-types', productTypeRoutes);
   protectedApi.use('/stats', statsRoutes);
 
   app.use('/api', protectedApi);

--- a/backend/src/controllers/productTypeController.ts
+++ b/backend/src/controllers/productTypeController.ts
@@ -1,0 +1,9 @@
+import { mapProductTypesToSummary } from '../mappers/productClassificationMapper';
+import { listActiveProductTypes } from '../services/productClassification/productTypeService';
+import { asyncHandler } from '../utils/asyncHandler';
+import { sendSuccess } from '../utils/sendApiResponse';
+
+export const getProductTypes = asyncHandler(async (_req, res) => {
+  const productTypes = await listActiveProductTypes();
+  sendSuccess(res, mapProductTypesToSummary(productTypes));
+});

--- a/backend/src/mappers/productClassificationMapper.test.ts
+++ b/backend/src/mappers/productClassificationMapper.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { mapProductTypesToSummary } from './productClassificationMapper';
+
+describe('mapProductTypesToSummary', () => {
+  it('maps only the product type fields exposed by the API', () => {
+    const result = mapProductTypesToSummary([
+      {
+        id: 11,
+        code: 'milk',
+        name: '牛乳',
+        standardCategoryId: 4,
+        displayOrder: 1,
+        isActive: true,
+      },
+    ]);
+
+    expect(result).toEqual([
+      { id: 11, code: 'milk', name: '牛乳', standardCategoryId: 4 },
+    ]);
+  });
+});

--- a/backend/src/mappers/productClassificationMapper.ts
+++ b/backend/src/mappers/productClassificationMapper.ts
@@ -1,0 +1,11 @@
+import type { ProductType } from '@prisma/client';
+import type { ProductTypeSummary } from '../types/apiSchemas';
+
+export function mapProductTypesToSummary(productTypes: ProductType[]): ProductTypeSummary[] {
+  return productTypes.map((productType) => ({
+    id: productType.id,
+    code: productType.code,
+    name: productType.name,
+    standardCategoryId: productType.standardCategoryId,
+  }));
+}

--- a/backend/src/repositories/productClassificationRepository.ts
+++ b/backend/src/repositories/productClassificationRepository.ts
@@ -1,4 +1,5 @@
 import type { ClassificationCorrectionScope } from '@prisma/client';
+import { prisma } from '../utils/prismaClient';
 import type { PrismaTx } from '../utils/prismaTransaction';
 
 export async function findActiveProductTypeWithCategoryInTx(tx: PrismaTx, productTypeId: number) {
@@ -9,6 +10,13 @@ export async function findActiveProductTypeWithCategoryInTx(tx: PrismaTx, produc
       standardCategory: { isActive: true },
     },
     include: { standardCategory: { include: { parent: true } } },
+  });
+}
+
+export async function findActiveProductTypes() {
+  return prisma.productType.findMany({
+    where: { isActive: true, standardCategory: { isActive: true } },
+    orderBy: [{ standardCategory: { displayOrder: 'asc' } }, { displayOrder: 'asc' }],
   });
 }
 

--- a/backend/src/routes/productTypeRoutes.ts
+++ b/backend/src/routes/productTypeRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getProductTypes } from '../controllers/productTypeController';
+
+const router = express.Router();
+
+router.get('/', getProductTypes);
+
+export default router;

--- a/backend/src/services/productClassification/productTypeService.ts
+++ b/backend/src/services/productClassification/productTypeService.ts
@@ -1,0 +1,6 @@
+import { findActiveProductTypes } from '../../repositories/productClassificationRepository';
+
+/** 商品種別選択UI用の有効な共通マスタ一覧 */
+export async function listActiveProductTypes() {
+  return findActiveProductTypes();
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -23,6 +23,27 @@ tags:
   - name: health
 
 paths:
+  /product-types:
+    get:
+      tags: [product-classification]
+      summary: 有効な商品種別一覧取得
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiSuccessEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProductTypeSummary'
+
   /auth/resolve-family:
     post:
       tags: [auth]

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -4,6 +4,44 @@
  */
 
 export interface paths {
+    "/product-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 有効な商品種別一覧取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiSuccessEnvelope"] & {
+                            data?: components["schemas"]["ProductTypeSummary"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/resolve-family": {
         parameters: {
             query?: never;

--- a/frontend/src/api/receiptApi.ts
+++ b/frontend/src/api/receiptApi.ts
@@ -10,6 +10,7 @@ import type {
   ReceiptItemDetail,
   ReceiptJobListItem,
   ReceiptJobStatus,
+  ProductTypeSummary,
 } from './generated';
 
 export type ListReceiptsParams = {
@@ -25,6 +26,16 @@ export type CommitReceiptPayload = {
 };
 
 export type ReceiptJobStatusResponse = ApiSuccessResponse<ReceiptJobStatus>;
+export type ProductClassificationCorrectionScope =
+  | 'item_only'
+  | 'same_ocr_name'
+  | 'same_classification_name';
+
+export type ProductClassificationCorrectionPayload = {
+  productTypeId: number;
+  scope: ProductClassificationCorrectionScope;
+  classificationName?: string;
+};
 
 /** レシート・ジョブ・按分 API（/api/receipts/*, /family-groups/members） */
 export const receiptApi = {
@@ -51,6 +62,19 @@ export const receiptApi = {
     categoryId: number
   ): Promise<ApiSuccessResponse<ReceiptItemDetail>> {
     const res = await apiClient.patch(`/receipts/items/${itemId}`, { categoryId });
+    return res.data;
+  },
+
+  async listProductTypes(): Promise<ApiSuccessResponse<ProductTypeSummary[]>> {
+    const res = await apiClient.get('/product-types');
+    return res.data;
+  },
+
+  async updateItemProductClassification(
+    itemId: number,
+    payload: ProductClassificationCorrectionPayload
+  ): Promise<ApiSuccessResponse<ReceiptItemDetail>> {
+    const res = await apiClient.patch(`/receipts/items/${itemId}/product-classification`, payload);
     return res.data;
   },
 

--- a/frontend/src/features/receipt/components/ProductClassificationCorrectionModal.tsx
+++ b/frontend/src/features/receipt/components/ProductClassificationCorrectionModal.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { AppButton, AppModal, AppSelect, AppTextInput } from '../../../components/ui';
+import type { ProductTypeSummary, ReceiptItemDetail } from '../../../api/generated';
+import type { ProductClassificationCorrectionScope } from '../../../api/receiptApi';
+import { colors } from '../../../theme/colors';
+import { spacing } from '../../../theme/spacing';
+
+type Props = {
+  item: ReceiptItemDetail | null;
+  productTypes: ProductTypeSummary[];
+  selectedProductTypeId: number | null;
+  scope: ProductClassificationCorrectionScope;
+  classificationName: string;
+  loading: boolean;
+  onClose: () => void;
+  onProductTypeChange: (productTypeId: number | null) => void;
+  onScopeChange: (scope: ProductClassificationCorrectionScope) => void;
+  onClassificationNameChange: (value: string) => void;
+  onSave: () => void;
+};
+
+const scopeOptions: Array<{ value: ProductClassificationCorrectionScope; label: string; detail: string }> = [
+  { value: 'item_only', label: 'この明細だけ', detail: '明細の修正履歴のみ残します。' },
+  { value: 'same_ocr_name', label: '同じOCR商品名にも適用', detail: '同じOCR商品名を世帯内で再利用します。' },
+  { value: 'same_classification_name', label: '同じ分類用名称にも適用', detail: '入力した分類用名称を世帯内の別名として再利用します。' },
+];
+
+export const ProductClassificationCorrectionModal: React.FC<Props> = ({
+  item,
+  productTypes,
+  selectedProductTypeId,
+  scope,
+  classificationName,
+  loading,
+  onClose,
+  onProductTypeChange,
+  onScopeChange,
+  onClassificationNameChange,
+  onSave,
+}) => (
+  <AppModal
+    visible={Boolean(item)}
+    onRequestClose={onClose}
+    title="商品種別を修正"
+    description={item ? `対象明細: ${item.name}` : undefined}
+    footer={
+      <>
+        <AppButton title="キャンセル" variant="outline" onPress={onClose} disabled={loading} />
+        <AppButton
+          title="保存"
+          onPress={onSave}
+          loading={loading}
+          disabled={!selectedProductTypeId || (scope === 'same_classification_name' && !classificationName.trim())}
+        />
+      </>
+    }
+  >
+    <Text style={styles.label}>商品種別</Text>
+    <AppSelect<number | null>
+      selectedValue={selectedProductTypeId}
+      onValueChange={onProductTypeChange}
+      options={productTypes.map((productType) => ({ label: productType.name, value: productType.id }))}
+      placeholder="商品種別を選択"
+    />
+
+    <Text style={styles.label}>適用範囲</Text>
+    {scopeOptions.map((option) => {
+      const selected = option.value === scope;
+      return (
+        <TouchableOpacity
+          key={option.value}
+          style={[styles.scopeOption, selected && styles.scopeOptionSelected]}
+          onPress={() => onScopeChange(option.value)}
+          accessibilityRole="radio"
+          accessibilityState={{ selected }}
+        >
+          <Text style={[styles.scopeLabel, selected && styles.scopeLabelSelected]}>{option.label}</Text>
+          <Text style={styles.scopeDetail}>{option.detail}</Text>
+        </TouchableOpacity>
+      );
+    })}
+
+    {scope === 'same_classification_name' ? (
+      <View style={styles.classificationNameField}>
+        <Text style={styles.label}>分類用名称</Text>
+        <AppTextInput
+          value={classificationName}
+          onChangeText={onClassificationNameChange}
+          placeholder="例：牛乳"
+          autoCapitalize="none"
+        />
+        <Text style={styles.fieldHint}>この名称を同じ商品種別として世帯内で再利用します。</Text>
+      </View>
+    ) : null}
+  </AppModal>
+);
+
+const styles = StyleSheet.create({
+  label: { color: colors.text.main, fontSize: 14, fontWeight: '600', marginBottom: spacing.xs, marginTop: spacing.sm },
+  scopeOption: { borderWidth: 1, borderColor: colors.border, borderRadius: 8, padding: spacing.sm, marginTop: spacing.xs },
+  scopeOptionSelected: { borderColor: colors.primary, backgroundColor: colors.semantic.active.bg },
+  scopeLabel: { color: colors.text.main, fontSize: 14, fontWeight: '600' },
+  scopeLabelSelected: { color: colors.primary },
+  scopeDetail: { color: colors.text.muted, fontSize: 12, marginTop: 2 },
+  classificationNameField: { marginTop: spacing.sm },
+  fieldHint: { color: colors.text.muted, fontSize: 12, marginTop: spacing.xs },
+});

--- a/frontend/src/features/receipt/components/ReceiptDetailComponent.tsx
+++ b/frontend/src/features/receipt/components/ReceiptDetailComponent.tsx
@@ -7,6 +7,7 @@ import { ReceiptDetailActions } from './ReceiptDetailActions';
 import { ReceiptDetailHeader } from './ReceiptDetailHeader';
 import { ReceiptDetailImagePanel } from './ReceiptDetailImagePanel';
 import { ReceiptDetailItemList } from './ReceiptDetailItemList';
+import { ProductClassificationCorrectionModal } from './ProductClassificationCorrectionModal';
 import { receiptDetailStyles as styles } from '../styles/receiptDetailStyles';
 
 export interface ReceiptDetailComponentProps {
@@ -80,9 +81,23 @@ export const ReceiptDetailComponent: React.FC<ReceiptDetailComponentProps> = ({
             onCategoryChange={onCategoryChange}
             onUpdateItem={detail.updateEditItem}
             onUpdateField={detail.updateEditField}
+            onEditProductClassification={(item) => void detail.openProductClassificationCorrection(item)}
           />
         </View>
       </View>
+      <ProductClassificationCorrectionModal
+        item={detail.correctionItem}
+        productTypes={detail.productTypes}
+        selectedProductTypeId={detail.correctionProductTypeId}
+        scope={detail.correctionScope}
+        classificationName={detail.classificationName}
+        loading={detail.correctionLoading}
+        onClose={detail.closeProductClassificationCorrection}
+        onProductTypeChange={detail.setCorrectionProductTypeId}
+        onScopeChange={detail.setCorrectionScope}
+        onClassificationNameChange={detail.setClassificationName}
+        onSave={() => void detail.saveProductClassificationCorrection()}
+      />
       <View style={styles.scrollFooter} />
     </ScrollView>
   );

--- a/frontend/src/features/receipt/components/ReceiptDetailItemList.tsx
+++ b/frontend/src/features/receipt/components/ReceiptDetailItemList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { AppSelect, AppTextInput } from '../../../components/ui';
+import { AppButton, AppSelect, AppTextInput } from '../../../components/ui';
 import type { ReceiptDetail, ReceiptItemDetail } from '../../../types/receipt';
 import { receiptDetailStyles as styles } from '../styles/receiptDetailStyles';
 import { getProductClassificationDisplay } from '../utils/productClassificationDisplay';
@@ -19,6 +19,7 @@ type Props = {
     value: ReceiptItemDetail[keyof ReceiptItemDetail] | string
   ) => void;
   onUpdateField: (key: keyof ReceiptDetail, value: ReceiptDetail[keyof ReceiptDetail] | string) => void;
+  onEditProductClassification: (item: ReceiptItemDetail) => void;
 };
 
 export const ReceiptDetailItemList: React.FC<Props> = ({
@@ -29,6 +30,7 @@ export const ReceiptDetailItemList: React.FC<Props> = ({
   onCategoryChange,
   onUpdateItem,
   onUpdateField,
+  onEditProductClassification,
 }) => (
   <View style={styles.itemsSection}>
     <Text style={styles.itemsSectionTitle}>明細・カテゴリ設定</Text>
@@ -84,6 +86,7 @@ export const ReceiptDetailItemList: React.FC<Props> = ({
           </View>
 
           <View style={styles.detailItemBottom}>
+            <Text style={styles.categoryLabel}>家計簿カテゴリ</Text>
             <AppSelect<number | null>
               selectedValue={item.categoryId ?? null}
               onValueChange={(val) =>
@@ -100,6 +103,15 @@ export const ReceiptDetailItemList: React.FC<Props> = ({
                 <Text style={styles.productTypeDetail}>（{classification.detail}）</Text>
               ) : null}
             </View>
+            {!isEditing ? (
+              <AppButton
+                title="商品種別を修正"
+                size="sm"
+                variant="outline"
+                style={styles.productTypeEditButton}
+                onPress={() => onEditProductClassification(item)}
+              />
+            ) : null}
           </View>
         </View>
       );

--- a/frontend/src/features/receipt/hooks/useReceiptDetail.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptDetail.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { receiptApi } from '../../../api/receiptApi';
+import type { ProductClassificationCorrectionScope } from '../../../api/receiptApi';
 import { useIsWideLayout } from '../../../hooks/useIsWideLayout';
-import type { CategorySummary, ReceiptDetail, ReceiptItemDetail } from '../../../types/receipt';
+import type { CategorySummary, ProductTypeSummary, ReceiptDetail, ReceiptItemDetail } from '../../../types/receipt';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { showAlert } from '../../../utils/alertMessage';
 import { useReceiptImageSource } from '../../../utils/receiptImageSource';
@@ -27,6 +28,12 @@ export function useReceiptDetail({
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [editData, setEditData] = useState<ReceiptDetail | null>(null);
+  const [productTypes, setProductTypes] = useState<ProductTypeSummary[]>([]);
+  const [correctionItem, setCorrectionItem] = useState<ReceiptItemDetail | null>(null);
+  const [correctionProductTypeId, setCorrectionProductTypeId] = useState<number | null>(null);
+  const [correctionScope, setCorrectionScope] = useState<ProductClassificationCorrectionScope>('item_only');
+  const [classificationName, setClassificationName] = useState('');
+  const [correctionLoading, setCorrectionLoading] = useState(false);
 
   const cacheKey = useMemo(() => Date.now(), []);
   const imageSource = useReceiptImageSource(receipt?.imagePath);
@@ -111,6 +118,49 @@ export function useReceiptDetail({
     }
   };
 
+  const openProductClassificationCorrection = async (item: ReceiptItemDetail) => {
+    setCorrectionItem(item);
+    setCorrectionProductTypeId(item.productTypeId);
+    setCorrectionScope('item_only');
+    setClassificationName('');
+    if (productTypes.length > 0) return;
+
+    try {
+      const res = await receiptApi.listProductTypes();
+      if (res.success) setProductTypes(res.data);
+    } catch (err: unknown) {
+      console.error('Failed to load product types', getApiErrorMessage(err));
+      showAlert('エラー', '商品種別の取得に失敗しました。');
+      setCorrectionItem(null);
+    }
+  };
+
+  const closeProductClassificationCorrection = () => {
+    if (!correctionLoading) setCorrectionItem(null);
+  };
+
+  const saveProductClassificationCorrection = async () => {
+    if (!correctionItem || !correctionProductTypeId) return;
+    setCorrectionLoading(true);
+    try {
+      const res = await receiptApi.updateItemProductClassification(correctionItem.id, {
+        productTypeId: correctionProductTypeId,
+        scope: correctionScope,
+        ...(correctionScope === 'same_classification_name' ? { classificationName } : {}),
+      });
+      if (res.success) {
+        showAlert('成功', '商品種別を修正しました。');
+        setCorrectionItem(null);
+        onSaveSuccess?.();
+      }
+    } catch (err: unknown) {
+      console.error('Failed to correct product classification', getApiErrorMessage(err));
+      showAlert('エラー', '商品種別の修正に失敗しました。');
+    } finally {
+      setCorrectionLoading(false);
+    }
+  };
+
   return {
     isWide,
     isEditing,
@@ -124,6 +174,18 @@ export function useReceiptDetail({
     updateEditField,
     updateEditItem,
     handleSave,
+    productTypes,
+    correctionItem,
+    correctionProductTypeId,
+    correctionScope,
+    classificationName,
+    correctionLoading,
+    setCorrectionProductTypeId,
+    setCorrectionScope,
+    setClassificationName,
+    openProductClassificationCorrection,
+    closeProductClassificationCorrection,
+    saveProductClassificationCorrection,
   };
 }
 

--- a/frontend/src/features/receipt/styles/receiptDetailStyles.ts
+++ b/frontend/src/features/receipt/styles/receiptDetailStyles.ts
@@ -72,10 +72,12 @@ export const receiptDetailStyles = StyleSheet.create({
   currencySymbol: { fontSize: 14, color: colors.text.muted },
   multiplier: { fontSize: 14, color: colors.text.muted },
   categorySelect: { marginTop: spacing.xs },
+  categoryLabel: { fontSize: 12, color: colors.text.muted, marginTop: spacing.xs },
   productTypeRow: { flexDirection: 'row', alignItems: 'center', marginTop: spacing.sm },
   productTypeLabel: { fontSize: 12, color: colors.text.muted, marginRight: spacing.sm },
   productTypeValue: { fontSize: 13, color: colors.text.main, fontWeight: '600' },
   productTypeDetail: { fontSize: 12, color: colors.text.muted },
+  productTypeEditButton: { alignSelf: 'flex-start', marginTop: spacing.sm },
   taxSection: {
     marginTop: spacing.lg,
     paddingVertical: 15,

--- a/frontend/src/features/receipt/utils/productClassificationDisplay.test.ts
+++ b/frontend/src/features/receipt/utils/productClassificationDisplay.test.ts
@@ -23,4 +23,15 @@ describe('getProductClassificationDisplay', () => {
       })
     ).toEqual({ label: '初期分類の対象外' });
   });
+
+  it('shows a manually corrected product type separately from category status', () => {
+    expect(
+      getProductClassificationDisplay({
+        productType: { id: 11, code: 'milk', name: '牛乳', standardCategoryId: 4 },
+        productTypeStatus: 'classified',
+        classificationSource: 'manual',
+        classificationConfidence: 'high',
+      })
+    ).toEqual({ label: '牛乳', detail: '手動修正' });
+  });
 });

--- a/frontend/src/features/receipt/utils/productClassificationDisplay.ts
+++ b/frontend/src/features/receipt/utils/productClassificationDisplay.ts
@@ -21,7 +21,11 @@ export function getProductClassificationDisplay(
             ? '標準辞書'
             : item.classificationSource === 'ai'
               ? 'AI候補'
-              : undefined;
+              : item.classificationSource === 'manual'
+                ? '手動修正'
+                : item.classificationSource === 'similarity'
+                  ? '類似候補'
+                  : undefined;
     return { label: item.productType.name, detail: source };
   }
 

--- a/frontend/src/types/receipt.ts
+++ b/frontend/src/types/receipt.ts
@@ -24,6 +24,7 @@ export interface ReceiptInput {
 /** OpenAPI DTO（receipt API） */
 export type {
   CategorySummary,
+  ProductTypeSummary,
   ItemSplitSummary,
   ReceiptItemDetail,
   ReceiptDetail,


### PR DESCRIPTION
## 概要

Issue #110-2（レシート確認画面の商品種別修正UI）を実装します。

## 変更内容

- 有効な共通商品種別を取得する `GET /product-types` を追加
- レシート詳細で家計簿カテゴリと商品種別を別々に表示
- 明細単位の商品種別修正モーダルを追加
- 適用範囲（この明細だけ／同じOCR商品名／同じ分類用名称）を選択可能にし、初期値をこの明細だけに設定
- 別名適用時に分類用名称を必須入力
- 全体編集と修正APIを分離し、監査履歴と世帯学習を保持

## 影響

- DBスキーマ変更、migration適用、データ初期化は含みません。
- stable環境には変更を加えていません。

## 検証

- Backend: `npm test`（80 passed、29 skipped）
- Backend: `npx tsc --noEmit`
- Backend: `npm run check:openapi`
- Frontend: `npm test`（67 passed）
- Frontend: `npx tsc --noEmit`

Closes #550