### PR TITLE
test: Gemini・BullMQのモック方針を整備

### DIFF
--- a/backend/src/utils/normalizer.test.ts
+++ b/backend/src/utils/normalizer.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { getCleanText } from './normalizer';
+
+describe('getCleanText', () => {
+  it('normalizes Unicode form, case, whitespace, and control characters', () => {
+    expect(getCleanText('  ＭＩＬＫ\n\t\u0000  １Ｌ  ')).toBe('milk 1l');
+  });
+
+  it('returns an empty string for absent input', () => {
+    expect(getCleanText(null)).toBe('');
+    expect(getCleanText(undefined)).toBe('');
+  });
+});

--- a/docs/design/ai-pipeline.md
+++ b/docs/design/ai-pipeline.md
@@ -418,11 +418,12 @@ Gemini API と BullMQ Worker は **非決定論・外部依存** のため、自
 
 | 対象 | 方針 | 根拠 |
 |------|------|------|
-| Gemini | 結合テストで `vi.mock('../services/geminiService')` 等 | [testing/plan.md §4](../testing/plan.md) |
-| BullMQ Worker | テスト時は `receiptWorker` を import しない | `app.ts` / `server.ts` 分離（#91-3） |
-| Redis / Queue | Supertest 結合テストは Worker なしで API のみ検証 | `app.integration.test.ts` |
+| Gemini | レシート解析フローは `ReceiptAnalysisProvider` を差し替え、直接依存のテストだけ `vi.mock()` を使う | [testing/plan.md §4](../testing/plan.md) |
+| BullMQ Worker | テスト時は `server.ts` / `receiptWorker` を import しない | `app.ts` / `server.ts` 分離（#91-3） |
+| Redis / Queue | Supertest結合テストはファイル先頭で `test/mockReceiptQueue` を import し、Redis接続なしで API のみ検証する | `mockReceiptQueue.ts` |
+| normalizer | `getCleanText` は単体テスト、Prisma依存の `normalizeStoreName` はDB結合テスト | [testing/plan.md §4](../testing/plan.md) |
 
-詳細なモック戦略は Should 優先の [#91-7 / Issue #284](https://github.com/yama180sx/receipt-ai-app/issues/284) で拡充予定。本パイプラインの E2E（実 OCR）は [testing/plan.md §3](../testing/plan.md) のスコープ外とする。
+実Gemini OCR・実Redis Workerを通すE2Eは [testing/plan.md §3](../testing/plan.md) のスコープ外とし、手動回帰で確認する。
 
 ---
 

--- a/docs/testing/plan.md
+++ b/docs/testing/plan.md
@@ -89,8 +89,18 @@ Epic: [#277 Issue #91](https://github.com/yama180sx/receipt-ai-app/issues/277)
 
 ### 外部依存のモック
 
-- **Gemini**: 結合テストでは `vi.mock('../services/geminiService')` 等で必ずモック
-- **BullMQ Worker**: テスト時は import しない
+- **Gemini**: レシート解析フローでは `ReceiptAnalysisProvider` を
+  `setReceiptAnalysisProvider()` で差し替える。`geminiService.ts` を直接利用する
+  モジュールのテストでは `vi.mock()` を使い、実APIを呼ばない。
+- **BullMQ Worker**: `createApp()` を使うテストでは `server.ts` を import しないため、
+  Worker は起動しない。Queueを利用するSupertest結合テストは、ファイル先頭で
+  `test/mockReceiptQueue` を import してRedis接続を置き換える。
+- **normalizer**: `getCleanText` はDBなしの単体テストで検証する。
+  `normalizeStoreName` はPrismaで世帯内の店舗を検索するため、Prismaを模倣した単体テストは
+  行わず、テナント分離を含むDB結合テストで検証する。
+
+実Gemini OCR、実Redis Worker、実画像アップロードを通す確認は自動テストの対象外とし、
+`regression-checklist.md` に従う手動確認で扱う。
 
 ## 5. CI 方針
 


### PR DESCRIPTION
## 概要

Issue #284 のGemini・BullMQ・Redis・normalizerに関するテスト境界を明文化し、純粋な正規化処理の単体テストを追加します。

## 変更内容

- `getCleanText` のUnicode正規化・空入力を検証する単体テストを追加
- GeminiのProvider差し替え、BullMQ Worker非起動、Redis Queueモックの方針をテスト計画へ追記
- AIパイプラインのas-built資料を実装に合わせて更新

## 影響

実Gemini API・Redis Workerを自動テストから分離し、外部依存なしでレシート解析フローを検証できる方針を固定します。DBスキーマ・stable環境への変更はありません。

## 確認

- `cd backend && npm test`（116 passed / 37 skipped）
- `git diff --check`