### PR TITLE
feat: 商品分類AIの契約を追加 #112-1

### DIFF
--- a/backend/prisma/seed-prompts.ts
+++ b/backend/prisma/seed-prompts.ts
@@ -44,20 +44,42 @@ async function main() {
     version: 1
   };
 
-  for (const familyGroup of familyGroups) {
-    const existing = await prisma.promptTemplate.findFirst({
-      where: { familyGroupId: familyGroup.id, key: analysisPrompt.key },
-      orderBy: { id: 'asc' },
-    });
+  const productClassificationPrompt = {
+    key: "PRODUCT_CLASSIFICATION",
+    description: "商品候補から商品種別を選択するための基本プロンプト",
+    systemPrompt: `あなたは家計簿レシートの商品分類を支援するアシスタントです。
+入力の各 item について、candidates に示された候補だけを用いて最も適切な productTypeId を選択してください。
+候補に適切なものがない、または判断できない場合は productTypeId を null にしてください。
+itemId は入力値をそのまま返し、confidence は high / medium / low のいずれかにしてください。
 
-    if (existing) {
-      await prisma.promptTemplate.update({ where: { id: existing.id }, data: analysisPrompt });
-    } else {
-      await prisma.promptTemplate.create({ data: { ...analysisPrompt, familyGroupId: familyGroup.id } });
+出力形式（JSON のみ）:
+{
+  "items": [
+    { "itemId": 1, "productTypeId": 2, "confidence": "high" }
+  ]
+}`,
+    isActive: true,
+    version: 1,
+  };
+
+  const prompts = [analysisPrompt, productClassificationPrompt];
+
+  for (const familyGroup of familyGroups) {
+    for (const prompt of prompts) {
+      const existing = await prisma.promptTemplate.findFirst({
+        where: { familyGroupId: familyGroup.id, key: prompt.key },
+        orderBy: { id: 'asc' },
+      });
+
+      if (existing) {
+        await prisma.promptTemplate.update({ where: { id: existing.id }, data: prompt });
+      } else {
+        await prisma.promptTemplate.create({ data: { ...prompt, familyGroupId: familyGroup.id } });
+      }
     }
   }
 
-  console.log('✅ PromptTemplate initial seed completed with optimized Tax logic.');
+  console.log('✅ PromptTemplate initial seed completed.');
 }
 
 main()

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -67,6 +67,22 @@ const DEFAULT_PROMPT = {
   version: 1,
 };
 
+const DEFAULT_PRODUCT_CLASSIFICATION_PROMPT = {
+  key: 'PRODUCT_CLASSIFICATION',
+  name: '商品分類システム標準プロンプト',
+  description: '候補内の商品種別だけを選択して明細を分類するための基本プロンプト',
+  systemPrompt: `あなたは家計簿の商品分類担当です。入力された各明細について、明細ごとに提示された候補の商品種別IDから最も適切なものだけを選んでください。
+
+必ず守ること:
+- 候補にない商品種別ID、カテゴリ名、自由文の分類名は返さない。
+- 判断できない場合は productTypeId を null にする。
+- confidence は high / medium / low のいずれかにする。
+- 出力には要求された itemId を重複させない。
+- JSON以外の文章やMarkdownは出力しない。`,
+  isActive: true,
+  version: 1,
+};
+
 async function seedMastersForFamily(
   familyGroupId: number,
   options: { useExplicitCategoryIds?: boolean } = {}
@@ -90,6 +106,9 @@ async function seedMastersForFamily(
 
   await prisma.promptTemplate.create({
     data: { ...DEFAULT_PROMPT, familyGroupId },
+  });
+  await prisma.promptTemplate.create({
+    data: { ...DEFAULT_PRODUCT_CLASSIFICATION_PROMPT, familyGroupId },
   });
 }
 

--- a/backend/prisma/seeds/prompt_templates.json
+++ b/backend/prisma/seeds/prompt_templates.json
@@ -15,5 +15,18 @@
     "version": 1,
     "createdAt": "2026-06-07T20:55:48.904Z",
     "updatedAt": "2026-06-07T20:55:48.904Z"
+  },
+  {
+    "id": 10,
+    "familyGroupId": 1,
+    "key": "PRODUCT_CLASSIFICATION",
+    "name": "商品分類システム標準プロンプト",
+    "description": "候補内の商品種別だけを選択して明細を分類するための基本プロンプト",
+    "systemPrompt": "あなたは家計簿の商品分類担当です。入力された各明細について、明細ごとに提示された候補の商品種別IDから最も適切なものだけを選んでください。\n\n必ず守ること:\n- 候補にない商品種別ID、カテゴリ名、自由文の分類名は返さない。\n- 判断できない場合は productTypeId を null にする。\n- confidence は high / medium / low のいずれかにする。\n- 出力には要求された itemId を重複させない。\n- JSON以外の文章やMarkdownは出力しない。",
+    "domainHints": null,
+    "isActive": true,
+    "version": 1,
+    "createdAt": "2026-06-07T20:55:48.904Z",
+    "updatedAt": "2026-06-07T20:55:48.904Z"
   }
 ]

