### PR TITLE
feat: 商品分類の類似検索基盤を追加 #111-1

### DIFF
--- a/backend/prisma/migrations/20260729090000_add_trigram_similarity_search/migration.sql
+++ b/backend/prisma/migrations/20260729090000_add_trigram_similarity_search/migration.sql
@@ -1,0 +1,36 @@
+-- Issue #111-1: 商品分類候補検索と履歴検索で共有する pg_trgm 基盤
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE "Receipt"
+  ADD COLUMN "normalizedStoreName" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "Item"
+  ADD COLUMN "normalizedName" TEXT NOT NULL DEFAULT '';
+
+-- 既存データはDBで可能な範囲の小文字化・空白整理を行う。
+-- NFKCを含む完全な正規化は、以後アプリケーションの getCleanText で保存する。
+UPDATE "Receipt"
+SET "normalizedStoreName" = lower(trim(regexp_replace("storeName", '\s+', ' ', 'g')))
+WHERE "normalizedStoreName" = '';
+
+UPDATE "Item"
+SET "normalizedName" = lower(trim(regexp_replace("name", '\s+', ' ', 'g')))
+WHERE "normalizedName" = '';
+
+CREATE INDEX "Receipt_normalizedStoreName_trgm_idx"
+  ON "Receipt" USING GIN ("normalizedStoreName" gin_trgm_ops);
+
+CREATE INDEX "Item_normalizedName_trgm_idx"
+  ON "Item" USING GIN ("normalizedName" gin_trgm_ops);
+
+CREATE INDEX "StandardProductDictionary_normalizedName_trgm_idx"
+  ON "StandardProductDictionary" USING GIN ("normalizedName" gin_trgm_ops);
+
+CREATE INDEX "HouseholdProductDictionary_normalizedName_trgm_idx"
+  ON "HouseholdProductDictionary" USING GIN ("normalizedName" gin_trgm_ops);
+
+CREATE INDEX "ProductClassificationHistory_normalizedName_trgm_idx"
+  ON "ProductClassificationHistory" USING GIN ("normalizedName" gin_trgm_ops);
+
+CREATE INDEX "ProductClassificationAlias_normalizedName_trgm_idx"
+  ON "ProductClassificationAlias" USING GIN ("normalizedName" gin_trgm_ops);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -116,6 +116,7 @@ model Receipt {
   memberId      Int
   member        FamilyMember  @relation(fields: [memberId], references: [id])
   storeName     String
+  normalizedStoreName String @default("")
   date          DateTime      @db.Timestamptz(3)
   totalAmount   Int // 支払合計（税込）
   // [Issue #71] 外税額を保持するフィールド
@@ -143,6 +144,7 @@ model Item {
   classificationSource     ClassificationSource?
   classificationConfidence ClassificationConfidence?
   name                     String
+  normalizedName           String                    @default("")
   price                    Float
   quantity                 Float                     @default(1.0)
 

--- a/backend/src/__tests__/integration/productSimilaritySearch.integration.test.ts
+++ b/backend/src/__tests__/integration/productSimilaritySearch.integration.test.ts
@@ -1,0 +1,87 @@
+import '../../test/mockReceiptQueue';
+
+import { Prisma } from '@prisma/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { findProductSimilarityCandidates } from '../../services/productClassification/productSimilaritySearchService';
+import { prisma } from '../../utils/prismaClient';
+import { shouldRunDbIntegration } from './helpers/integrationHelpers';
+
+const familyGroupId = 1;
+const otherFamilyGroupId = 2;
+const householdName = '類似検索用特濃牛乳';
+const standardName = '類似検索用ポテトチップス';
+
+async function productTypeByCode(code: string) {
+  const productType = await prisma.productType.findUnique({
+    where: { code },
+    select: { id: true, standardCategoryId: true },
+  });
+  if (!productType) throw new Error(`Product type ${code} is not seeded.`);
+  return productType;
+}
+
+describe.skipIf(!shouldRunDbIntegration())('Product similarity search (#111-1)', () => {
+  afterEach(async () => {
+    await prisma.productClassificationHistory.deleteMany({
+      where: { normalizedName: householdName, familyGroupId: { in: [familyGroupId, otherFamilyGroupId] } },
+    });
+    await prisma.standardProductDictionary.deleteMany({ where: { normalizedName: standardName } });
+  });
+
+  it('returns same-household and standard candidates without exposing another household', async () => {
+    const milk = await productTypeByCode('milk');
+    const tissues = await productTypeByCode('tissues');
+    const chips = await productTypeByCode('potato-chips');
+
+    await prisma.productClassificationHistory.create({
+      data: { familyGroupId, normalizedName: householdName, productTypeId: milk.id },
+    });
+    await prisma.productClassificationHistory.create({
+      data: { familyGroupId: otherFamilyGroupId, normalizedName: householdName, productTypeId: tissues.id },
+    });
+    await prisma.standardProductDictionary.create({
+      data: {
+        normalizedName: standardName,
+        standardCategoryId: chips.standardCategoryId,
+        productTypeId: chips.id,
+      },
+    });
+
+    const householdCandidates = await findProductSimilarityCandidates(prisma as never, {
+      familyGroupId,
+      itemName: '類似検索用特濃牛乳 1000ml',
+    });
+    const standardCandidates = await findProductSimilarityCandidates(prisma as never, {
+      familyGroupId,
+      itemName: '類似検索用ポテトチップ',
+    });
+
+    expect(householdCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ productTypeId: milk.id, source: 'history' }),
+      ])
+    );
+    expect(householdCandidates).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ productTypeId: tissues.id })])
+    );
+    expect(standardCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ productTypeId: chips.id, source: 'standard_dictionary' }),
+      ])
+    );
+  });
+
+  it('creates the trigram indexes used by the shared search base', async () => {
+    await prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe('SET LOCAL enable_seqscan = off');
+      const plan = await tx.$queryRaw<Array<{ 'QUERY PLAN': unknown }>>(Prisma.sql`
+        EXPLAIN (FORMAT JSON)
+        SELECT id
+        FROM "Item"
+        WHERE "normalizedName" % ${householdName}
+      `);
+
+      expect(JSON.stringify(plan)).toContain('Item_normalizedName_trgm_idx');
+    });
+  });
+});

