### PR TITLE
feat: 履歴のあいまい検索を追加

### DIFF
--- a/backend/src/__tests__/integration/receipt.integration.test.ts
+++ b/backend/src/__tests__/integration/receipt.integration.test.ts
@@ -6,6 +6,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../../app';
 import { clearMockReceiptJobs, registerMockReceiptJob } from '../../test/mockJobStore';
+import { prisma } from '../../utils/prismaClient';
+import { getCleanText } from '../../utils/normalizer';
 import {
   ensureTestMemberPassword,
   getTenantBItemId,
@@ -38,6 +40,50 @@ describe.skipIf(!shouldRunDbIntegration())('Receipt API integration', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('検索語で店舗名または明細名が類似する世帯内レシートだけを返す', async () => {
+    const suffix = Date.now();
+    const marker = `履歴検索牛乳${suffix}`;
+    const storeName = `履歴検索店${suffix}`;
+    const receipt = await prisma.receipt.create({
+      data: {
+        familyGroupId: 1,
+        memberId: 1,
+        storeName,
+        normalizedStoreName: getCleanText(storeName),
+        date: new Date('2026-07-31T00:00:00.000Z'),
+        totalAmount: 180,
+        items: {
+          create: {
+            name: marker,
+            normalizedName: getCleanText(marker),
+            price: 180,
+            quantity: 1,
+          },
+        },
+      },
+    });
+
+    try {
+      const token = await loginAsTestMember(app);
+      const res = await request(app)
+        .get('/api/receipts')
+        .query({ q: marker })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((item: { id: number }) => item.id)).toContain(receipt.id);
+
+      const storeRes = await request(app)
+        .get('/api/receipts')
+        .query({ q: storeName })
+        .set('Authorization', `Bearer ${token}`);
+      expect(storeRes.status).toBe(200);
+      expect(storeRes.body.data.map((item: { id: number }) => item.id)).toContain(receipt.id);
+    } finally {
+      await prisma.receipt.delete({ where: { id: receipt.id } });
+    }
   });
 });
 