--- a/backend/src/ai/geminiProductClassificationProvider.ts
+++ b/backend/src/ai/geminiProductClassificationProvider.ts
@@ -1,0 +1,37 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { findActivePromptTemplateByKeyForFamilyGroup } from '../repositories/promptRepository';
+import type { ProductClassificationProvider } from './productClassificationProvider';
+import {
+  PRODUCT_CLASSIFICATION_PROMPT_KEY,
+  type ProductClassificationAiRequest,
+} from './productClassificationContract';
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY ?? '');
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.0-flash';
+
+function buildClassificationPrompt(systemPrompt: string, request: ProductClassificationAiRequest): string {
+  return `${systemPrompt}\n\n### 分類対象 (JSON)\n${JSON.stringify({
+    storeName: request.storeName,
+    items: request.items,
+  })}\n\n出力は次のJSONオブジェクトだけにしてください。\n{"items":[{"itemId":123,"productTypeId":11,"confidence":"high"}]}`;
+}
+
+/** Geminiによる分類専用実装。画像OCRは扱わず、テキストと候補だけを送る。 */
+export const geminiProductClassificationProvider: ProductClassificationProvider = {
+  async classifyProducts(request) {
+    const template = await findActivePromptTemplateByKeyForFamilyGroup(
+      request.familyGroupId,
+      PRODUCT_CLASSIFICATION_PROMPT_KEY
+    );
+    if (!template) {
+      throw new Error('分類AI用プロンプトテンプレート(PRODUCT_CLASSIFICATION)が見つかりません。');
+    }
+
+    const model = genAI.getGenerativeModel({
+      model: GEMINI_MODEL,
+      generationConfig: { responseMimeType: 'application/json' },
+    });
+    const result = await model.generateContent(buildClassificationPrompt(template.systemPrompt, request));
+    return result.response.text();
+  },
+};

--- a/backend/src/ai/index.ts
+++ b/backend/src/ai/index.ts
@@ -1,7 +1,20 @@
 export type { ReceiptAnalysisProvider } from './receiptAnalysisProvider';
+export type { ProductClassificationProvider } from './productClassificationProvider';
 export { geminiReceiptAnalysisProvider } from './geminiReceiptAnalysisProvider';
+export { geminiProductClassificationProvider } from './geminiProductClassificationProvider';
 export {
   getReceiptAnalysisProvider,
   resetReceiptAnalysisProvider,
   setReceiptAnalysisProvider,
 } from './receiptAnalysisProviderRegistry';
+export {
+  getProductClassificationProvider,
+  resetProductClassificationProvider,
+  setProductClassificationProvider,
+} from './productClassificationProviderRegistry';
+export {
+  parseAndValidateProductClassificationResponse,
+  ProductClassificationResponseValidationError,
+  PRODUCT_CLASSIFICATION_PROMPT_KEY,
+} from './productClassificationContract';
+export { classifyProductsWithAi } from './productClassificationAiService';