--- a/backend/src/repositories/productClassificationRepository.ts
+++ b/backend/src/repositories/productClassificationRepository.ts
@@ -1,4 +1,4 @@
-import type { ClassificationCorrectionScope } from '@prisma/client';
+import { Prisma, type ClassificationCorrectionScope } from '@prisma/client';
 import { prisma } from '../utils/prismaClient';
 import type { PrismaTx } from '../utils/prismaTransaction';
 
@@ -75,4 +75,108 @@ export async function upsertProductClassificationAliasInTx(
     create: { ...input, isActive: true },
     update: { productTypeId: input.productTypeId, isActive: true },
   });
+}
+
+export type ProductSimilarityCandidateSource =
+  | 'history'
+  | 'household_dictionary'
+  | 'alias'
+  | 'standard_dictionary';
+
+export type ProductSimilarityCandidate = {
+  normalizedName: string;
+  productTypeId: number;
+  productTypeName: string;
+  standardCategoryId: number;
+  source: ProductSimilarityCandidateSource;
+  similarity: number;
+};
+
+type ProductSimilarityCandidateRow = ProductSimilarityCandidate;
+
+/**
+ * pg_trgm による商品分類候補検索。
+ * 世帯固有の候補は必ず familyGroupId で絞り、標準辞書だけは全世帯共通で検索する。
+ * このRepositoryは候補を返すだけで、Itemの分類状態を更新しない。
+ */
+export async function findSimilarProductClassificationCandidatesInTx(
+  tx: PrismaTx,
+  input: { familyGroupId: number; normalizedName: string; limit: number }
+): Promise<ProductSimilarityCandidate[]> {
+  const rows = await tx.$queryRaw<ProductSimilarityCandidateRow[]>(Prisma.sql`
+    WITH candidates AS (
+      SELECT
+        history."normalizedName",
+        history."productTypeId",
+        'history'::text AS source,
+        1 AS source_priority,
+        similarity(history."normalizedName", ${input.normalizedName}) AS similarity
+      FROM "ProductClassificationHistory" AS history
+      WHERE history."familyGroupId" = ${input.familyGroupId}
+        AND history."normalizedName" % ${input.normalizedName}
+
+      UNION ALL
+
+      SELECT
+        dictionary."normalizedName",
+        dictionary."productTypeId",
+        'household_dictionary'::text AS source,
+        2 AS source_priority,
+        similarity(dictionary."normalizedName", ${input.normalizedName}) AS similarity
+      FROM "HouseholdProductDictionary" AS dictionary
+      WHERE dictionary."familyGroupId" = ${input.familyGroupId}
+        AND dictionary."isActive" = true
+        AND dictionary."normalizedName" % ${input.normalizedName}
+
+      UNION ALL
+
+      SELECT
+        alias."normalizedName",
+        alias."productTypeId",
+        'alias'::text AS source,
+        3 AS source_priority,
+        similarity(alias."normalizedName", ${input.normalizedName}) AS similarity
+      FROM "ProductClassificationAlias" AS alias
+      WHERE alias."familyGroupId" = ${input.familyGroupId}
+        AND alias."isActive" = true
+        AND alias."normalizedName" % ${input.normalizedName}
+
+      UNION ALL
+
+      SELECT
+        standard."normalizedName",
+        standard."productTypeId",
+        'standard_dictionary'::text AS source,
+        4 AS source_priority,
+        similarity(standard."normalizedName", ${input.normalizedName}) AS similarity
+      FROM "StandardProductDictionary" AS standard
+      WHERE standard."isActive" = true
+        AND standard."normalizedName" % ${input.normalizedName}
+    ), ranked AS (
+      SELECT
+        candidates.*,
+        row_number() OVER (
+          PARTITION BY candidates."productTypeId"
+          ORDER BY candidates.similarity DESC, candidates.source_priority ASC, candidates."normalizedName" ASC
+        ) AS candidate_rank
+      FROM candidates
+    )
+    SELECT
+      ranked."normalizedName",
+      ranked."productTypeId",
+      product_type."name" AS "productTypeName",
+      product_type."standardCategoryId",
+      ranked.source,
+      ranked.similarity
+    FROM ranked
+    INNER JOIN "ProductType" AS product_type ON product_type.id = ranked."productTypeId"
+    INNER JOIN "StandardCategory" AS standard_category ON standard_category.id = product_type."standardCategoryId"
+    WHERE ranked.candidate_rank = 1
+      AND product_type."isActive" = true
+      AND standard_category."isActive" = true
+    ORDER BY ranked.similarity DESC, ranked.source_priority ASC, ranked."normalizedName" ASC
+    LIMIT ${input.limit}
+  `);
+
+  return rows;
 }

