### PR TITLE
feat: 分類AIを未解決明細へ統合 #112-2

### DIFF
--- a/backend/src/repositories/receipt/receiptReadRepository.ts
+++ b/backend/src/repositories/receipt/receiptReadRepository.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma, ProductTypeStatus } from '@prisma/client';
 import { prisma } from '../../utils/prismaClient';
 import type { PrismaTx } from '../../utils/prismaTransaction';
 import { AppError } from '../../utils/appError';
@@ -121,6 +121,56 @@ export async function findItemWithReceiptInTx(tx: PrismaTx, itemId: number) {
   return tx.item.findUnique({
     where: { id: itemId },
     include: { receipt: true },
+  });
+}
+
+const productClassificationAiTargetInclude = {
+  receipt: { select: { familyGroupId: true, storeName: true } },
+  productClassificationCandidates: {
+    include: { productType: { include: { standardCategory: true } } },
+    orderBy: { rank: 'asc' },
+  },
+} satisfies Prisma.ItemInclude;
+
+/** AI分類を送信できる、候補を持つ要確認明細だけを世帯スコープで取得する。 */
+export async function findProductClassificationAiTargets(
+  itemIds: number[],
+  familyGroupId: number
+) {
+  if (itemIds.length === 0) return [];
+  return prisma.item.findMany({
+    where: {
+      id: { in: itemIds },
+      productTypeStatus: ProductTypeStatus.NEEDS_REVIEW,
+      receipt: { familyGroupId },
+      productClassificationCandidates: { some: {} },
+    },
+    include: productClassificationAiTargetInclude,
+    orderBy: { id: 'asc' },
+  });
+}
+
+/** AI応答の反映直前に対象明細を再確認する。 */
+export async function findProductClassificationAiTargetInTx(
+  tx: PrismaTx,
+  itemId: number,
+  familyGroupId: number
+) {
+  return tx.item.findFirst({
+    where: {
+      id: itemId,
+      productTypeStatus: ProductTypeStatus.NEEDS_REVIEW,
+      receipt: { familyGroupId },
+      productClassificationCandidates: { some: {} },
+    },
+    include: productClassificationAiTargetInclude,
+  });
+}
+
+export async function findItemById(itemId: number) {
+  return prisma.item.findUnique({
+    where: { id: itemId },
+    include: { category: true, productType: true },
   });
 }
 

--- a/backend/src/repositories/receipt/receiptWriteRepository.ts
+++ b/backend/src/repositories/receipt/receiptWriteRepository.ts
@@ -174,6 +174,27 @@ export async function updateItemCategoryInTx(
   });
 }
 
+/** 商品分類AIなどが、カテゴリ以外を含む分類状態だけを更新するための入口。 */
+export async function updateItemProductClassificationInTx(
+  tx: PrismaTx,
+  itemId: number,
+  data: Pick<
+    ItemCreateInput,
+    | 'categoryId'
+    | 'standardCategoryId'
+    | 'productTypeId'
+    | 'productTypeStatus'
+    | 'classificationSource'
+    | 'classificationConfidence'
+  >
+) {
+  return tx.item.update({
+    where: { id: itemId },
+    data,
+    include: { category: true, productType: true },
+  });
+}
+
 export async function deleteItemSplitsInTx(tx: PrismaTx, itemId: number) {
   return tx.itemSplit.deleteMany({ where: { itemId } });
 }

