### PR TITLE
fix: 標準ルール登録の入力エラーを明確化

### DIFF
--- a/backend/src/schemas/receiptSchema.ts
+++ b/backend/src/schemas/receiptSchema.ts
@@ -67,9 +67,9 @@ export const productClassificationReclassificationSchema = z
   }));
 
 export const standardProductClassificationRuleSchema = z.object({
-  keyword: z.string().trim().min(1).max(100),
-  productTypeId: z.coerce.number().int().positive(),
-  priority: z.coerce.number().int().min(0).max(100000),
+  keyword: z.string().trim().min(1, 'キーワードを入力してください').max(100, 'キーワードは100文字以内で入力してください'),
+  productTypeId: z.coerce.number().int('商品種別を選択してください').positive('商品種別を選択してください'),
+  priority: z.coerce.number().int('優先度は整数で入力してください').min(0, '優先度は0以上で入力してください').max(100000, '優先度は100000以下で入力してください'),
   reason: z.string().trim().min(1, '変更理由は必須です').max(500),
 });
 

--- a/frontend/src/features/admin/hooks/useStandardProductClassificationRules.ts
+++ b/frontend/src/features/admin/hooks/useStandardProductClassificationRules.ts
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { adminApi, receiptApi, type ProductTypeSummary, type StandardProductClassificationRule } from '../../../api';
 import { showApiErrorAlert } from '../../../utils/apiError';