--- a/backend/src/ai/productClassificationAiService.test.ts
+++ b/backend/src/ai/productClassificationAiService.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProductClassificationProvider } from './productClassificationProvider';
+import { classifyProductsWithAi } from './productClassificationAiService';
+import type { ProductClassificationAiRequest } from './productClassificationContract';
+
+const request: ProductClassificationAiRequest = {
+  familyGroupId: 1,
+  items: [
+    {
+      itemId: 10,
+      itemName: '特濃牛乳',
+      normalizedName: '特濃牛乳',
+      candidates: [{ productTypeId: 11, name: '牛乳', standardCategoryName: '乳製品' }],
+    },
+  ],
+};
+
+describe('classifyProductsWithAi', () => {
+  it('returns a validated response from an injected provider', async () => {
+    const provider: ProductClassificationProvider = {
+      classifyProducts: vi.fn().mockResolvedValue(
+        '{"items":[{"itemId":10,"productTypeId":11,"confidence":"high"}]}'
+      ),
+    };
+
+    await expect(classifyProductsWithAi(request, provider)).resolves.toEqual({
+      items: [{ itemId: 10, productTypeId: 11, confidence: 'high' }],
+    });
+  });
+
+  it('rejects an invalid provider response without returning a partial result', async () => {
+    const provider: ProductClassificationProvider = {
+      classifyProducts: vi.fn().mockResolvedValue(
+        '{"items":[{"itemId":10,"productTypeId":999,"confidence":"high"}]}'
+      ),
+    };
+
+    await expect(classifyProductsWithAi(request, provider)).rejects.toThrow('候補外の商品種別ID');
+  });
+});

--- a/backend/src/ai/productClassificationAiService.ts
+++ b/backend/src/ai/productClassificationAiService.ts
@@ -1,0 +1,19 @@
+import type { ProductClassificationProvider } from './productClassificationProvider';
+import { getProductClassificationProvider } from './productClassificationProviderRegistry';
+import {
+  parseAndValidateProductClassificationResponse,
+  type ProductClassificationAiRequest,
+  type ProductClassificationAiResponse,
+} from './productClassificationContract';
+
+/**
+ * 分類AIの生応答を取得してから契約検証する。
+ * 永続化や障害時の継続処理は後続Phaseの責務とする。
+ */
+export async function classifyProductsWithAi(
+  request: ProductClassificationAiRequest,
+  provider: ProductClassificationProvider = getProductClassificationProvider()
+): Promise<ProductClassificationAiResponse> {
+  const rawText = await provider.classifyProducts(request);
+  return parseAndValidateProductClassificationResponse(rawText, request);
+}

--- a/backend/src/ai/productClassificationContract.test.ts
+++ b/backend/src/ai/productClassificationContract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseAndValidateProductClassificationResponse,
+  ProductClassificationResponseValidationError,
+  type ProductClassificationAiRequest,
+} from './productClassificationContract';
+
+const request: ProductClassificationAiRequest = {
+  familyGroupId: 1,
+  storeName: 'テスト店',
+  items: [
+    {
+      itemId: 10,
+      itemName: '特濃牛乳 1000ml',
+      normalizedName: '特濃牛乳 1000ml',
+      candidates: [
+        { productTypeId: 11, name: '牛乳', standardCategoryName: '乳製品' },
+      ],
+    },
+  ],
+};
+
+describe('parseAndValidateProductClassificationResponse', () => {
+  it('accepts a response that selects only a supplied candidate', () => {
+    expect(
+      parseAndValidateProductClassificationResponse(
+        '{"items":[{"itemId":10,"productTypeId":11,"confidence":"high"}]}',
+        request
+      )
+    ).toEqual({ items: [{ itemId: 10, productTypeId: 11, confidence: 'high' }] });
+  });
+
+  it('accepts null as a valid no-selection response', () => {
+    expect(
+      parseAndValidateProductClassificationResponse(
+        '{"items":[{"itemId":10,"productTypeId":null,"confidence":"low"}]}',
+        request
+      )
+    ).toEqual({ items: [{ itemId: 10, productTypeId: null, confidence: 'low' }] });
+  });
+
+  it.each([
+    '{not-json}',
+    '{"items":[{"itemId":10,"productTypeId":99,"confidence":"high"}]}',
+    '{"items":[{"itemId":10,"productTypeId":11,"confidence":"high"},{"itemId":10,"productTypeId":11,"confidence":"high"}]}',
+    '{"items":[{"itemId":99,"productTypeId":11,"confidence":"high"}]}',
+    '{"items":[{"itemId":10,"productTypeId":11,"confidence":"certain"}]}',
+    '{"items":[{"itemId":10,"productTypeId":11,"confidence":"high","reason":"候補一致"}]}',
+  ])('rejects an invalid batch response: %s', (rawText) => {
+    expect(() => parseAndValidateProductClassificationResponse(rawText, request)).toThrow(
+      ProductClassificationResponseValidationError
+    );
+  });
+});