--- a/backend/src/repositories/receiptRepository.ts
+++ b/backend/src/repositories/receiptRepository.ts
@@ -17,6 +17,9 @@ export {
   findReceiptByIdInTx,
   findReceiptByIdForTenantInTx,
   findItemWithReceiptInTx,
+  findProductClassificationAiTargets,
+  findProductClassificationAiTargetInTx,
+  findItemById,
   findCategoryByIdInTx,
   findItemSplitsInTx,
   findFamilyMembersByIdsInTx,
@@ -41,6 +44,7 @@ export {
   deleteItemsByReceiptIdInTx,
   createItemsInTx,
   updateItemCategoryInTx,
+  updateItemProductClassificationInTx,
   deleteItemSplitsInTx,
   createItemSplitsInTx,
 } from './receipt/receiptWriteRepository';

--- a/backend/src/services/productClassification/productClassificationAiIntegrationService.test.ts
+++ b/backend/src/services/productClassification/productClassificationAiIntegrationService.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ClassificationConfidence,
+  ClassificationSource,
+  ProductTypeStatus,
+} from '@prisma/client';
+
+const { aiMocks, receiptRepositoryMocks, productRepositoryMocks } = vi.hoisted(() => ({
+  aiMocks: { classifyProductsWithAi: vi.fn() },
+  receiptRepositoryMocks: {
+    findItemById: vi.fn(),
+    findProductClassificationAiTargetInTx: vi.fn(),
+    findProductClassificationAiTargets: vi.fn(),
+    updateItemProductClassificationInTx: vi.fn(),
+  },
+  productRepositoryMocks: {
+    findActiveProductTypeWithCategoryInTx: vi.fn(),
+    findCategoryForProductTypeInTx: vi.fn(),
+  },
+}));
+
+vi.mock('../../ai', () => aiMocks);
+vi.mock('../../repositories/receiptRepository', () => receiptRepositoryMocks);
+vi.mock('../../repositories/productClassificationRepository', () => productRepositoryMocks);
+vi.mock('../../utils/prismaTransaction', () => ({
+  runInTransaction: (fn: (tx: object) => Promise<unknown>) => fn({}),
+}));
+
+import { applyProductClassificationAiToItems } from './productClassificationAiIntegrationService';
+
+const target = {
+  id: 10,
+  name: '特濃牛乳 1000ml',
+  normalizedName: '特濃牛乳 1000ml',
+  categoryId: 5,
+  receipt: { familyGroupId: 1, storeName: 'テスト店' },
+  productClassificationCandidates: [
+    {
+      productTypeId: 11,
+      productType: { name: '牛乳', standardCategory: { name: '乳製品' } },
+    },
+  ],
+};
+
+describe('applyProductClassificationAiToItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    receiptRepositoryMocks.findProductClassificationAiTargets.mockResolvedValue([target]);
+    receiptRepositoryMocks.findProductClassificationAiTargetInTx.mockResolvedValue(target);
+    receiptRepositoryMocks.updateItemProductClassificationInTx.mockResolvedValue({});
+    productRepositoryMocks.findActiveProductTypeWithCategoryInTx.mockResolvedValue({
+      id: 11,
+      standardCategoryId: 21,
+      standardCategory: { name: '乳製品', parent: { name: '食費' } },
+    });
+    productRepositoryMocks.findCategoryForProductTypeInTx.mockResolvedValue({ id: 5 });
+  });
+
+  it('high の候補内選択だけを分類済みとして保存する', async () => {
+    aiMocks.classifyProductsWithAi.mockResolvedValue({
+      items: [{ itemId: 10, productTypeId: 11, confidence: 'high' }],
+    });
+
+    await applyProductClassificationAiToItems(1, [10]);
+
+    expect(receiptRepositoryMocks.updateItemProductClassificationInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      10,
+      expect.objectContaining({
+        categoryId: 5,
+        standardCategoryId: 21,
+        productTypeId: 11,
+        productTypeStatus: ProductTypeStatus.CLASSIFIED,
+        classificationSource: ClassificationSource.AI,
+        classificationConfidence: ClassificationConfidence.HIGH,
+      })
+    );
+  });
+
+  it.each([
+    { productTypeId: 11, confidence: 'medium' as const, expectedConfidence: ClassificationConfidence.MEDIUM },
+    { productTypeId: null, confidence: 'low' as const, expectedConfidence: ClassificationConfidence.LOW },
+  ])('medium・low・null は候補を残した要確認状態として保存する', async ({
+    productTypeId,
+    confidence,
+    expectedConfidence,
+  }) => {
+    aiMocks.classifyProductsWithAi.mockResolvedValue({
+      items: [{ itemId: 10, productTypeId, confidence }],
+    });
+
+    await applyProductClassificationAiToItems(1, [10]);
+
+    expect(receiptRepositoryMocks.updateItemProductClassificationInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      10,
+      expect.objectContaining({
+        categoryId: 5,
+        standardCategoryId: null,
+        productTypeId: null,
+        productTypeStatus: ProductTypeStatus.NEEDS_REVIEW,
+        classificationSource: ClassificationSource.AI,
+        classificationConfidence: expectedConfidence,
+      })
+    );
+  });
+
+  it('AI障害時は例外を伝播せず既存の要確認状態を維持する', async () => {
+    aiMocks.classifyProductsWithAi.mockRejectedValue(new Error('Gemini unavailable'));
+
+    await expect(applyProductClassificationAiToItems(1, [10])).resolves.toBeUndefined();
+    expect(receiptRepositoryMocks.updateItemProductClassificationInTx).not.toHaveBeenCalled();
+  });
+
+  it('AI分類対象の取得失敗もレシート保存へ伝播させない', async () => {
+    receiptRepositoryMocks.findProductClassificationAiTargets.mockRejectedValue(
+      new Error('database temporarily unavailable')
+    );
+
+    await expect(applyProductClassificationAiToItems(1, [10])).resolves.toBeUndefined();
+    expect(aiMocks.classifyProductsWithAi).not.toHaveBeenCalled();
+    expect(receiptRepositoryMocks.updateItemProductClassificationInTx).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/productClassification/productClassificationAiIntegrationService.ts
+++ b/backend/src/services/productClassification/productClassificationAiIntegrationService.ts
@@ -1,0 +1,134 @@
+import {
+  ClassificationConfidence,
+  ClassificationSource,
+  ProductTypeStatus,
+} from '@prisma/client';
+import { classifyProductsWithAi } from '../../ai';
+import logger from '../../utils/logger';
+import { runInTransaction } from '../../utils/prismaTransaction';
+import {
+  findItemById,
+  findProductClassificationAiTargetInTx,
+  findProductClassificationAiTargets,
+  updateItemProductClassificationInTx,
+} from '../../repositories/receiptRepository';
+import {
+  findActiveProductTypeWithCategoryInTx,
+  findCategoryForProductTypeInTx,
+} from '../../repositories/productClassificationRepository';
+
+const confidenceMap = {
+  high: ClassificationConfidence.HIGH,
+  medium: ClassificationConfidence.MEDIUM,
+  low: ClassificationConfidence.LOW,
+} as const;
+
+/**
+ * 保存済みで候補を持つ要確認明細へ分類AIを適用する。
+ * 外部AIの障害・不正応答はここで吸収し、既に保存したレシートを失敗させない。
+ */
+export async function applyProductClassificationAiToItems(
+  familyGroupId: number,
+  itemIds: number[]
+): Promise<void> {
+  let targets;
+  try {
+    targets = await findProductClassificationAiTargets(itemIds, familyGroupId);
+  } catch (error) {
+    logger.warn('[ProductClassificationAI] AI分類対象を取得できませんでした。レシート保存は継続します。', {
+      familyGroupId,
+      itemIds,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (targets.length === 0) return;
+
+  let response;
+  try {
+    response = await classifyProductsWithAi({
+      familyGroupId,
+      storeName: targets[0].receipt.storeName,
+      items: targets.map((item) => ({
+        itemId: item.id,
+        itemName: item.name,
+        normalizedName: item.normalizedName,
+        candidates: item.productClassificationCandidates.map((candidate) => ({
+          productTypeId: candidate.productTypeId,
+          name: candidate.productType.name,
+          standardCategoryName: candidate.productType.standardCategory.name,
+        })),
+      })),
+    });
+  } catch (error) {
+    logger.warn('[ProductClassificationAI] 分類AIを適用できませんでした。類似候補の要確認状態を維持します。', {
+      familyGroupId,
+      itemIds: targets.map((item) => item.id),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  try {
+    await runInTransaction(async (tx) => {
+      for (const result of response.items) {
+        // AI呼出中の手動修正・再編集を上書きしないよう、状態と候補を再確認する。
+        const item = await findProductClassificationAiTargetInTx(tx, result.itemId, familyGroupId);
+        if (!item) continue;
+
+        if (result.productTypeId !== null && result.confidence === 'high') {
+          const isCurrentCandidate = item.productClassificationCandidates.some(
+            (candidate) => candidate.productTypeId === result.productTypeId
+          );
+          if (!isCurrentCandidate) continue;
+
+          const productType = await findActiveProductTypeWithCategoryInTx(tx, result.productTypeId);
+          if (!productType) continue;
+
+          const rootCategoryName =
+            productType.standardCategory.parent?.name ?? productType.standardCategory.name;
+          const category = await findCategoryForProductTypeInTx(tx, familyGroupId, rootCategoryName);
+          if (!category) {
+            logger.warn('[ProductClassificationAI] 対応する世帯カテゴリがないため自動確定を見送ります。', {
+              familyGroupId,
+              itemId: item.id,
+              productTypeId: productType.id,
+            });
+            continue;
+          }
+
+          await updateItemProductClassificationInTx(tx, item.id, {
+            categoryId: category.id,
+            standardCategoryId: productType.standardCategoryId,
+            productTypeId: productType.id,
+            productTypeStatus: ProductTypeStatus.CLASSIFIED,
+            classificationSource: ClassificationSource.AI,
+            classificationConfidence: ClassificationConfidence.HIGH,
+          });
+          continue;
+        }
+
+        // medium / low / null は候補を保持し、ユーザー確認対象のままとする。
+        await updateItemProductClassificationInTx(tx, item.id, {
+          categoryId: item.categoryId,
+          standardCategoryId: null,
+          productTypeId: null,
+          productTypeStatus: ProductTypeStatus.NEEDS_REVIEW,
+          classificationSource: ClassificationSource.AI,
+          classificationConfidence: confidenceMap[result.confidence],
+        });
+      }
+    });
+  } catch (error) {
+    logger.warn('[ProductClassificationAI] AI分類結果を保存できませんでした。類似候補の要確認状態を維持します。', {
+      familyGroupId,
+      itemIds: targets.map((item) => item.id),
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** 単一明細の更新後に、AI反映後の表示用データを取得する。 */
+export async function findItemAfterProductClassificationAi(itemId: number) {
+  return findItemById(itemId);
+}

--- a/backend/src/services/receipt/receiptPersistenceService.ts
+++ b/backend/src/services/receipt/receiptPersistenceService.ts
@@ -9,6 +9,7 @@ import {
 } from '../../repositories/receiptRepository';
 import { DuplicateReceiptError } from './receiptDuplicateError';
 import { persistReceiptCommitInTx } from './receiptCommitPersistence';
+import { applyProductClassificationAiToItems } from '../productClassification/productClassificationAiIntegrationService';
 
 /**
  * パース済みデータを DB に永続化（重複チェック ＋ 世帯別学習）
@@ -63,6 +64,13 @@ export async function saveParsedReceipt(
       warnings,
       usageLogId,
     })
+  );
+
+  // 外部AIはDB commit後に実行する。失敗時も保存済みレシートはそのまま返す。
+  const savedBeforeAi = await findReceiptById(savedId);
+  await applyProductClassificationAiToItems(
+    familyGroupId,
+    savedBeforeAi?.items.map((item) => item.id) ?? []
   );
 
   const final = await findReceiptById(savedId);

--- a/backend/src/services/receipt/receiptUpdateService.ts
+++ b/backend/src/services/receipt/receiptUpdateService.ts
@@ -8,11 +8,16 @@ import {
   deleteItemsByReceiptIdInTx,
   findCategoryByIdInTx,
   findItemWithReceiptInTx,
+  findReceiptById,
   findReceiptByIdForTenantInTx,
   findReceiptByIdInTx,
   updateItemCategoryInTx,
   updateReceiptInTx as patchReceiptInTx,
 } from '../../repositories/receiptRepository';
+import {
+  applyProductClassificationAiToItems,
+  findItemAfterProductClassificationAi,
+} from '../productClassification/productClassificationAiIntegrationService';
 import { saveParsedReceipt } from './receiptPersistenceService';
 import {
   classifyItemWithSimilarityCandidates,
@@ -114,7 +119,14 @@ export async function updateReceiptById(
   familyGroupId: number,
   input: UpdateReceiptInput
 ) {
-  return runInTransaction((tx) => applyFullReceiptUpdateInTx(tx, receiptId, familyGroupId, input));
+  const updated = await runInTransaction((tx) =>
+    applyFullReceiptUpdateInTx(tx, receiptId, familyGroupId, input)
+  );
+  await applyProductClassificationAiToItems(
+    familyGroupId,
+    updated?.items.map((item) => item.id) ?? []
+  );
+  return findReceiptById(receiptId);
 }
 
 async function updateItemCategoryInTxHandler(
@@ -155,7 +167,9 @@ export async function updateItemCategoryById(
   familyGroupId: number,
   categoryId: number | null | undefined
 ) {
-  return runInTransaction((tx) =>
+  const updatedItem = await runInTransaction((tx) =>
     updateItemCategoryInTxHandler(tx, itemId, familyGroupId, categoryId)
   );
+  await applyProductClassificationAiToItems(familyGroupId, [itemId]);
+  return (await findItemAfterProductClassificationAi(itemId)) ?? updatedItem;
 }

--- a/docs/design/ai-pipeline.md
+++ b/docs/design/ai-pipeline.md
@@ -41,9 +41,11 @@ RecAIpt の AI パイプラインは、レシート画像を **Google Gemini** �
 | 入力 | `familyGroupId`、任意の店舗名、明細 ID・OCR 名・正規化名・候補の商品種別（標準カテゴリを含む） |
 | 出力 | 明細 ID、候補内の商品種別 ID または `null`、`high` / `medium` / `low` の確信度 |
 | 検証 | JSON スキーマ、明細 ID の重複・未知 ID、候補外商品種別、確信度を全件検証する。不正な応答はバッチ全体を拒否する。 |
-| 永続化 | Provider / 契約検証層は DB に保存しない。候補の選定、結果保存、利用量記録は後続の分類フローが担当する。 |
+| 永続化 | Provider / 契約検証層は DB に保存しない。保存後の統合サービスが結果を反映し、利用量記録は別途の分類フローが担当する。 |
 
-実装は `backend/src/ai/productClassificationAiService.ts` を境界とする。Provider は Gemini の生テキストを返し、サービス層が契約検証済みの結果だけを後続処理へ渡す。これにより、AI が候補外の種別を返しても保存処理へ到達しない。
+実装は `backend/src/ai/productClassificationAiService.ts` を契約境界とする。Provider は Gemini の生テキストを返し、サービス層が契約検証済みの結果だけを後続処理へ渡す。これにより、AI が候補外の種別を返しても保存処理へ到達しない。
+
+`productClassificationAiIntegrationService.ts` は、レシート・明細の保存完了後に候補を持つ `needs_review` 明細だけを一括送信する。`high` の候補内選択だけを `classified` / `ai` として確定し、それ以外・未返却結果は候補を残した `needs_review` とする。AI通信・検証・反映の失敗は記録して吸収し、レシート保存を失敗させない。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #112-2（#557）として、類似候補を持つ未解決明細を分類AIへ送信し、検証済みの結果を保存済み明細へ反映します。

## 変更内容

- 保存後の `needs_review` 明細だけを分類AIへバッチ送信
- `high` の候補内選択だけを `classified / ai / high` として確定
- `medium`・`low`・`null` は候補を維持した `needs_review` として保存
- 新規保存、レシート全体編集、明細カテゴリ変更の各経路へ統合
- AI通信・応答検証・対象取得・反映失敗を吸収し、レシート保存を継続
- as-built設計資料を更新

## 影響

AI呼び出しはDB commit後に実行します。手動修正や再編集と競合した場合は、反映直前に世帯・候補・状態を再確認して上書きを防ぎます。

開発環境へのmigration適用・データ初期化は行っていません（本PRにmigrationは含みません）。

## 検証

- `npx prisma validate`
- `npx tsc --noEmit`
- `npm test`（106 passed, 37 skipped）

Closes #557