+import { showAlert } from '../../../utils/alertMessage';
+
+const unsafeKeywords = new Set(['茶', '水', '炭酸', '飲料', 'ポテト']);
+
+function getNormalizedKeyword(keyword: string): string {
+  return keyword.normalize('NFKC').toLowerCase().replace(/\s+/g, ' ').trim();
+}
 
 export function useStandardProductClassificationRules() {
   const [rules, setRules] = useState<StandardProductClassificationRule[]>([]);
@@ -36,7 +43,27 @@ export function useStandardProductClassificationRules() {
   }, [keyword]);
   const create = useCallback(async () => {
     const parsedPriority = Number(priority);
-    if (!productTypeId || !Number.isInteger(parsedPriority) || !reason.trim()) return;
+    const normalizedKeyword = getNormalizedKeyword(keyword);
+    if (!normalizedKeyword) {
+      showAlert('入力エラー', 'キーワードを入力してください。');
+      return;
+    }
+    if (normalizedKeyword.length < 2 || unsafeKeywords.has(normalizedKeyword)) {
+      showAlert('入力エラー', 'キーワードは2文字以上で、広すぎる語（茶、水、炭酸、飲料、ポテト）は登録できません。');
+      return;
+    }
+    if (!productTypeId) {
+      showAlert('入力エラー', '商品種別を選択してください。');
+      return;
+    }
+    if (!Number.isInteger(parsedPriority) || parsedPriority < 0 || parsedPriority > 100000) {
+      showAlert('入力エラー', '優先度は0から100000までの整数で入力してください。');
+      return;
+    }
+    if (!reason.trim()) {
+      showAlert('入力エラー', '変更理由を入力してください。');
+      return;
+    }
     try {
       if (editingId) await adminApi.updateStandardProductClassificationRule(editingId, { keyword, productTypeId, priority: parsedPriority, reason });
       else await adminApi.createStandardProductClassificationRule({ keyword, productTypeId, priority: parsedPriority, reason });

--- a/frontend/src/utils/apiError.test.ts
+++ b/frontend/src/utils/apiError.test.ts
@@ -69,6 +69,27 @@ describe('apiError', () => {
     expect(getApiErrorMessage('unknown')).toBe('通信エラーが発生しました。');
   });
 
+  it('appends API validation details to the generic validation message', () => {
+    const axiosError = new axios.AxiosError(
+      'Request failed',
+      'ERR_BAD_REQUEST',
+      undefined,
+      undefined,
+      {
+        status: 400,
+        data: {
+          message: '入力内容に不備があります',
+          details: [{ field: 'priority', message: '優先度は整数で入力してください' }],
+        },
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as never,
+      }
+    );
+
+    expect(getApiErrorMessage(axiosError)).toBe('入力内容に不備があります\n優先度は整数で入力してください');
+  });
+
   it('showApiErrorAlert notifies user with extracted message', () => {
     const error = new axios.AxiosError(
       'Request failed',
@@ -88,6 +109,28 @@ describe('apiError', () => {
 
     expect(showAlert).toHaveBeenCalledWith('エラー', 'サーバーエラー');
     expect(console.error).toHaveBeenCalled();
+  });
+
+  it('logs an expected 4xx response as a warning instead of an error', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new axios.AxiosError(
+      'Request failed',
+      'ERR_BAD_REQUEST',
+      undefined,
+      undefined,
+      {
+        status: 400,
+        data: { message: '入力内容に不備があります' },
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as never,
+      }
+    );
+
+    showApiErrorAlert('エラー', error);
+
+    expect(console.error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
   });
 
   it('showApiErrorAlert uses fallback when message is unavailable', () => {

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -8,6 +8,19 @@ function readStringField(data: unknown, key: 'error' | 'message'): string | unde
   return typeof value === 'string' ? value : undefined;
 }
 
+function readValidationDetails(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const details = (data as Record<string, unknown>).details;
+  if (!Array.isArray(details)) return undefined;
+
+  const messages = details.flatMap((detail) => {
+    if (!detail || typeof detail !== 'object') return [];
+    const message = (detail as Record<string, unknown>).message;
+    return typeof message === 'string' ? [message] : [];
+  });
+  return messages.length > 0 ? messages.join('\n') : undefined;
+}
+
 /** Axios レスポンス body（存在する場合） */
 export function getApiErrorResponseData(error: unknown): unknown {
   if (error instanceof OpenApiHttpError) {
@@ -40,7 +53,10 @@ export function getApiErrorMessage(
   if (fromError) return fromError;
 
   const fromMessage = readStringField(data, 'message');
-  if (fromMessage) return fromMessage;
+  if (fromMessage) {
+    const validationDetails = readValidationDetails(data);
+    return validationDetails ? `${fromMessage}\n${validationDetails}` : fromMessage;
+  }
 
   if (error instanceof Error && error.message) {
     return error.message;
@@ -55,6 +71,12 @@ export function showApiErrorAlert(
   error: unknown,
   fallback = '通信エラーが発生しました。'
 ): void {
-  console.error(`[API Error] ${title}:`, error);
+  // 4xx は利用者が修正できる想定内の入力・状態エラーであり、Expo の
+  // 開発用 Console Error 画面を出さない。5xx と通信障害だけを error として記録する。
+  if ((getApiErrorStatus(error) ?? 0) >= 500 || getApiErrorStatus(error) === undefined) {
+    console.error(`[API Error] ${title}:`, error);
+  } else {
+    console.warn(`[API Warning] ${title}:`, getApiErrorMessage(error, fallback));
+  }
   showAlert(title, getApiErrorMessage(error, fallback));
 }


### PR DESCRIPTION
## 概要

標準商品分類ルールの登録時に、入力エラーが包括的なメッセージだけで表示され、Expo開発版では想定内の400レスポンスまでConsole Error画面として表示される問題を修正します。

## 原因

バックエンドはZod検証エラーの項目別詳細を`details`に返していましたが、フロントエンドは表示していませんでした。また、4xxの想定内APIエラーも`console.error`で出力していました。

## 変更内容

- 標準ルールフォームでキーワード、商品種別、優先度、変更理由を事前検証
- バックエンドの標準ルール入力エラーを日本語化
- APIの検証詳細を利用者向けメッセージに表示
- 4xxを警告扱いとし、ExpoのConsole Error画面を回避

## 影響

不正入力時に登録リクエストを送信せず、修正すべき項目を画面で案内します。正常な登録・既存API契約・DBスキーマへの変更はありません。

## 検証

- `cd frontend && npm test -- src/utils/apiError.test.ts`
- `cd frontend && npx tsc --noEmit`
- `cd backend && npx tsc --noEmit`
- `cd backend && npm test -- src/schemas/receiptSchema.test.ts src/middleware/errorHandler.test.ts`
- `git diff --check`