--- a/backend/src/ai/productClassificationContract.ts
+++ b/backend/src/ai/productClassificationContract.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+export const PRODUCT_CLASSIFICATION_PROMPT_KEY = 'PRODUCT_CLASSIFICATION';
+
+export type ProductClassificationCandidateInput = {
+  productTypeId: number;
+  name: string;
+  standardCategoryName: string;
+};
+
+export type ProductClassificationAiItemInput = {
+  itemId: number;
+  itemName: string;
+  normalizedName: string;
+  candidates: ProductClassificationCandidateInput[];
+};
+
+export type ProductClassificationAiRequest = {
+  familyGroupId: number;
+  storeName?: string;
+  items: ProductClassificationAiItemInput[];
+};
+
+export type ProductClassificationAiItemResult = {
+  itemId: number;
+  productTypeId: number | null;
+  confidence: 'high' | 'medium' | 'low';
+};
+
+export type ProductClassificationAiResponse = {
+  items: ProductClassificationAiItemResult[];
+};
+
+export class ProductClassificationResponseValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProductClassificationResponseValidationError';
+  }
+}
+
+const productClassificationResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      itemId: z.number().int().positive(),
+      productTypeId: z.number().int().positive().nullable(),
+      confidence: z.enum(['high', 'medium', 'low']),
+    }).strict()
+  ),
+}).strict();
+
+/**
+ * AIのJSON文字列を契約・候補制約に照らして検証する。
+ * 1件でも不正なら部分採用せず、呼び出し結果全体を無効とする。
+ */
+export function parseAndValidateProductClassificationResponse(
+  rawText: string,
+  request: ProductClassificationAiRequest
+): ProductClassificationAiResponse {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(rawText);
+  } catch {
+    throw new ProductClassificationResponseValidationError('分類AIの応答がJSONではありません。');
+  }
+
+  const parsed = productClassificationResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ProductClassificationResponseValidationError('分類AIの応答形式が不正です。');
+  }
+
+  const requestedItems = new Map(request.items.map((item) => [item.itemId, item]));
+  const returnedItemIds = new Set<number>();
+
+  for (const result of parsed.data.items) {
+    const requestedItem = requestedItems.get(result.itemId);
+    if (!requestedItem) {
+      throw new ProductClassificationResponseValidationError('要求していない明細IDが含まれています。');
+    }
+    if (returnedItemIds.has(result.itemId)) {
+      throw new ProductClassificationResponseValidationError('明細IDが重複しています。');
+    }
+    returnedItemIds.add(result.itemId);
+
+    if (
+      result.productTypeId !== null &&
+      !requestedItem.candidates.some((candidate) => candidate.productTypeId === result.productTypeId)
+    ) {
+      throw new ProductClassificationResponseValidationError('候補外の商品種別IDが含まれています。');
+    }
+  }
+
+  return parsed.data;
+}

--- a/backend/src/ai/productClassificationProvider.ts
+++ b/backend/src/ai/productClassificationProvider.ts
@@ -1,0 +1,6 @@
+import type { ProductClassificationAiRequest } from './productClassificationContract';
+
+/** 商品分類AIの生JSON応答を取得するProviderの差し替え点。 */
+export interface ProductClassificationProvider {
+  classifyProducts(request: ProductClassificationAiRequest): Promise<string>;
+}

--- a/backend/src/ai/productClassificationProviderRegistry.test.ts
+++ b/backend/src/ai/productClassificationProviderRegistry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProductClassificationProvider } from './productClassificationProvider';
+import {
+  getProductClassificationProvider,
+  resetProductClassificationProvider,
+  setProductClassificationProvider,
+} from './productClassificationProviderRegistry';
+import { geminiProductClassificationProvider } from './geminiProductClassificationProvider';
+
+describe('productClassificationProviderRegistry', () => {
+  it('returns the Gemini provider by default', () => {
+    resetProductClassificationProvider();
+    expect(getProductClassificationProvider()).toBe(geminiProductClassificationProvider);
+  });
+
+  it('allows injecting a mock provider for tests', async () => {
+    const provider: ProductClassificationProvider = {
+      classifyProducts: vi.fn().mockResolvedValue('{"items":[]}'),
+    };
+    setProductClassificationProvider(provider);
+
+    await expect(
+      getProductClassificationProvider().classifyProducts({ familyGroupId: 1, items: [] })
+    ).resolves.toBe('{"items":[]}');
+
+    resetProductClassificationProvider();
+  });
+});