--- a/backend/src/repositories/receipt/receiptWriteRepository.ts
+++ b/backend/src/repositories/receipt/receiptWriteRepository.ts
@@ -2,6 +2,7 @@ import { prisma } from '../../utils/prismaClient';
 import type { ClassificationConfidence, ClassificationSource, ProductTypeStatus } from '@prisma/client';
 import type { PrismaTx } from '../../utils/prismaTransaction';
 import { AppError } from '../../utils/appError';
+import { getCleanText } from '../../utils/normalizer';
 
 export async function deleteReceiptById(receiptId: number, familyGroupId: number) {
   const existing = await prisma.receipt.findUnique({ where: { id: receiptId } });
@@ -15,6 +16,7 @@ export type ReceiptCreateWithItemsInput = {
   memberId: number;
   familyGroupId: number;
   storeName: string;
+  normalizedStoreName: string;
   date: Date;
   totalAmount: number;
   taxAmount: number;
@@ -22,6 +24,7 @@ export type ReceiptCreateWithItemsInput = {
   rawText: string;
   items: Array<{
     name: string;
+    normalizedName: string;
     price: number;
     quantity: number;
     categoryId: number | null;
@@ -40,6 +43,7 @@ export async function createReceiptInTx(tx: PrismaTx, input: ReceiptCreateWithIt
       memberId: input.memberId,
       familyGroupId: input.familyGroupId,
       storeName: input.storeName,
+      normalizedStoreName: input.normalizedStoreName,
       date: input.date,
       totalAmount: input.totalAmount,
       taxAmount: input.taxAmount,
@@ -65,13 +69,14 @@ export async function linkApiUsageLogToReceiptInTx(
 export async function updateReceiptInTx(
   tx: PrismaTx,
   receiptId: number,
-  data: { date?: Date; storeName?: string; totalAmount?: number }
+  data: { date?: Date; storeName?: string; normalizedStoreName?: string; totalAmount?: number }
 ) {
   return tx.receipt.update({
     where: { id: receiptId },
     data: {
       date: data.date,
       storeName: data.storeName,
+      normalizedStoreName: data.normalizedStoreName,
       totalAmount: data.totalAmount,
     },
   });
@@ -85,13 +90,14 @@ export async function updateReceiptStoreNamesInTx(
 ) {
   return tx.receipt.updateMany({
     where: { storeName: sourceStoreName, familyGroupId },
-    data: { storeName: targetStoreName },
+    data: { storeName: targetStoreName, normalizedStoreName: getCleanText(targetStoreName) },
   });
 }
 
 export type ItemCreateInput = {
   receiptId: number;
   name: string;
+  normalizedName: string;
   price: number;
   quantity: number;
   categoryId: number | null;

--- a/backend/src/services/productClassification/productSimilaritySearchService.test.ts
+++ b/backend/src/services/productClassification/productSimilaritySearchService.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repositoryMocks = vi.hoisted(() => ({
+  findSimilarProductClassificationCandidatesInTx: vi.fn(),
+}));
+
+vi.mock('../../repositories/productClassificationRepository', () => repositoryMocks);
+
+import {
+  findProductSimilarityCandidates,
+  PRODUCT_SIMILARITY_CANDIDATE_LIMIT,
+} from './productSimilaritySearchService';
+
+describe('findProductSimilarityCandidates', () => {
+  beforeEach(() => {
+    repositoryMocks.findSimilarProductClassificationCandidatesInTx.mockReset();
+  });
+
+  it('normalizes the item name and limits candidates to five', async () => {
+    repositoryMocks.findSimilarProductClassificationCandidatesInTx.mockResolvedValue([]);
+
+    await findProductSimilarityCandidates({} as never, {
+      familyGroupId: 1,
+      itemName: '  MILK　1000ML ',
+      limit: 10,
+    });
+
+    expect(repositoryMocks.findSimilarProductClassificationCandidatesInTx).toHaveBeenCalledWith(
+      {},
+      {
+        familyGroupId: 1,
+        normalizedName: 'milk 1000ml',
+        limit: PRODUCT_SIMILARITY_CANDIDATE_LIMIT,
+      }
+    );
+  });
+
+  it('does not query for an empty normalized item name', async () => {
+    await expect(
+      findProductSimilarityCandidates({} as never, { familyGroupId: 1, itemName: '  ' })
+    ).resolves.toEqual([]);
+
+    expect(repositoryMocks.findSimilarProductClassificationCandidatesInTx).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/productClassification/productSimilaritySearchService.ts
+++ b/backend/src/services/productClassification/productSimilaritySearchService.ts
@@ -1,0 +1,26 @@
+import { getCleanText } from '../../utils/normalizer';
+import {
+  findSimilarProductClassificationCandidatesInTx,
+  type ProductSimilarityCandidate,
+} from '../../repositories/productClassificationRepository';
+import type { PrismaTx } from '../../utils/prismaTransaction';
+
+export const PRODUCT_SIMILARITY_CANDIDATE_LIMIT = 5;
+
+/**
+ * 商品分類で利用する類似候補を返す。候補提示専用であり、分類の自動確定は行わない。
+ */
+export async function findProductSimilarityCandidates(
+  tx: PrismaTx,
+  input: { familyGroupId: number; itemName: string; limit?: number }
+): Promise<ProductSimilarityCandidate[]> {
+  const normalizedName = getCleanText(input.itemName);
+  if (!normalizedName) return [];
+
+  const limit = Math.min(Math.max(input.limit ?? PRODUCT_SIMILARITY_CANDIDATE_LIMIT, 1), PRODUCT_SIMILARITY_CANDIDATE_LIMIT);
+  return findSimilarProductClassificationCandidatesInTx(tx, {
+    familyGroupId: input.familyGroupId,
+    normalizedName,
+    limit,
+  });
+}

--- a/backend/src/services/receipt/receiptCommitPersistence.ts
+++ b/backend/src/services/receipt/receiptCommitPersistence.ts
@@ -1,4 +1,5 @@
 import logger from '../../utils/logger';
+import { getCleanText } from '../../utils/normalizer';
 import type { PrismaTx } from '../../utils/prismaTransaction';
 import type { ParsedItem, ReceiptCommitPayload } from '../../types/receipt';
 import {
@@ -54,6 +55,7 @@ export async function persistReceiptCommitInTx(
 
       return {
         name: item.name,
+        normalizedName: getCleanText(item.name),
         price: parseFloat(String(item.price || 0)),
         quantity: parseFloat(String(item.quantity || 1)),
         ...classification,
@@ -65,6 +67,7 @@ export async function persistReceiptCommitInTx(
     memberId,
     familyGroupId,
     storeName: officialStoreName,
+    normalizedStoreName: getCleanText(officialStoreName),
     date: jstDate,
     totalAmount,
     taxAmount,

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -1,4 +1,5 @@
 import { AppError } from '../../utils/appError';
+import { getCleanText } from '../../utils/normalizer';
 import { runInTransaction, type PrismaTx } from '../../utils/prismaTransaction';
 import type { ReceiptCreateItemInput } from '../../types/receipt';
 import type { TenantContext } from '../../utils/context';
@@ -72,6 +73,7 @@ async function applyFullReceiptUpdateInTx(
   await patchReceiptInTx(tx, receiptId, {
     date: date ? new Date(date) : undefined,
     storeName: storeName || undefined,
+    normalizedStoreName: storeName ? getCleanText(storeName) : undefined,
     totalAmount: finalTotal,
   });
 
@@ -82,6 +84,7 @@ async function applyFullReceiptUpdateInTx(
       itemList.map(async (item) => ({
         receiptId,
         name: item.name,
+        normalizedName: getCleanText(item.name),
         price: parseFloat(String(item.price)) || 0,
         quantity: parseFloat(String(item.quantity)) || 0,
         ...(await classifyItemByExactMatch(tx, {

--- a/docs/design/database-schema.md
+++ b/docs/design/database-schema.md
@@ -113,6 +113,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | familyGroupId | Int | No | — | — | FamilyGroup.id | — | 複合 |
 | memberId | Int | No | — | — | FamilyMember.id | — | — |
 | storeName | String | No | — | — | — | — | — |
+| normalizedStoreName | String | No | `""` | — | — | — | GIN（`pg_trgm`） |
 | date | DateTime | No | — | — | — | — | 複合 |
 | totalAmount | Int | No | — | — | — | — | — |
 | taxAmount | Float | No | 0.0 | — | — | — | — |
@@ -121,7 +122,7 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | createdAt | DateTime | No | now() | — | — | — | — |
 
 **FK:** `familyGroupId` → `FamilyGroup.id`, `memberId` → `FamilyMember.id`  
-**Index:** `(familyGroupId, date)`
+**Index:** `(familyGroupId, date)`, `GIN(normalizedStoreName gin_trgm_ops)`
 
 > `memberId` は立替者（支払者）。業務意味は [domain-model.md §3.2](./domain-model.md)。
 
@@ -135,10 +136,14 @@ Epic: [#276 Issue #90](https://github.com/yama180sx/receipt-ai-app/issues/276)
 | receiptId | Int | No | — | — | Receipt.id | — | — |
 | categoryId | Int | Yes | — | — | Category.id | — | — |
 | name | String | No | — | — | — | — | — |
+| normalizedName | String | No | `""` | — | — | — | GIN（`pg_trgm`） |
 | price | Float | No | — | — | — | — | — |
 | quantity | Float | No | 1.0 | — | — | — | — |
 
 **FK:** `receiptId` → `Receipt.id` (**onDelete: Cascade**), `categoryId` → `Category.id`
+**Index:** `GIN(normalizedName gin_trgm_ops)`
+
+`normalizedStoreName` と `normalizedName` は、商品分類の類似候補検索および将来の履歴検索で共有する検索キーである。既存データはmigrationで小文字化・空白整理を行い、新規・更新データはアプリケーションの `getCleanText` で保存する。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #553（Issue #111-1）の pg_trgm 類似検索基盤を追加します。

## 変更内容

- pg_trgm 拡張、正規化検索列、GIN index の migration を追加
- レシート・明細の作成／編集時に正規化値を保存
- 世帯内の履歴・辞書・別名と共通標準辞書を検索する候補Repository／Serviceを追加
- 世帯境界、標準辞書候補、trigram index を検証するテストを追加
- DBスキーマ資料を更新

## 影響

候補検索基盤のみの追加です。既存の完全一致分類フロー、公開API、UIは変更しません。類似候補による自動確定は行いません。

## 検証

- backend: npm test（85 passed、Postgres統合テストはCIで実行）
- backend: npm run check:openapi
- backend: npx tsc --noEmit
- backend: npx prisma validate

## 運用

開発環境へのmigration適用・データ初期化は、このPRでは実施していません。