--- a/backend/src/controllers/receiptController.ts
+++ b/backend/src/controllers/receiptController.ts
@@ -203,11 +203,12 @@ export const getProductClassificationReviewItems = asyncHandler(async (req, res)
 
 export const getReceipts = asyncHandler(async (req, res) => {
   const { familyGroupId } = requireTenantContext();
-  const { month, memberId } = req.query;
+  const { month, memberId, q } = req.query;
   const receipts = await listReceipts({
     familyGroupId,
     memberId: typeof memberId === 'string' ? memberId : undefined,
     month: typeof month === 'string' ? month : undefined,
+    query: typeof q === 'string' ? q : undefined,
   });
   sendSuccess(res, mapReceiptList(receipts));
 });

--- a/backend/src/repositories/receipt/receiptReadRepository.ts
+++ b/backend/src/repositories/receipt/receiptReadRepository.ts
@@ -3,6 +3,7 @@ import { prisma } from '../../utils/prismaClient';
 import type { PrismaTx } from '../../utils/prismaTransaction';
 import { AppError } from '../../utils/appError';
 import { getLocalMonthDateRange, normalizeYearMonth } from '../../utils/yearMonth';
+import { getCleanText } from '../../utils/normalizer';
 import {
   receiptWithItemsCategory,
   receiptWithItemsCategorySplits,
@@ -12,6 +13,7 @@ export type ListReceiptsParams = {
   familyGroupId: number;
   memberId?: string;
   month?: string;
+  query?: string;
 };
 
 function buildListWhere(params: ListReceiptsParams): Prisma.ReceiptWhereInput {
@@ -34,9 +36,41 @@ function buildListWhere(params: ListReceiptsParams): Prisma.ReceiptWhereInput {
   return where;
 }
 
+/**
+ * 店舗名・明細名を pg_trgm で検索する。検索候補は必ず世帯で絞り込み、
+ * 呼び出し側の月・メンバー条件は通常の Prisma where と合成する。
+ */
+async function findReceiptIdsByFuzzyQuery(familyGroupId: number, query: string): Promise<number[]> {
+  const normalizedQuery = getCleanText(query);
+  if (!normalizedQuery) return [];
+
+  const rows = await prisma.$queryRaw<{ id: number }[]>`
+    SELECT receipt.id
+    FROM "Receipt" AS receipt
+    WHERE receipt."familyGroupId" = ${familyGroupId}
+      AND (
+        receipt."normalizedStoreName" % ${normalizedQuery}
+        OR EXISTS (
+          SELECT 1
+          FROM "Item" AS item
+          WHERE item."receiptId" = receipt.id
+            AND item."normalizedName" % ${normalizedQuery}
+        )
+      )
+  `;
+
+  return rows.map((row) => row.id);
+}
+
 export async function findReceipts(params: ListReceiptsParams) {
+  const where = buildListWhere(params);
+  const query = typeof params.query === 'string' ? params.query : '';
+  if (getCleanText(query)) {
+    where.id = { in: await findReceiptIdsByFuzzyQuery(params.familyGroupId, query) };
+  }
+
   return prisma.receipt.findMany({
-    where: buildListWhere(params),
+    where,
     include: receiptWithItemsCategorySplits,
     orderBy: { date: 'desc' },
   });

--- a/docs/design/api-spec.md
+++ b/docs/design/api-spec.md
@@ -283,6 +283,7 @@ sequenceDiagram
 |---------------|-----------|------|
 | `GET /receipts` | `month` | `YYYY-MM` フィルタ（任意） |
 | `GET /receipts` | `memberId` | 支払者フィルタ。空文字 `""` = 世帯全体 |
+| `GET /receipts` | `q` | 店舗名または明細名の `pg_trgm` 類似検索語（任意）。月・支払者フィルタと併用可能。画面は入力後300msで検索する |
 | `GET /product-classification/review-items` | `status` | カンマ区切りの `needs_review` / `unclassified` / `outside_initial_scope`。省略時は全状態 |
 | `GET /product-classification/review-items` | `categoryId` | 家計簿 Category による絞り込み（任意） |
 | `GET /product-classification/review-items` | `month` | `YYYY-MM` による期間絞り込み（任意） |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -320,6 +320,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: q
+          in: query
+          description: 店舗名または明細名の類似検索語
+          schema:
+            type: string
       responses:
         '200':
           description: OK

--- a/frontend/src/api/generated/schema.ts
+++ b/frontend/src/api/generated/schema.ts
@@ -477,6 +477,8 @@ export interface paths {
                 query?: {
                     month?: string;
                     memberId?: string;
+                    /** @description 店舗名または明細名の類似検索語 */
+                    q?: string;
                 };
                 header?: never;
                 path?: never;

--- a/frontend/src/api/receiptApi.ts
+++ b/frontend/src/api/receiptApi.ts
@@ -20,6 +20,7 @@ import type {
 export type ListReceiptsParams = {
   month?: string;
   memberId?: string;
+  q?: string;
 };
 
 export type CommitReceiptPayload = {

--- a/frontend/src/features/history/hooks/useReceiptHistory.ts
+++ b/frontend/src/features/history/hooks/useReceiptHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { categoryApi, receiptApi } from '../../../api';
 import { useIsWideLayout } from '../../../hooks/useIsWideLayout';
 import type { CategorySummary, ReceiptDetail } from '../../../types/receipt';
@@ -20,6 +20,9 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
   const [selectedReceipt, setSelectedReceipt] = useState<ReceiptDetail | null>(null);
   const [selectedMonth, setSelectedMonth] = useState('');
   const [selectedMember, setSelectedMember] = useState(currentMemberId.toString());
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const receiptRequestIdRef = useRef(0);
 
   const months = useMemo(() => getRecentYearMonths(6), []);
   const monthSelectOptions = useMonthSelectOptions(months, isWide);
@@ -34,6 +37,13 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
 
   const API_URL = process.env.EXPO_PUBLIC_API_URL || '';
   const baseUrl = API_URL.replace(/\/api\/?$/, '');
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, 300);
+    return () => clearTimeout(timeoutId);
+  }, [searchQuery]);
 
   const fetchCategories = useCallback(async () => {
     try {
@@ -58,12 +68,15 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
   }, []);
 
   const fetchReceipts = useCallback(async () => {
+    const requestId = ++receiptRequestIdRef.current;
     try {
       setLoading(true);
       const res = await receiptApi.listReceipts({
         ...(selectedMonth ? { month: selectedMonth } : {}),
         memberId: selectedMember,
+        ...(debouncedSearchQuery ? { q: debouncedSearchQuery } : {}),
       });
+      if (requestId !== receiptRequestIdRef.current) return;
       if (res.success) {
         const data = res.data;
         setReceipts(data);
@@ -76,11 +89,13 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
         }
       }
     } catch (err) {
-      showApiErrorAlert('エラー', err, '履歴の取得に失敗しました。');
+      if (requestId === receiptRequestIdRef.current) {
+        showApiErrorAlert('エラー', err, '履歴の取得に失敗しました。');
+      }
     } finally {
-      setLoading(false);
+      if (requestId === receiptRequestIdRef.current) setLoading(false);
     }
-  }, [selectedMonth, selectedMember, isWide, selectedReceipt?.id]);
+  }, [selectedMonth, selectedMember, debouncedSearchQuery, isWide, selectedReceipt?.id]);
 
   useEffect(() => {
     fetchCategories();
@@ -89,7 +104,7 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
 
   useEffect(() => {
     fetchReceipts();
-  }, [selectedMonth, selectedMember]);
+  }, [selectedMonth, selectedMember, debouncedSearchQuery]);
 
   const handleCategoryChange = async (itemId: number, categoryId: number | null) => {
     if (!categoryId) return;
@@ -126,6 +141,8 @@ export function useReceiptHistory({ currentMemberId }: UseReceiptHistoryOptions)
     setSelectedMonth,
     selectedMember,
     setSelectedMember,
+    searchQuery,
+    setSearchQuery,
     monthSelectOptions,
     memberSelectOptions,
     baseUrl,

--- a/frontend/src/screens/HistoryScreen.tsx
+++ b/frontend/src/screens/HistoryScreen.tsx
@@ -8,7 +8,7 @@ import {
   ActivityIndicator,
   Platform,
 } from 'react-native';
-import { AppBackButton, AppModal, AppSelect } from '../components/ui';
+import { AppBackButton, AppModal, AppSelect, AppTextInput } from '../components/ui';
 import { ReceiptDetailComponent } from '../components/ReceiptDetailComponent';
 import { useReceiptHistory } from '../features/history';
 import { colors } from '../theme/colors';
@@ -70,6 +70,15 @@ export default function HistoryScreen({ onBack, currentMemberId, onGoToSplitEdit
         </View>
 
         <View style={[styles.filterContainer, history.isWide ? styles.filterContainerWide : styles.filterContainerMobile]}>
+          <View style={[styles.filterSelectWrap, history.isWide && styles.filterSelectWrapWide]}>
+            <AppTextInput
+              value={history.searchQuery}
+              onChangeText={history.setSearchQuery}
+              placeholder="店舗名・商品名で検索"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
           <View style={[styles.filterSelectWrap, history.isWide && styles.filterSelectWrapWide]}>
             <AppSelect<string>
               selectedValue={history.selectedMonth}


### PR DESCRIPTION
## 概要

Issue #135 として、履歴画面から店舗名・商品名をあいまい検索できるようにします。

## 変更内容

- `GET /receipts?q=...` を追加し、世帯内の店舗名・明細名を pg_trgm で類似検索
- 月・支払者フィルタと検索語を併用可能に
- 履歴画面に検索欄を追加（300msデバウンス、古い応答の破棄）
- OpenAPI、生成型、As-built API仕様を更新
- 店舗名・明細名の検索を検証するDB結合テストを追加

## DB変更

なし。商品分類で導入済みの `pg_trgm` 拡張・正規化列・GINインデックスを共有利用します。

## 確認

- Backend: 116 passed / 38 skipped
- Frontend: 67 passed
- 検索を含む `receipt.integration.test.ts`: 14 passed
- `git diff --check`

## 後続

検索結果のページネーションは #586 で扱います。