--- a/backend/src/ai/productClassificationProviderRegistry.ts
+++ b/backend/src/ai/productClassificationProviderRegistry.ts
@@ -1,0 +1,17 @@
+import { geminiProductClassificationProvider } from './geminiProductClassificationProvider';
+import type { ProductClassificationProvider } from './productClassificationProvider';
+
+let currentProvider: ProductClassificationProvider = geminiProductClassificationProvider;
+
+export function getProductClassificationProvider(): ProductClassificationProvider {
+  return currentProvider;
+}
+
+/** テスト等でProviderを差し替える。 */
+export function setProductClassificationProvider(provider: ProductClassificationProvider): void {
+  currentProvider = provider;
+}
+
+export function resetProductClassificationProvider(): void {
+  currentProvider = geminiProductClassificationProvider;
+}

--- a/backend/src/repositories/promptRepository.ts
+++ b/backend/src/repositories/promptRepository.ts
@@ -24,6 +24,16 @@ export async function findActivePromptTemplateByKey(key: string) {
   });
 }
 
+export async function findActivePromptTemplateByKeyForFamilyGroup(
+  familyGroupId: number,
+  key: string
+) {
+  return prisma.promptTemplate.findFirst({
+    where: { familyGroupId, key, isActive: true },
+    orderBy: { updatedAt: 'desc' },
+  });
+}
+
 export async function deactivatePromptTemplatesByKey(familyGroupId: number, key: string) {
   return prisma.promptTemplate.updateMany({
     where: { key, familyGroupId },

--- a/docs/design/ai-pipeline.md
+++ b/docs/design/ai-pipeline.md
@@ -30,6 +30,23 @@ RecAIpt の AI パイプラインは、レシート画像を **Google Gemini** �
 
 ---
 
+## 1.1 商品分類 AI の契約境界
+
+商品分類はレシート画像解析とは別の AI 呼び出しとして扱う。画像や自由入力の分類候補を渡さず、類似検索などで絞り込んだ候補だけを Gemini に提示する。
+
+| 項目 | 内容 |
+|------|------|
+| プロンプトキー | `PRODUCT_CLASSIFICATION`（`PromptTemplate` の世帯別レコード） |
+| Provider | `ProductClassificationProvider` / `GeminiProductClassificationProvider` |
+| 入力 | `familyGroupId`、任意の店舗名、明細 ID・OCR 名・正規化名・候補の商品種別（標準カテゴリを含む） |
+| 出力 | 明細 ID、候補内の商品種別 ID または `null`、`high` / `medium` / `low` の確信度 |
+| 検証 | JSON スキーマ、明細 ID の重複・未知 ID、候補外商品種別、確信度を全件検証する。不正な応答はバッチ全体を拒否する。 |
+| 永続化 | Provider / 契約検証層は DB に保存しない。候補の選定、結果保存、利用量記録は後続の分類フローが担当する。 |
+
+実装は `backend/src/ai/productClassificationAiService.ts` を境界とする。Provider は Gemini の生テキストを返し、サービス層が契約検証済みの結果だけを後続処理へ渡す。これにより、AI が候補外の種別を返しても保存処理へ到達しない。
+
+---
+
 ## 2. 3層正規化
 
 フェーズ1（[MILESTONE_PHASE1.md](../MILESTONE_PHASE1.md)）で定義した設計思想を、現行実装に沿って整理する。3 層は **適用タイミング** が異なる。


### PR DESCRIPTION
## 概要

Issue #112-1（#556）として、商品分類AIの呼び出し契約・Gemini Provider・応答検証基盤を追加します。

## 変更内容

- `ProductClassificationProvider` と Gemini 実装、差し替え用Registryを追加
- `PRODUCT_CLASSIFICATION` の世帯別プロンプトテンプレートとシード処理を追加
- 明細ID・候補内の商品種別・確信度を対象とするAI入出力契約を追加
- 不正JSON、未知/重複明細、候補外種別、契約外の確信度・フィールドをバッチ全体で拒否
- 分類AIの責務境界をas-built設計資料へ記録

## 影響

このPRは分類結果の保存・利用量記録・レシート確定フローには接続しません。後続Issueで、検証済み結果だけを保存処理へ渡します。

開発環境へのmigration適用・データ初期化は行っていません（本PRにmigrationは含みません）。

## 検証

- `npx prisma validate`
- `npx tsc --noEmit`
- `npm test`（101 passed, 37 skipped）

Closes #556
