### PR TITLE
fix: 再分類対象の状態enumを正しく変換

### DIFF
--- a/backend/src/schemas/receiptSchema.test.ts
+++ b/backend/src/schemas/receiptSchema.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { ClassificationCorrectionScope } from '@prisma/client';
-import { deactivateProductClassificationLearningDataSchema, productClassificationCorrectionSchema } from './receiptSchema';
+import { ClassificationCorrectionScope, ProductTypeStatus } from '@prisma/client';
+import {
+  deactivateProductClassificationLearningDataSchema,
+  productClassificationCorrectionSchema,
+  productClassificationReclassificationSchema,
+} from './receiptSchema';
 
 describe('productClassificationCorrectionSchema', () => {
   it('requires classificationName only for SAME_CLASSIFICATION_NAME', () => {
@@ -34,5 +38,19 @@ describe('deactivateProductClassificationLearningDataSchema', () => {
   it('requires a non-empty reason', () => {
     expect(deactivateProductClassificationLearningDataSchema.safeParse({ reason: '  ' }).success).toBe(false);
     expect(deactivateProductClassificationLearningDataSchema.parse({ reason: '誤分類のため' })).toEqual({ reason: '誤分類のため' });
+  });
+});
+
+describe('productClassificationReclassificationSchema', () => {
+  it('converts API statuses to the Prisma enum values', () => {
+    const result = productClassificationReclassificationSchema.parse({
+      statuses: ['unclassified', 'needs_review'],
+      limit: 10,
+    });
+
+    expect(result.statuses).toEqual([
+      ProductTypeStatus.UNCLASSIFIED,
+      ProductTypeStatus.NEEDS_REVIEW,
+    ]);
   });
 });

--- a/backend/src/schemas/receiptSchema.ts
+++ b/backend/src/schemas/receiptSchema.ts
@@ -1,4 +1,4 @@
-import { ClassificationCorrectionScope } from '@prisma/client';
+import { ClassificationCorrectionScope, ProductTypeStatus } from '@prisma/client';
 import { z } from 'zod';
 
 /**
@@ -50,8 +50,8 @@ export const deactivateProductClassificationLearningDataSchema = z.object({
 });
 
 const reclassificationStatusMap = {
-  unclassified: 'unclassified',
-  needs_review: 'needs_review',
+  unclassified: ProductTypeStatus.UNCLASSIFIED,
+  needs_review: ProductTypeStatus.NEEDS_REVIEW,
 } as const;
 
 export const productClassificationReclassificationSchema = z


### PR DESCRIPTION
## 概要

PR #592で追加した既存明細の再分類が対象0件になる不具合を修正します。

- API入力の unclassified / needs_review をPrismaの内部enum UNCLASSIFIED / NEEDS_REVIEW へ変換
- 変換結果を検証する回帰テストを追加

## 原因

入力値を小文字のままサービスへ渡していたため、安全フィルタが全件を除外していました。

## 影響

未分類・要確認の既存明細が再分類対象として選択されます。手動確定済み明細は引き続き対象外です。

## 確認

- backend: npm test（124 passed / 39 skipped）
- backend: TypeScript型検査
- dev DBで、麦茶・珈琲の未分類5件と標準辞書の完全一致を確認